### PR TITLE
Phase 4: add local document ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ research, documents, and agent-assisted tasks in one place.
 | Desktop workbench | Runs from source on macOS | Clean first-run onboarding |
 | Jobs and history | Built-in mutable SQLite repository; private installs may explicitly select JobHunter | Clean first-run initialization and synthetic demo data |
 | Browser workspace | Electron-owned local capability | Local capability with truthful unavailable states |
-| Documents | Local editor and retained-OOXML engine exist; some artifact flows remain privately coupled | Local create, edit, save, reopen, and export |
+| Documents | SQLite/local mode supports editable create, save, snapshots, DOCX import, paired DOCX/PDF publish, restart, and download; JobHunter render/refresh remain optional | Installed-app acceptance with representative DOCX files |
 | Agent | Existing private deployments can connect an agent runtime | Clearly optional; offline/not-configured by default |
 | MCP | Thin adapter over the JobOS API | Local API/MCP path with stable capability errors |
 
@@ -81,9 +81,10 @@ Do not treat a disconnected window as completed onboarding.
 ## Demo data
 
 `jobos-init` initializes a fresh local profile with exactly one clearly labeled
-synthetic demo job. Removing that job is persistent; JobOS will not silently
-re-seed it. `jobos-init --reset-demo --confirm-reset-demo` is the separate,
-explicitly confirmed reset path.
+synthetic demo job and one `(FAKE)`, fictional, do-not-apply starter resume.
+Removing the demo also removes its editable document metadata and is persistent;
+JobOS will not silently re-seed either item. `jobos-init --reset-demo
+--confirm-reset-demo` is the separate, explicitly confirmed reset path for both.
 
 ## Data and privacy
 

--- a/docs/public/architecture.md
+++ b/docs/public/architecture.md
@@ -49,11 +49,18 @@ may supply compatible adapters without changing the default composition.
 ## Current transition state
 
 The public composition now uses a dedicated mutable SQLite canonical-jobs
-repository, separate from workbench state. JobHunter loads dynamically only when
-an installed private runtime explicitly selects that provider, and artifact
-publication remains a separate gateway. Operator-specific runtime defaults and
-first-run initialization/demo onboarding are still unfinished, so this must not
-be read as proof that clean-clone acceptance has passed.
+repository, separate from workbench state. Job and artifact providers are selected
+independently: a private install may keep SQLite jobs while explicitly selecting
+the JobHunter artifact gateway. JobHunter loads dynamically only for a selected
+private capability. `JobOsStateStore`
+owns editable metadata, snapshots, registry metadata, revision, and replay state;
+`SQLiteJobRepository` owns jobs; and `LocalArtifactRepository` owns bytes beneath
+the configured application-data artifact root. Editable local publication writes
+one validated DOCX/PDF pair, then registers both against the same editable
+revision. The private `ArtifactGateway` remains the optional seam for JobHunter
+publish, render, and refresh and reports an unconfigured capability when absent.
+This source behavior is not proof that packaged onboarding or clean-clone
+installed-app acceptance has passed.
 
 Canonical-job mutations commit before the related workbench selection/audit
 event. If the second local write fails, retrying converges through canonical-URL
@@ -81,7 +88,9 @@ pnpm contracts:check
 ```
 
 The MCP adapter maps those application operations and errors rather than
-reimplementing domain behavior.
+reimplementing domain behavior. MCP file publication accepts only explicit
+`JOBOS_DOCUMENT_ROOTS` or the artifact root from local `config.json`; it does not
+trust the process working directory or a Hermes profile directory.
 
 ## Document provenance
 

--- a/docs/public/data-privacy.md
+++ b/docs/public/data-privacy.md
@@ -23,9 +23,11 @@ The accepted public composition will store:
 - credentials in the platform credential provider, with a documented restrictive
   source-development fallback.
 
-A fresh profile will contain one unmistakably synthetic demo job. No real jobs,
-people, companies, resumes, cover letters, browser history, or conversations may
-be included in source, fixtures, documentation, or launch media.
+A fresh profile will contain one unmistakably synthetic demo job and one
+publication-safe `(FAKE)` starter resume that repeatedly identifies itself as
+fictional and do-not-apply. No real jobs, people, companies, resumes, cover
+letters, browser history, or conversations may be included in source, fixtures,
+documentation, or launch media.
 
 ## Data locations
 
@@ -81,7 +83,10 @@ reconfigure those credentials after a restore. Do not export tokens into the
 backup, documentation, a support bundle, or a public issue.
 
 The fictional demo has a narrow reset command:
-`jobos-init --reset-demo --confirm-reset-demo`. It does not reset other jobs.
+`jobos-init --reset-demo --confirm-reset-demo`. Removing the demo intentionally
+also removes its editable document metadata and ordinary initialization does not
+restore either item. The explicit reset restores the one demo job and its one
+starter resume; it does not reset other jobs.
 For a completely fresh source profile, initialize a new `--data-dir`; move old
 runtime data aside instead of deleting it until its backup is verified.
 

--- a/docs/public/troubleshooting.md
+++ b/docs/public/troubleshooting.md
@@ -53,19 +53,24 @@ request as the API schema change. Do not hand-edit generated clients.
 
 ## Desktop opens but services are unavailable
 
-That is currently possible during open-source preparation. The public local
-composition and onboarding flow have not landed yet. Do not add private paths or
-credentials merely to make a public-source test appear connected. Capture only
-safe capability/status text and check the current release-status section in the
-README.
+That is currently possible during open-source preparation. Local SQLite jobs and
+editable artifact storage do not require JobHunter or Hermes, but agent features
+and JobHunter artifact render/refresh/publication remain optional and return an
+unconfigured capability when absent. Do not add private paths or credentials
+merely to make a public-source test appear connected. This does not mean packaged
+binary provisioning or installed-app acceptance is complete.
 
 ## Resetting local development state
 
-Current source-development state may exist at `data/jobos.db` and
-`data/jobs.db`; installed macOS
-state lives under the user's JobOS Application Support directory. Back up files
-before deleting anything. The accepted public reset command will arrive with the
-idempotent initializer and is not available yet.
+Use `config.json` to locate the active state database, jobs database, artifact
+root, and logs. Installed macOS state normally lives under the user's JobOS
+Application Support directory. Back up every configured location before changing
+anything. The narrow fictional-demo reset is `jobos-init --reset-demo
+--confirm-reset-demo`; it restores only the demo job and its starter document.
+
+MCP document publication reads files only below `JOBOS_DOCUMENT_ROOTS` when set,
+or below the artifact root in the active local config. It deliberately does not
+fall back to the launch directory or a Hermes profile cache.
 
 ## Filing a useful bug
 

--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -6,8 +6,10 @@ import json
 import sqlite3
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager, contextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import wraps
+from pathlib import Path
 from threading import Lock
 from typing import Annotated, Literal, ParamSpec, TypeVar, cast
 from urllib.parse import quote
@@ -21,6 +23,15 @@ from jobos_api import __version__
 from jobos_api.activity import ActivityReportRequest, ActivityReportResponse
 from jobos_api.agent_gateway import AgentGateway, OfflineAgentGateway
 from jobos_api.artifact_gateway import ArtifactGateway
+from jobos_api.artifact_repository import (
+    DOCX_MEDIA_TYPE,
+    PDF_MEDIA_TYPE,
+    ArtifactRepository,
+    ArtifactStorageError,
+    ArtifactValidationError,
+    ArtifactWrite,
+    StoredArtifact,
+)
 from jobos_api.capabilities import (
     BrowserCommandRequest,
     BrowserCommandResponse,
@@ -51,7 +62,6 @@ from jobos_api.document_operations import (
 )
 from jobos_api.documents import (
     ARTIFACT_ID_PATTERN,
-    PDF_MEDIA_TYPE,
     ArtifactApprovalRequest,
     ArtifactPublishRequest,
     ArtifactRefreshRequest,
@@ -59,9 +69,9 @@ from jobos_api.documents import (
     ArtifactTrustError,
     JobArtifactsResponse,
     ResumeRenderRequest,
+    VerifiedArtifact,
     artifact_record,
     content_headers,
-    materialize_external_import,
     materialize_published_document,
     read_source_artifact,
     verify_facade_artifacts,
@@ -122,12 +132,14 @@ from jobos_api.jobs import (
     list_jobs,
     normalize_job_detail,
 )
+from jobos_api.local_artifact_repository import LocalArtifactRepository
 from jobos_api.redaction import sanitize_text
 from jobos_api.responses import DeviceSessionResponse, HealthResponse, VersionResponse
 from jobos_api.settings import Settings
 from jobos_api.state_store import (
     ConversationBusy,
     EditableDocumentConflict,
+    EditablePublicationConflict,
     IdempotencyConflict,
     JobOsStateStore,
     WorkspaceRevisionConflict,
@@ -137,6 +149,16 @@ from jobos_api.workspace import WorkspaceSnapshotCommand, WorkspaceSnapshotRespo
 
 P = ParamSpec("P")
 R = TypeVar("R")
+LOCAL_ARTIFACT_STORAGE_UNAVAILABLE = "Local artifact storage is unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedEditableImport:
+    artifact_id: str | None
+    filename: str | None
+    sha256: str
+    document_key: Literal["resume", "cover_letter", "references"]
+    stored: StoredArtifact | None = None
 
 
 def create_app(
@@ -144,6 +166,7 @@ def create_app(
     *,
     job_repository: JobRepository | None = None,
     artifact_gateway: ArtifactGateway | None = None,
+    artifact_repository: ArtifactRepository | None = None,
     agent_gateway: AgentGateway | None = None,
     capability_broker: CapabilityBroker | None = None,
     state_store: JobOsStateStore | None = None,
@@ -155,6 +178,10 @@ def create_app(
         artifact_gateway = artifact_gateway or composed_artifacts
     jobs = job_repository
     artifacts = artifact_gateway
+    local_artifacts = artifact_repository or LocalArtifactRepository(
+        settings.resolved_local_artifact_root()
+    )
+    trusted_artifact_roots = settings.resolved_artifact_roots()
     device_authenticator = DeviceAuthenticator(settings.device_credential_registry())
     bearer = HTTPBearer(auto_error=False)
     configured_gateway = agent_gateway
@@ -1161,6 +1188,7 @@ def create_app(
                     detail="Only a fictional demo job can be removed",
                 )
             jobs.delete_job(job_id)
+        state_store.delete_job_documents(job_id)
         if state_store.job_workspace_state().selected_job_id == job_id:
             state_store.save_job_selection(None, command.origin)
         result_payload = JobMutationResponse(event_id=0).model_dump(mode="json")
@@ -1380,53 +1408,65 @@ def create_app(
         job_id: str,
         document_id: str,
         source: CreateRegisteredImportRequest | CreateExternalImportRequest,
-    ) -> tuple[str, str | None, str]:
+    ) -> PreparedEditableImport:
         if source.mode == "import_registered_artifact":
             artifact = state_store.editable_import_source(job_id, source.source_artifact_id)
-            return (
-                source.source_artifact_id,
-                str(artifact["filename"]) if artifact.get("filename") else None,
-                str(artifact["sha256"]),
-            )
-        if settings.hermes_job_hunter_cwd is None:
-            raise HTTPException(
-                status_code=503,
-                detail=(
-                    "External DOCX import requires the configured Job Hunter publication workspace"
-                ),
+            return PreparedEditableImport(
+                artifact_id=source.source_artifact_id,
+                filename=str(artifact["filename"]) if artifact.get("filename") else None,
+                sha256=str(artifact["sha256"]),
+                document_key=source.document_key,
             )
         source_bytes = source.source_bytes()
-        manifest_path, artifact_path = materialize_external_import(
+        stored = local_artifacts.store_import(
             job_id=job_id,
             document_id=document_id,
+            artifact=ArtifactWrite(
+                filename=source.source_filename,
+                media_type=DOCX_MEDIA_TYPE,
+                content=source_bytes,
+                sha256=source.source_sha256,
+            ),
+        )
+        return PreparedEditableImport(
+            artifact_id=None,
+            filename=source.source_filename,
+            sha256=source.source_sha256,
             document_key=source.document_key,
-            source_filename=source.source_filename,
-            source_sha256=source.source_sha256,
-            source_bytes=source_bytes,
-            workspace_root=settings.hermes_job_hunter_cwd,
+            stored=stored,
         )
-        raw = artifacts.publish_document_artifact(
-            job_id,
-            source.document_key,
-            LABELS[source.document_key],
-            str(manifest_path),
-            str(artifact_path),
+
+    def register_import_source(
+        job_id: str,
+        prepared: PreparedEditableImport,
+        connection: sqlite3.Connection,
+    ) -> tuple[str, str | None, str]:
+        if prepared.artifact_id is not None:
+            return prepared.artifact_id, prepared.filename, prepared.sha256
+        if prepared.stored is None:  # pragma: no cover - dataclass construction is local
+            raise ArtifactStorageError("External DOCX was not stored")
+        verified = VerifiedArtifact(
+            job_id=job_id,
+            document_key=prepared.document_key,
+            document_label=LABELS[prepared.document_key],
+            source_revision=f"external:{prepared.sha256}",
+            artifact_revision=prepared.sha256,
+            media_type=DOCX_MEDIA_TYPE,
+            sha256=prepared.sha256,
+            render_status="succeeded",
+            render_sequence=state_store.next_document_artifact_sequence(
+                job_id, connection=connection
+            ),
+            canonical_path=str(prepared.stored.canonical_path),
+            filename=prepared.filename,
+            failure_message=None,
         )
-        verified = verify_source_artifact(raw, settings.artifact_roots)
-        if (
-            verified.job_id != job_id
-            or verified.document_key != source.document_key
-            or verified.document_label != LABELS[source.document_key]
-            or verified.media_type
-            != "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            or verified.render_status != "succeeded"
-            or verified.sha256 != source.source_sha256
-        ):
-            raise ArtifactTrustError("Published external DOCX metadata does not match the import")
-        artifact_id, _ = state_store.register_document_artifacts(job_id, [verified])
+        artifact_id, _ = state_store.register_document_artifacts(
+            job_id, [verified], connection=connection
+        )
         if artifact_id is None:
-            raise ArtifactTrustError("Published external DOCX was not registered")
-        return artifact_id, source.source_filename, source.source_sha256
+            raise ArtifactStorageError("External DOCX was not registered")
+        return artifact_id, prepared.filename, prepared.sha256
 
     @app.get("/v1/jobs/{job_id}/editable-documents", tags=["editable-documents"])
     def editable_documents_list(
@@ -1515,9 +1555,9 @@ def create_app(
             content = blank_content(command.document_key)
             settings_value = default_settings()
             import_report = {"source_filename": None, "imported_at": None, "issues": []}
-            source_artifact_id = source_filename = source_sha256 = None
             imported = False
             document_id = None
+            prepared_import = None
             validate_content(content, DocumentSettings.model_validate(settings_value), [])
         else:
             if state_store.get_job_editable_document(job_id, command.document_key) is not None:
@@ -1527,10 +1567,12 @@ def create_app(
                 )
             document_id = state_store.new_editable_document_id()
             try:
-                source_artifact_id, source_filename, source_sha256 = resolve_import_source(
-                    job_id, document_id, command
-                )
-            except (ArtifactTrustError, OSError, ValueError) as error:
+                prepared_import = resolve_import_source(job_id, document_id, command)
+            except (ArtifactStorageError, OSError, sqlite3.OperationalError) as error:
+                raise HTTPException(
+                    status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
+                ) from error
+            except (ArtifactTrustError, ValueError) as error:
                 raise HTTPException(status_code=422, detail=str(error)) from error
             content = command.content
             settings_value = command.settings.model_dump(mode="json")
@@ -1543,6 +1585,12 @@ def create_app(
         )
 
         def create_document(connection: sqlite3.Connection) -> dict[str, object]:
+            if prepared_import is not None:
+                source_artifact_id, source_filename, source_sha256 = register_import_source(
+                    job_id, prepared_import, connection
+                )
+            else:
+                source_artifact_id = source_filename = source_sha256 = None
             row = state_store.create_editable_document(
                 job_id=job_id,
                 document_key=command.document_key,
@@ -1574,6 +1622,10 @@ def create_app(
             )
         except ValueError as error:
             raise HTTPException(status_code=409, detail=str(error)) from error
+        except (ArtifactStorageError, OSError, sqlite3.OperationalError) as error:
+            raise HTTPException(
+                status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
+            ) from error
         except IdempotencyConflict as error:
             raise HTTPException(status_code=409, detail=str(error)) from error
         return EditableDocument.model_validate(result)
@@ -1670,11 +1722,14 @@ def create_app(
                 detail="Imported document type must match the existing editable document",
             )
         try:
-            source_artifact_id, source_filename, source_sha256 = resolve_import_source(
+            prepared_import = resolve_import_source(
                 str(current["job_id"]), document_id, command.source
             )
 
             def replace_document(connection: sqlite3.Connection) -> dict[str, object]:
+                source_artifact_id, source_filename, source_sha256 = register_import_source(
+                    str(current["job_id"]), prepared_import, connection
+                )
                 row = state_store.replace_editable_document_from_import(
                     document_id,
                     expected_revision=command.base_revision,
@@ -1698,13 +1753,17 @@ def create_app(
                 mutation=replace_document,
                 label=f"Replaced {current['document_label']} from DOCX",
                 job_id=str(current["job_id"]),
-                detail={"source_artifact_id": source_artifact_id},
+                detail={"source_sha256": prepared_import.sha256},
             )
         except EditableDocumentConflict as error:
             raise editable_conflict(error) from error
         except KeyError as error:
             raise HTTPException(status_code=404, detail="Editable document not found") from error
-        except (ArtifactTrustError, OSError, ValueError) as error:
+        except (ArtifactStorageError, OSError, sqlite3.OperationalError) as error:
+            raise HTTPException(
+                status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
+            ) from error
+        except (ArtifactTrustError, ValueError) as error:
             raise HTTPException(status_code=422, detail=str(error)) from error
         except IdempotencyConflict as error:
             raise HTTPException(status_code=409, detail=str(error)) from error
@@ -1927,9 +1986,6 @@ def create_app(
                 status_code=409,
                 detail="Resolve all document suggestions before publication",
             )
-        if settings.hermes_job_hunter_cwd is None:
-            raise HTTPException(status_code=503, detail="Job Hunter workspace is unavailable")
-
         canonical_bytes = json.dumps(
             {
                 "schema_version": current["schema_version"],
@@ -1944,113 +2000,67 @@ def create_app(
             sort_keys=True,
         ).encode()
         canonical_sha256 = hashlib.sha256(canonical_bytes).hexdigest()
-        publication_source_bytes = json.dumps(
-            {
-                "schema_version": current["schema_version"],
-                "document_id": document_id,
-                "document_revision": current["revision"],
-                "canonical_sha256": canonical_sha256,
-                "original_source_sha256": current["source_sha256"],
-            },
-            separators=(",", ":"),
-            sort_keys=True,
-        ).encode()
-        publication_source_base64 = base64.b64encode(publication_source_bytes).decode("ascii")
-        publication_source_sha256 = hashlib.sha256(publication_source_bytes).hexdigest()
         try:
-            state_store.ensure_editable_publication_snapshot(
-                document_id,
-                expected_revision=command.expected_revision,
-                actor="user",
+            docx_bytes = base64.b64decode(command.docx_base64, validate=True)
+            pdf_bytes = base64.b64decode(command.pdf_base64, validate=True)
+            stored_docx, stored_pdf = local_artifacts.store_publication_pair(
+                job_id=str(current["job_id"]),
+                document_id=document_id,
+                document_revision=command.expected_revision,
+                docx=ArtifactWrite(
+                    command.docx_filename,
+                    DOCX_MEDIA_TYPE,
+                    docx_bytes,
+                    command.docx_sha256,
+                ),
+                pdf=ArtifactWrite(
+                    command.pdf_filename,
+                    PDF_MEDIA_TYPE,
+                    pdf_bytes,
+                    command.pdf_sha256,
+                ),
             )
-        except EditableDocumentConflict as error:
-            raise editable_conflict(error) from error
-        except KeyError as error:
-            raise HTTPException(status_code=404, detail="Editable document not found") from error
-
-        publications = (
-            (command.docx_filename, command.docx_base64, "docx"),
-            (command.pdf_filename, command.pdf_base64, "pdf"),
-        )
-        try:
-            for artifact_filename, artifact_base64, extension in publications:
-                publish_command = ArtifactPublishRequest(
-                    document_key=cast(
-                        Literal["resume", "cover_letter", "references"],
-                        current["document_key"],
-                    ),
-                    document_label=str(current["document_label"]),
-                    source_filename="publication-source.json",
-                    source_base64=publication_source_base64,
-                    artifact_filename=artifact_filename,
-                    artifact_base64=artifact_base64,
-                    origin="user",
-                    idempotency_key=(
-                        f"editable-{hashlib.sha256(f'{document_id}:{command.expected_revision}:{extension}'.encode()).hexdigest()[:32]}"
-                    ),
-                )
-                artifact_request_hash = mutation_hash(
-                    "document.publish",
-                    {
-                        "job_id": current["job_id"],
-                        "document_key": current["document_key"],
-                        "document_label": current["document_label"],
-                        "source_filename": "publication-source.json",
-                        "source_sha256": publication_source_sha256,
-                        "artifact_filename": artifact_filename,
-                        "artifact_sha256": (
-                            command.docx_sha256 if extension == "docx" else command.pdf_sha256
-                        ),
-                        "origin": "user",
-                    },
-                )
-                artifact_replay = mutation_replay(
-                    identity=identity,
-                    target=f"jobs/{current['job_id']}/artifacts",
-                    command_name="document.publish",
-                    idempotency_key=publish_command.idempotency_key,
-                    request_hash=artifact_request_hash,
-                )
-                if artifact_replay is not None:
-                    continue
-                source_path, artifact_path = materialize_published_document(
-                    publish_command,
-                    job_id=str(current["job_id"]),
-                    workspace_root=settings.hermes_job_hunter_cwd,
-                )
-                raw = artifacts.publish_document_artifact(
-                    str(current["job_id"]),
-                    str(current["document_key"]),
-                    str(current["document_label"]),
-                    str(source_path),
-                    str(artifact_path),
-                )
-                verified = verify_source_artifact(raw, settings.artifact_roots)
-                state_store.register_document_artifacts(
-                    str(current["job_id"]),
-                    [verified],
-                    editable_document_id=document_id,
-                    editable_document_revision=command.expected_revision,
-                )
-                publication_state = artifact_list(str(current["job_id"]))
-                record_mutation(
-                    identity=identity,
-                    target=f"jobs/{current['job_id']}/artifacts",
-                    command_name="document.publish",
-                    origin="user",
-                    idempotency_key=publish_command.idempotency_key,
-                    request_hash=artifact_request_hash,
-                    result=publication_state.model_dump(mode="json"),
-                    label=f"Published {current['document_label']} {extension.upper()}",
-                    job_id=str(current["job_id"]),
-                    detail={
-                        "artifact_id": publication_state.current_artifact_id,
-                        "document_key": current["document_key"],
-                    },
-                )
-        except (ArtifactTrustError, OSError, ValueError) as error:
+        except (ArtifactStorageError, OSError, sqlite3.OperationalError) as error:
+            raise HTTPException(
+                status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
+            ) from error
+        except (ArtifactValidationError, ValueError) as error:
             raise HTTPException(status_code=422, detail=str(error)) from error
+
         def mark_published(connection: sqlite3.Connection) -> dict[str, object]:
+            first_sequence = state_store.next_document_artifact_sequence(
+                str(current["job_id"]), connection=connection
+            )
+            document_key = cast(
+                Literal["resume", "cover_letter", "references"],
+                current["document_key"],
+            )
+            verified_pair = [
+                VerifiedArtifact(
+                    job_id=str(current["job_id"]),
+                    document_key=document_key,
+                    document_label=str(current["document_label"]),
+                    source_revision=(
+                        f"editable:{document_id}:{command.expected_revision}:{canonical_sha256}"
+                    ),
+                    artifact_revision=stored.sha256,
+                    media_type=stored.media_type,
+                    sha256=stored.sha256,
+                    render_status="succeeded",
+                    render_sequence=first_sequence + offset,
+                    canonical_path=str(stored.canonical_path),
+                    filename=stored.filename,
+                    failure_message=None,
+                )
+                for offset, stored in enumerate((stored_docx, stored_pdf))
+            ]
+            state_store.register_editable_publication_pair(
+                str(current["job_id"]),
+                verified_pair,
+                editable_document_id=document_id,
+                editable_document_revision=command.expected_revision,
+                connection=connection,
+            )
             row = state_store.mark_editable_document_published(
                 document_id,
                 expected_revision=command.expected_revision,
@@ -2072,8 +2082,14 @@ def create_app(
             )
         except EditableDocumentConflict as error:
             raise editable_conflict(error) from error
+        except EditablePublicationConflict as error:
+            raise HTTPException(status_code=409, detail=str(error)) from error
         except KeyError as error:
             raise HTTPException(status_code=404, detail="Editable document not found") from error
+        except (OSError, sqlite3.OperationalError) as error:
+            raise HTTPException(
+                status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
+            ) from error
         except IdempotencyConflict as error:
             raise HTTPException(status_code=409, detail=str(error)) from error
         return EditableDocument.model_validate(result)
@@ -2099,6 +2115,19 @@ def create_app(
         )
 
     def registered_artifact_payload(record: dict[str, object]) -> bytes:
+        registered_path = Path(str(record["canonical_path"])).expanduser()
+        local_root = local_artifacts.root
+        if registered_path == local_root or local_root in registered_path.parents:
+            try:
+                return local_artifacts.read(
+                    path=registered_path,
+                    media_type=str(record["media_type"]),
+                    expected_sha256=str(record["sha256"]),
+                )
+            except (ArtifactStorageError, OSError) as error:
+                raise HTTPException(
+                    status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
+                ) from error
         try:
             _, payload = read_source_artifact(
                 {
@@ -2115,8 +2144,12 @@ def create_app(
                     "render_sequence": 0,
                     "path": record["canonical_path"],
                 },
-                settings.artifact_roots,
+                trusted_artifact_roots,
             )
+        except ArtifactStorageError as error:
+            raise HTTPException(
+                status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
+            ) from error
         except (ArtifactTrustError, OSError) as error:
             raise HTTPException(
                 status_code=409,
@@ -2233,8 +2266,12 @@ def create_app(
             return JobArtifactsResponse.model_validate(replay)
         try:
             raw_artifacts = artifacts.list_job_artifacts(job_id)
-            verified = verify_facade_artifacts(raw_artifacts, settings.artifact_roots)
+            verified = verify_facade_artifacts(raw_artifacts, trusted_artifact_roots)
             state_store.register_document_artifacts(job_id, verified)
+        except (ArtifactStorageError, OSError) as error:
+            raise HTTPException(
+                status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
+            ) from error
         except (ArtifactTrustError, ValueError) as error:
             raise HTTPException(status_code=422, detail=str(error)) from error
         result = artifact_list(job_id)
@@ -2284,10 +2321,14 @@ def create_app(
             raw = artifacts.render_resume(
                 job_id, command.source_id, {"format": command.output_format}
             )
-            verified = verify_source_artifact(raw, settings.artifact_roots)
+            verified = verify_source_artifact(raw, trusted_artifact_roots)
             state_store.register_document_artifacts(job_id, [verified])
         except KeyError as error:
             raise HTTPException(status_code=404, detail="Resume source not found") from error
+        except (ArtifactStorageError, OSError) as error:
+            raise HTTPException(
+                status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
+            ) from error
         except (ArtifactTrustError, ValueError) as error:
             raise HTTPException(status_code=422, detail=str(error)) from error
         result = artifact_list(job_id)
@@ -2337,11 +2378,15 @@ def create_app(
                 return JobArtifactsResponse.model_validate(replay)
             try:
                 raw = artifacts.register_artifact(job_id, command.artifact_reference)
-                verified = verify_source_artifact(raw, settings.artifact_roots)
+                verified = verify_source_artifact(raw, trusted_artifact_roots)
                 state_store.register_document_artifacts(job_id, [verified])
             except KeyError as error:
                 raise HTTPException(
                     status_code=404, detail="Artifact reference not found"
+                ) from error
+            except (ArtifactStorageError, OSError) as error:
+                raise HTTPException(
+                    status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
                 ) from error
             except (ArtifactTrustError, ValueError) as error:
                 raise HTTPException(status_code=422, detail=str(error)) from error
@@ -2371,7 +2416,10 @@ def create_app(
         require_trusted_mcp(identity, command.origin, mcp_token)
         ensure_job(job_id)
         if settings.hermes_job_hunter_cwd is None:
-            raise HTTPException(status_code=503, detail="Job Hunter workspace is unavailable")
+            raise HTTPException(
+                status_code=503,
+                detail="JobHunter artifact publication is unconfigured",
+            )
         source_bytes = command.source_bytes()
         artifact_bytes = command.artifact_bytes()
         request_hash = mutation_hash(
@@ -2412,11 +2460,15 @@ def create_app(
                 str(source_path),
                 str(artifact_path),
             )
-            verified = verify_source_artifact(raw, settings.artifact_roots)
+            verified = verify_source_artifact(raw, trusted_artifact_roots)
             state_store.register_document_artifacts(job_id, [verified])
         except KeyError as error:
             raise HTTPException(status_code=404, detail="Job not found") from error
-        except (ArtifactTrustError, OSError, ValueError) as error:
+        except (ArtifactStorageError, OSError) as error:
+            raise HTTPException(
+                status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE
+            ) from error
+        except (ArtifactTrustError, ValueError) as error:
             raise HTTPException(status_code=422, detail=str(error)) from error
         result = artifact_list(job_id)
         published = next(

--- a/services/api/jobos_api/artifact_gateway.py
+++ b/services/api/jobos_api/artifact_gateway.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
-from jobos_api.job_repository import NotFound, Unavailable
+from jobos_api.job_repository import Unavailable
 
 
 class ArtifactGateway(Protocol):
@@ -27,13 +27,13 @@ class ArtifactGateway(Protocol):
 
 
 class UnavailableArtifactGateway:
-    """Truthful public default until local artifact ownership lands."""
+    """Stable errors for optional private publication and rendering capabilities."""
 
     def list_job_artifacts(self, job_id: str) -> list[dict[str, Any]]:
-        return []
+        raise Unavailable("JobHunter artifact refresh is unconfigured")
 
     def register_artifact(self, job_id: str, artifact_reference: str) -> dict[str, Any]:
-        raise NotFound(f"Unknown artifact {artifact_reference}")
+        raise Unavailable("JobHunter artifact registration is unconfigured")
 
     def publish_document_artifact(
         self,
@@ -43,9 +43,9 @@ class UnavailableArtifactGateway:
         source_path: str,
         artifact_path: str,
     ) -> dict[str, Any]:
-        raise Unavailable("Artifact publication is unavailable")
+        raise Unavailable("JobHunter artifact publication is unconfigured")
 
     def render_resume(
         self, job_id: str, source_id: str, output_options: dict[str, Any]
     ) -> dict[str, Any]:
-        raise Unavailable("Artifact rendering is unavailable")
+        raise Unavailable("JobHunter artifact rendering is unconfigured")

--- a/services/api/jobos_api/artifact_repository.py
+++ b/services/api/jobos_api/artifact_repository.py
@@ -1,0 +1,965 @@
+from __future__ import annotations
+
+import errno
+import os
+import re
+import stat
+import zipfile
+from contextlib import suppress
+from dataclasses import dataclass
+from hashlib import sha256
+from io import BytesIO
+from pathlib import Path, PurePosixPath
+from typing import Protocol
+from uuid import uuid4
+from xml.etree import ElementTree
+
+PDF_MEDIA_TYPE = "application/pdf"
+DOCX_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+ALLOWED_MEDIA_TYPES = frozenset({PDF_MEDIA_TYPE, DOCX_MEDIA_TYPE})
+MAX_ARTIFACT_BYTES = 20_000_000
+MAX_DOCX_ENTRIES = 2_048
+MAX_DOCX_EXPANDED_BYTES = 100_000_000
+MAX_DOCX_COMPRESSION_RATIO = 1_000
+MAX_DOCX_REQUIRED_XML_BYTES = 5_000_000
+MAX_STORED_FILENAME_BYTES = 255
+STORED_HASH_PREFIX_BYTES = 21
+MAX_CALLER_FILENAME_BYTES = MAX_STORED_FILENAME_BYTES - STORED_HASH_PREFIX_BYTES
+MAX_PDF_XREF_ENTRIES = 200_000
+MAX_PDF_TRAILER_BYTES = 65_536
+_DOCX_REQUIRED_PARTS = {
+    "[Content_Types].xml": "{http://schemas.openxmlformats.org/package/2006/content-types}Types",
+    "_rels/.rels": "{http://schemas.openxmlformats.org/package/2006/relationships}Relationships",
+    "word/document.xml": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document",
+}
+_CONTENT_TYPES_NAMESPACE = "http://schemas.openxmlformats.org/package/2006/content-types"
+_RELATIONSHIPS_NAMESPACE = "http://schemas.openxmlformats.org/package/2006/relationships"
+_OFFICE_DOCUMENT_RELATIONSHIP = (
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+)
+_WORD_MAIN_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"
+)
+_PDF_HEADER = re.compile(br"\A%PDF-(?:1\.[0-7]|2\.0)(?:\r\n|\r|\n)")
+_PDF_FINAL = re.compile(
+    br"startxref[ \t]*(?:\r\n|\r|\n)[ \t]*([0-9]{1,10})[ \t]*"
+    br"(?:\r\n|\r|\n)[ \t]*%%EOF[ \t]*(?:\r\n|\r|\n)?\Z"
+)
+
+
+class ArtifactRepositoryError(Exception):
+    """Base error for the local artifact repository boundary."""
+
+
+class ArtifactValidationError(ArtifactRepositoryError, ValueError):
+    """Caller-supplied artifact metadata or bytes are malformed."""
+
+
+class ArtifactStorageError(ArtifactRepositoryError, RuntimeError):
+    """Configured storage or already-stored bytes are not trustworthy."""
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactWrite:
+    filename: str
+    media_type: str
+    content: bytes
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class StoredArtifact:
+    canonical_path: Path
+    filename: str
+    media_type: str
+    sha256: str
+    size: int
+
+
+class ArtifactRepository(Protocol):
+    """Byte-only artifact storage; metadata remains owned by JobOsStateStore."""
+
+    @property
+    def root(self) -> Path: ...
+
+    def store_import(
+        self, *, job_id: str, document_id: str, artifact: ArtifactWrite
+    ) -> StoredArtifact: ...
+
+    def store_publication_pair(
+        self,
+        *,
+        job_id: str,
+        document_id: str,
+        document_revision: int,
+        docx: ArtifactWrite,
+        pdf: ArtifactWrite,
+    ) -> tuple[StoredArtifact, StoredArtifact]: ...
+
+    def read(self, *, path: Path, media_type: str, expected_sha256: str) -> bytes: ...
+
+
+def validate_safe_segment(value: str, label: str) -> str:
+    if not re.fullmatch(r"[A-Za-z0-9._-]{1,256}", value) or value in {".", ".."}:
+        raise ArtifactValidationError(f"{label} is not safe for artifact storage")
+    return value
+
+
+def validate_plain_filename(
+    filename: str,
+    media_type: str,
+    *,
+    maximum_bytes: int = MAX_CALLER_FILENAME_BYTES,
+) -> str:
+    if (
+        not filename
+        or filename != filename.strip()
+        or filename in {".", ".."}
+        or Path(filename).name != filename
+        or "/" in filename
+        or "\\" in filename
+        or any(ord(character) < 32 or ord(character) == 127 for character in filename)
+        or len(filename.encode("utf-8")) > maximum_bytes
+    ):
+        raise ArtifactValidationError("Artifact filename must be a plain filename")
+    expected_suffix = media_suffix(media_type)
+    if not filename.casefold().endswith(expected_suffix):
+        raise ArtifactValidationError("Artifact filename does not match its media type")
+    return filename
+
+
+def media_suffix(media_type: str) -> str:
+    if media_type == PDF_MEDIA_TYPE:
+        return ".pdf"
+    if media_type == DOCX_MEDIA_TYPE:
+        return ".docx"
+    raise ArtifactValidationError("Artifact media type is not allowlisted")
+
+
+def validate_artifact_bytes(
+    content: bytes,
+    *,
+    media_type: str,
+    expected_sha256: str | None = None,
+    maximum: int = MAX_ARTIFACT_BYTES,
+) -> str:
+    if media_type not in ALLOWED_MEDIA_TYPES:
+        raise ArtifactValidationError("Artifact media type is not allowlisted")
+    if not content or len(content) > maximum:
+        raise ArtifactValidationError("Artifact size is invalid")
+    if media_type == PDF_MEDIA_TYPE:
+        _validate_pdf(content)
+    else:
+        _validate_docx(content)
+    digest = sha256(content).hexdigest()
+    if expected_sha256 is not None and (
+        not re.fullmatch(r"[a-f0-9]{64}", expected_sha256) or digest != expected_sha256
+    ):
+        raise ArtifactValidationError("Artifact SHA-256 does not match")
+    return digest
+
+
+def _pdf_dictionary(content: bytes, start: int) -> tuple[bytes, int]:
+    start = content.find(b"<<", start, min(len(content), start + MAX_PDF_TRAILER_BYTES))
+    if start < 0:
+        raise ArtifactValidationError("PDF trailer dictionary is missing")
+    depth = 0
+    position = start
+    in_literal = False
+    escaped = False
+    while position < len(content) and position - start <= MAX_PDF_TRAILER_BYTES:
+        byte = content[position]
+        if in_literal:
+            if escaped:
+                escaped = False
+            elif byte == 0x5C:
+                escaped = True
+            elif byte == 0x29:
+                in_literal = False
+            position += 1
+            continue
+        if byte == 0x25:
+            newline = content.find(b"\n", position + 1)
+            position = len(content) if newline < 0 else newline + 1
+            continue
+        if byte == 0x28:
+            in_literal = True
+            position += 1
+            continue
+        if content[position : position + 2] == b"<<":
+            depth += 1
+            position += 2
+            continue
+        if content[position : position + 2] == b">>":
+            depth -= 1
+            position += 2
+            if depth == 0:
+                return content[start:position], position
+            continue
+        position += 1
+    raise ArtifactValidationError("PDF trailer dictionary is malformed or excessive")
+
+
+def _pdf_reference(dictionary: bytes, name: bytes) -> tuple[int, int] | None:
+    match = re.search(rb"/" + name + rb"\s+([0-9]+)\s+([0-9]+)\s+R\b", dictionary)
+    return (int(match.group(1)), int(match.group(2))) if match else None
+
+
+def _validate_pdf(content: bytes) -> None:
+    if _PDF_HEADER.match(content) is None:
+        raise ArtifactValidationError("Artifact bytes do not contain a valid PDF header")
+    final_window_start = max(0, len(content) - MAX_PDF_TRAILER_BYTES)
+    final = _PDF_FINAL.search(content, final_window_start)
+    if final is None:
+        raise ArtifactValidationError("PDF startxref or final EOF marker is invalid")
+    xref_offset = int(final.group(1))
+    if xref_offset <= 0 or xref_offset >= final.start():
+        raise ArtifactValidationError("PDF startxref offset is out of bounds")
+
+    root_reference: tuple[int, int] | None = None
+    xref_entries: dict[tuple[int, int], int] = {}
+    if content[xref_offset : xref_offset + 4] != b"xref":
+        raise ArtifactValidationError("PDF cross-reference streams are not supported")
+    position = xref_offset + 4
+    entry_count = 0
+    while True:
+        whitespace = re.match(br"[\x00\x09\x0a\x0c\x0d\x20]*", content[position:])
+        assert whitespace is not None
+        position += whitespace.end()
+        if content[position : position + 7] == b"trailer":
+            position += 7
+            break
+        subsection = re.match(br"([0-9]+)[ \t]+([0-9]+)(?:\r\n|\r|\n)", content[position:])
+        if subsection is None:
+            raise ArtifactValidationError("PDF cross-reference table is malformed")
+        first_object = int(subsection.group(1))
+        count = int(subsection.group(2))
+        entry_count += count
+        if count < 1 or entry_count > MAX_PDF_XREF_ENTRIES:
+            raise ArtifactValidationError("PDF cross-reference table is excessive")
+        position += subsection.end()
+        for index in range(count):
+            entry = re.match(
+                br"([0-9]{10})[ \t]([0-9]{5})[ \t]([nf])(?:[ \t]*(?:\r\n|\r|\n))",
+                content[position:],
+            )
+            if entry is None:
+                raise ArtifactValidationError("PDF cross-reference entry is malformed")
+            if entry.group(3) == b"n":
+                offset = int(entry.group(1))
+                generation = int(entry.group(2))
+                if offset <= 0 or offset >= xref_offset:
+                    raise ArtifactValidationError("PDF object offset is out of bounds")
+                xref_entries[(first_object + index, generation)] = offset
+            position += entry.end()
+    trailer, _ = _pdf_dictionary(content, position)
+    if re.search(br"/XRefStm\b", trailer) is not None:
+        raise ArtifactValidationError("PDF cross-reference streams are not supported")
+    size = re.search(br"/Size\s+([0-9]+)\b", trailer)
+    root_reference = _pdf_reference(trailer, b"Root")
+    if size is None or not 1 <= int(size.group(1)) <= MAX_PDF_XREF_ENTRIES:
+        raise ArtifactValidationError("PDF trailer size is invalid")
+    if root_reference is None:
+        raise ArtifactValidationError("PDF trailer does not identify a document catalog")
+    for (object_number, generation), offset in xref_entries.items():
+        header = re.match(rb"%d\s+%d\s+obj\b" % (object_number, generation), content[offset:])
+        if header is None:
+            raise ArtifactValidationError("PDF cross-reference does not match its objects")
+
+    root_number, root_generation = root_reference
+    root_offset = xref_entries.get(root_reference)
+    root_pattern = rb"(?:\A|[\r\n])%d\s+%d\s+obj\b" % (root_number, root_generation)
+    if root_offset is not None:
+        root_match = re.match(
+            rb"%d\s+%d\s+obj\b" % (root_number, root_generation), content[root_offset:]
+        )
+        root_start = root_offset + (root_match.end() if root_match else 0)
+    else:
+        located = re.search(root_pattern, content[:xref_offset])
+        root_start = located.end() if located else -1
+    if root_start < 0:
+        raise ArtifactValidationError("PDF document catalog object is missing")
+    root_end = content.find(b"endobj", root_start, min(xref_offset, root_start + 1_000_000))
+    if root_end < 0:
+        raise ArtifactValidationError("PDF document catalog object is malformed")
+    root_object = content[root_start:root_end]
+    if (
+        re.search(br"/Type\s*/Catalog\b", root_object) is None
+        or _pdf_reference(root_object, b"Pages") is None
+    ):
+        raise ArtifactValidationError("PDF document catalog is invalid")
+
+
+def _validate_docx(content: bytes) -> None:
+    try:
+        with zipfile.ZipFile(BytesIO(content)) as archive:
+            entries = archive.infolist()
+            if not entries or len(entries) > MAX_DOCX_ENTRIES:
+                raise ArtifactValidationError("DOCX ZIP entry count is invalid")
+            names: set[str] = set()
+            expanded = 0
+            for entry in entries:
+                name = entry.filename
+                pure = PurePosixPath(name)
+                raw_parts = name.split("/")
+                if entry.is_dir():
+                    raw_parts = raw_parts[:-1]
+                unix_mode = entry.external_attr >> 16
+                if (
+                    not name
+                    or "\\" in name
+                    or name.startswith("/")
+                    or pure.is_absolute()
+                    or not raw_parts
+                    or any(part in {"", ".", ".."} for part in raw_parts)
+                    or name in names
+                    or stat.S_ISLNK(unix_mode)
+                ):
+                    raise ArtifactValidationError("DOCX contains an unsafe ZIP entry")
+                names.add(name)
+                if entry.flag_bits & 0x1:
+                    raise ArtifactValidationError("DOCX contains an encrypted ZIP entry")
+                if entry.compress_type not in {zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED}:
+                    raise ArtifactValidationError("DOCX uses an unsupported ZIP compression method")
+                expanded += entry.file_size
+                if expanded > MAX_DOCX_EXPANDED_BYTES:
+                    raise ArtifactValidationError("DOCX ZIP expansion is excessive")
+                if (
+                    (entry.file_size and entry.compress_size == 0)
+                    or (
+                        entry.compress_size
+                        and entry.file_size
+                        > entry.compress_size * MAX_DOCX_COMPRESSION_RATIO
+                    )
+                ):
+                    raise ArtifactValidationError("DOCX ZIP compression ratio is excessive")
+            missing = _DOCX_REQUIRED_PARTS.keys() - names
+            if missing:
+                raise ArtifactValidationError("DOCX is missing required OOXML parts")
+            parsed_parts: dict[str, ElementTree.Element] = {}
+            for name, expected_tag in _DOCX_REQUIRED_PARTS.items():
+                if archive.getinfo(name).file_size > MAX_DOCX_REQUIRED_XML_BYTES:
+                    raise ArtifactValidationError("DOCX required OOXML part is excessive")
+                try:
+                    xml = archive.read(name)
+                    if b"<!doctype" in xml.lower() or b"<!entity" in xml.lower():
+                        raise ArtifactValidationError(
+                            "DOCX required OOXML contains a forbidden declaration"
+                        )
+                    root = ElementTree.fromstring(xml)
+                except ElementTree.ParseError as error:
+                    raise ArtifactValidationError("DOCX contains malformed OOXML") from error
+                if root.tag != expected_tag:
+                    raise ArtifactValidationError("DOCX contains invalid required OOXML parts")
+                parsed_parts[name] = root
+
+            content_types = parsed_parts["[Content_Types].xml"]
+            document = parsed_parts["word/document.xml"]
+            body_tag = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}body"
+            direct_bodies = document.findall(body_tag)
+            all_bodies = list(document.iter(body_tag))
+            if len(direct_bodies) != 1 or len(all_bodies) != 1:
+                raise ArtifactValidationError("DOCX main document must contain exactly one body")
+
+            word_overrides = [
+                entry
+                for entry in content_types.findall(
+                    f"{{{_CONTENT_TYPES_NAMESPACE}}}Override"
+                )
+                if entry.get("PartName") == "/word/document.xml"
+            ]
+            if (
+                len(word_overrides) != 1
+                or word_overrides[0].get("ContentType") != _WORD_MAIN_CONTENT_TYPE
+            ):
+                raise ArtifactValidationError(
+                    "DOCX main document content type is missing or invalid"
+                )
+
+            relationships = parsed_parts["_rels/.rels"]
+            office_documents = [
+                relationship
+                for relationship in relationships.findall(
+                    f"{{{_RELATIONSHIPS_NAMESPACE}}}Relationship"
+                )
+                if relationship.get("Type") == _OFFICE_DOCUMENT_RELATIONSHIP
+            ]
+            if len(office_documents) != 1:
+                raise ArtifactValidationError(
+                    "DOCX package must contain one officeDocument relationship"
+                )
+            office_document = office_documents[0]
+            target = office_document.get("Target", "")
+            normalized_target = PurePosixPath(target.lstrip("/"))
+            if (
+                office_document.get("TargetMode", "Internal") != "Internal"
+                or not target
+                or "\\" in target
+                or normalized_target.parts != ("word", "document.xml")
+            ):
+                raise ArtifactValidationError(
+                    "DOCX officeDocument relationship target is invalid"
+                )
+            corrupt = archive.testzip()
+            if corrupt is not None:
+                raise ArtifactValidationError("DOCX ZIP integrity check failed")
+    except ArtifactValidationError:
+        raise
+    except (zipfile.BadZipFile, zipfile.LargeZipFile, NotImplementedError, RuntimeError) as error:
+        raise ArtifactValidationError("Artifact bytes are not a valid DOCX") from error
+
+
+def resolve_repository_root(root: Path, *, create: bool) -> Path:
+    supplied = root.expanduser()
+    if supplied.is_symlink():
+        raise ArtifactStorageError("Artifact repository root must not be a symbolic link")
+    if create:
+        supplied.mkdir(parents=True, exist_ok=True, mode=0o700)
+    resolved = supplied.resolve(strict=True)
+    metadata = resolved.stat()
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise ArtifactStorageError("Artifact repository root must be a directory")
+    return resolved
+
+
+def _open_flags(*, directory: bool = False) -> int:
+    flags = os.O_RDONLY
+    if directory and hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    return flags
+
+
+def _same_identity(first: os.stat_result, second: os.stat_result) -> bool:
+    return (
+        first.st_dev == second.st_dev
+        and first.st_ino == second.st_ino
+        and stat.S_IFMT(first.st_mode) == stat.S_IFMT(second.st_mode)
+    )
+
+
+@dataclass(slots=True)
+class OpenedDirectoryChain:
+    """A retained no-follow descriptor chain beneath one validated root."""
+
+    root: Path
+    path: Path
+    descriptors: list[int]
+    segments: tuple[str, ...]
+
+    @property
+    def descriptor(self) -> int:
+        return self.descriptors[-1]
+
+    def assert_attached(self) -> None:
+        """Require every descriptor to remain at its original root-relative name."""
+        try:
+            named_root = os.stat(self.root, follow_symlinks=False)
+            if not _same_identity(named_root, os.fstat(self.descriptors[0])):
+                raise ArtifactStorageError("Configured artifact root changed during storage")
+            for index, segment in enumerate(self.segments):
+                named = os.stat(
+                    segment,
+                    dir_fd=self.descriptors[index],
+                    follow_symlinks=False,
+                )
+                opened = os.fstat(self.descriptors[index + 1])
+                if not stat.S_ISDIR(opened.st_mode) or not _same_identity(named, opened):
+                    raise ArtifactStorageError(
+                        "Artifact repository directory changed during storage"
+                    )
+        except OSError as error:
+            if error.errno in {errno.ELOOP, errno.ENOENT, errno.ENOTDIR}:
+                raise ArtifactStorageError(
+                    "Artifact repository directory changed during storage"
+                ) from error
+            raise
+
+    def close(self) -> None:
+        while self.descriptors:
+            os.close(self.descriptors.pop())
+
+    def __enter__(self) -> OpenedDirectoryChain:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+def open_directory_chain(root: Path, *segments: str) -> OpenedDirectoryChain:
+    """Create and open descendants only through descriptors rooted at ``root``."""
+    resolved_root = resolve_repository_root(root, create=False)
+    safe_segments = tuple(
+        validate_safe_segment(segment, "Artifact path segment") for segment in segments
+    )
+    expected_root = os.stat(resolved_root, follow_symlinks=False)
+    descriptors: list[int] = []
+    try:
+        root_descriptor = os.open(resolved_root, _open_flags(directory=True))
+        descriptors.append(root_descriptor)
+        opened_root = os.fstat(root_descriptor)
+        if not stat.S_ISDIR(opened_root.st_mode) or not _same_identity(
+            expected_root, opened_root
+        ):
+            raise ArtifactStorageError("Configured artifact root changed during storage")
+
+        current = root_descriptor
+        for segment in safe_segments:
+            created = False
+            try:
+                os.mkdir(segment, mode=0o700, dir_fd=current)
+                created = True
+            except FileExistsError:
+                pass
+            if created:
+                os.fsync(current)
+            descriptor = os.open(segment, _open_flags(directory=True), dir_fd=current)
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISDIR(metadata.st_mode):
+                os.close(descriptor)
+                raise ArtifactStorageError("Artifact repository ancestor is not a directory")
+            descriptors.append(descriptor)
+            current = descriptor
+
+        opened = OpenedDirectoryChain(
+            root=resolved_root,
+            path=resolved_root.joinpath(*safe_segments),
+            descriptors=descriptors,
+            segments=safe_segments,
+        )
+        opened.assert_attached()
+        return opened
+    except OSError as error:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+        if error.errno in {errno.ELOOP, errno.ENOENT, errno.ENOTDIR}:
+            raise ArtifactStorageError(
+                "Artifact repository path contains a symbolic link or missing component"
+            ) from error
+        raise
+    except BaseException:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+        raise
+
+
+def open_contained_file(
+    path: Path,
+    *,
+    roots: tuple[Path, ...],
+) -> tuple[Path, int, os.stat_result]:
+    """Open one regular file beneath a trusted root without following descendant links."""
+    supplied = Path(os.path.abspath(path.expanduser()))
+    resolved_roots: list[tuple[Path, os.stat_result]] = []
+    for root in roots:
+        try:
+            resolved = resolve_repository_root(root, create=False)
+            resolved_roots.append((resolved, os.stat(resolved, follow_symlinks=False)))
+        except FileNotFoundError:
+            continue
+
+    selected: tuple[Path, tuple[str, ...], os.stat_result] | None = None
+    for root, root_metadata in sorted(
+        resolved_roots, key=lambda item: len(item[0].parts), reverse=True
+    ):
+        try:
+            relative = supplied.relative_to(root)
+        except ValueError:
+            continue
+        if relative.parts and all(part not in {"", ".", ".."} for part in relative.parts):
+            selected = root, relative.parts, root_metadata
+            break
+    if selected is None:
+        raise ArtifactStorageError("Artifact is outside configured roots")
+
+    root, parts, expected_root = selected
+    descriptors: list[int] = []
+    try:
+        root_descriptor = os.open(root, _open_flags(directory=True))
+        descriptors.append(root_descriptor)
+        opened_root = os.fstat(root_descriptor)
+        if not stat.S_ISDIR(opened_root.st_mode) or not _same_identity(
+            expected_root, opened_root
+        ):
+            raise ArtifactStorageError("Configured artifact root changed during access")
+        current = root_descriptor
+        for part in parts[:-1]:
+            descriptor = os.open(part, _open_flags(directory=True), dir_fd=current)
+            descriptors.append(descriptor)
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise ArtifactStorageError("Artifact ancestor is not a directory")
+            current = descriptor
+        descriptor = os.open(parts[-1], _open_flags(), dir_fd=current)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            os.close(descriptor)
+            raise ArtifactStorageError("Artifact is not a regular file")
+        return root.joinpath(*parts), descriptor, metadata
+    except OSError as error:
+        if error.errno in {errno.ELOOP, errno.ENOENT, errno.ENOTDIR}:
+            raise ArtifactStorageError(
+                "Artifact path contains a symbolic link or missing component"
+            ) from error
+        raise
+    finally:
+        for opened in reversed(descriptors):
+            os.close(opened)
+
+
+def read_open_file(
+    descriptor: int,
+    metadata: os.stat_result,
+    *,
+    maximum: int,
+) -> bytes:
+    if metadata.st_size <= 0 or metadata.st_size > maximum:
+        raise ArtifactStorageError("Artifact size is invalid")
+    chunks: list[bytes] = []
+    remaining = maximum + 1
+    while remaining:
+        chunk = os.read(descriptor, min(1024 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    content = b"".join(chunks)
+    after = os.fstat(descriptor)
+    if (
+        not _same_identity(metadata, after)
+        or after.st_size != metadata.st_size
+        or len(content) != metadata.st_size
+        or len(content) > maximum
+    ):
+        raise ArtifactStorageError("Artifact changed during access")
+    return content
+
+
+def verify_artifact_file(
+    path: Path,
+    *,
+    roots: tuple[Path, ...],
+    media_type: str,
+    expected_sha256: str,
+    maximum: int = MAX_ARTIFACT_BYTES,
+) -> tuple[Path, bytes]:
+    candidate, content = read_contained_file(path, roots=roots, maximum=maximum)
+    try:
+        validate_plain_filename(
+            candidate.name,
+            media_type,
+            maximum_bytes=MAX_STORED_FILENAME_BYTES,
+        )
+        validate_artifact_bytes(
+            content,
+            media_type=media_type,
+            expected_sha256=expected_sha256,
+            maximum=maximum,
+        )
+    except ArtifactValidationError as error:
+        raise ArtifactStorageError("Stored artifact failed integrity validation") from error
+    return candidate, content
+
+
+def read_contained_file(
+    path: Path,
+    *,
+    roots: tuple[Path, ...],
+    maximum: int,
+) -> tuple[Path, bytes]:
+    candidate, descriptor, metadata = open_contained_file(path, roots=roots)
+    try:
+        content = read_open_file(descriptor, metadata, maximum=maximum)
+    finally:
+        os.close(descriptor)
+    return candidate, content
+
+
+def write_new_file_at(
+    directory_descriptor: int, filename: str, content: bytes
+) -> os.stat_result:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    descriptor = os.open(filename, flags, 0o600, dir_fd=directory_descriptor)
+    identity = os.fstat(descriptor)
+    try:
+        written = 0
+        while written < len(content):
+            count = os.write(descriptor, content[written:])
+            if count <= 0:
+                raise OSError("Artifact write made no progress")
+            written += count
+        os.fsync(descriptor)
+    except BaseException:
+        try:
+            named = os.stat(filename, dir_fd=directory_descriptor, follow_symlinks=False)
+            if _same_identity(identity, named):
+                os.unlink(filename, dir_fd=directory_descriptor)
+                os.fsync(directory_descriptor)
+        except FileNotFoundError:
+            pass
+        raise
+    finally:
+        os.close(descriptor)
+    os.fsync(directory_descriptor)
+    return identity
+
+
+def read_file_at(directory_descriptor: int, filename: str, *, maximum: int) -> bytes:
+    """Read one stable regular file relative to an already-open directory."""
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(filename, _open_flags(), dir_fd=directory_descriptor)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ArtifactStorageError("Stored artifact is not a regular file")
+        content = read_open_file(descriptor, metadata, maximum=maximum)
+        named = os.stat(filename, dir_fd=directory_descriptor, follow_symlinks=False)
+        if not _same_identity(metadata, named):
+            raise ArtifactStorageError("Stored artifact changed during access")
+        return content
+    except OSError as error:
+        if error.errno in {errno.ELOOP, errno.ENOENT, errno.ENOTDIR}:
+            raise ArtifactStorageError(
+                "Stored artifact path contains a symbolic link or missing component"
+            ) from error
+        raise
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _materialize_idempotent_file(
+    directory: OpenedDirectoryChain, filename: str, content: bytes
+) -> tuple[Path, os.stat_result | None]:
+    """Exclusively create or verify a content-addressed file in ``directory``."""
+    if (
+        not filename
+        or Path(filename).name != filename
+        or "/" in filename
+        or "\\" in filename
+        or len(filename.encode("utf-8")) > MAX_STORED_FILENAME_BYTES
+    ):
+        raise ArtifactValidationError("Stored artifact filename is unsafe")
+
+    directory.assert_attached()
+    created_identity: os.stat_result | None = None
+    try:
+        with suppress(FileExistsError):
+            created_identity = write_new_file_at(directory.descriptor, filename, content)
+        # Re-sync idempotent replays in case a prior process exited before the
+        # directory entry was durable.
+        os.fsync(directory.descriptor)
+        directory.assert_attached()
+        stored_content = read_file_at(
+            directory.descriptor,
+            filename,
+            maximum=max(len(content), 1),
+        )
+        if stored_content != content:
+            raise ArtifactStorageError("Published document destination is not trustworthy")
+        directory.assert_attached()
+        return directory.path / filename, created_identity
+    except BaseException:
+        if created_identity is not None:
+            try:
+                named = os.stat(
+                    filename,
+                    dir_fd=directory.descriptor,
+                    follow_symlinks=False,
+                )
+                if _same_identity(created_identity, named):
+                    os.unlink(filename, dir_fd=directory.descriptor)
+                    os.fsync(directory.descriptor)
+            except FileNotFoundError:
+                pass
+        raise
+
+
+def materialize_idempotent_file(
+    directory: OpenedDirectoryChain, filename: str, content: bytes
+) -> Path:
+    """Exclusively create or verify one content-addressed file."""
+    path, _ = _materialize_idempotent_file(directory, filename, content)
+    return path
+
+
+def _clean_owned_directory(
+    parent_descriptor: int,
+    directory_name: str,
+    directory_descriptor: int,
+    directory_identity: os.stat_result,
+    owned_files: dict[str, os.stat_result],
+) -> None:
+    """Remove only entries and a directory created by the current operation."""
+    for filename, identity in owned_files.items():
+        try:
+            named = os.stat(
+                filename,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            continue
+        if _same_identity(identity, named):
+            os.unlink(filename, dir_fd=directory_descriptor)
+    os.fsync(directory_descriptor)
+    try:
+        named_directory = os.stat(
+            directory_name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        return
+    if not _same_identity(directory_identity, named_directory):
+        return
+    try:
+        os.rmdir(directory_name, dir_fd=parent_descriptor)
+    except OSError as error:
+        if error.errno not in {errno.ENOTEMPTY, errno.EEXIST}:
+            raise
+    os.fsync(parent_descriptor)
+
+
+def materialize_idempotent_pair(
+    directory: OpenedDirectoryChain,
+    files: tuple[tuple[str, bytes], tuple[str, bytes]],
+) -> tuple[Path, Path]:
+    """Atomically create or verify two files in one deterministic pair directory."""
+    filenames = tuple(filename for filename, _ in files)
+    if filenames[0] == filenames[1]:
+        raise ArtifactValidationError("Published document pair filenames must be distinct")
+    pair_material = b"\0".join(
+        filename.encode("utf-8") + b"\0" + sha256(content).digest()
+        for filename, content in files
+    )
+    destination_name = f"pair-{sha256(pair_material).hexdigest()[:20]}"
+    temporary_name = f".pair-{uuid4().hex}.tmp"
+    temporary_descriptor: int | None = None
+    temporary_identity: os.stat_result | None = None
+    published_descriptor: int | None = None
+    owned_files: dict[str, os.stat_result] = {}
+    renamed = False
+    completed = False
+    try:
+        directory.assert_attached()
+        os.mkdir(temporary_name, mode=0o700, dir_fd=directory.descriptor)
+        temporary_descriptor = os.open(
+            temporary_name,
+            _open_flags(directory=True),
+            dir_fd=directory.descriptor,
+        )
+        temporary_identity = os.fstat(temporary_descriptor)
+        os.fsync(directory.descriptor)
+        temporary = OpenedDirectoryChain(
+            root=directory.root,
+            path=directory.path / temporary_name,
+            descriptors=[*directory.descriptors, temporary_descriptor],
+            segments=(*directory.segments, temporary_name),
+        )
+        for filename, content in files:
+            _, created_identity = _materialize_idempotent_file(
+                temporary, filename, content
+            )
+            if created_identity is not None:
+                owned_files[filename] = created_identity
+            temporary.assert_attached()
+        os.fsync(temporary_descriptor)
+        temporary.assert_attached()
+        try:
+            os.rename(
+                temporary_name,
+                destination_name,
+                src_dir_fd=directory.descriptor,
+                dst_dir_fd=directory.descriptor,
+            )
+        except OSError as error:
+            try:
+                published_descriptor = os.open(
+                    destination_name,
+                    _open_flags(directory=True),
+                    dir_fd=directory.descriptor,
+                )
+            except OSError:
+                raise error from None
+            try:
+                os.fsync(directory.descriptor)
+            except OSError as fsync_error:
+                raise ArtifactStorageError(
+                    "Could not synchronize published document pair directory"
+                ) from fsync_error
+        else:
+            renamed = True
+            published_descriptor = temporary_descriptor
+            try:
+                os.fsync(directory.descriptor)
+            except OSError as error:
+                raise ArtifactStorageError(
+                    "Could not synchronize published document pair directory"
+                ) from error
+
+        published = OpenedDirectoryChain(
+            root=directory.root,
+            path=directory.path / destination_name,
+            descriptors=[*directory.descriptors, published_descriptor],
+            segments=(*directory.segments, destination_name),
+        )
+        published.assert_attached()
+        for filename, content in files:
+            if read_file_at(
+                published_descriptor,
+                filename,
+                maximum=max(len(content), 1),
+            ) != content:
+                raise ArtifactStorageError(
+                    "Published document destination is not trustworthy"
+                )
+            published.assert_attached()
+        completed = True
+        return published.path / filenames[0], published.path / filenames[1]
+    finally:
+        try:
+            if (
+                temporary_descriptor is not None
+                and temporary_identity is not None
+                and (not renamed or not completed)
+            ):
+                _clean_owned_directory(
+                    directory.descriptor,
+                    destination_name if renamed else temporary_name,
+                    temporary_descriptor,
+                    temporary_identity,
+                    owned_files,
+                )
+        finally:
+            if (
+                published_descriptor is not None
+                and published_descriptor != temporary_descriptor
+            ):
+                os.close(published_descriptor)
+            if temporary_descriptor is not None:
+                os.close(temporary_descriptor)
+
+
+def write_new_file(path: Path, content: bytes) -> None:
+    """Create a file exclusively relative to a no-follow directory descriptor."""
+    parent_descriptor = os.open(path.parent, _open_flags(directory=True))
+    try:
+        write_new_file_at(parent_descriptor, path.name, content)
+    finally:
+        os.close(parent_descriptor)
+
+
+def fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, _open_flags(directory=True))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/services/api/jobos_api/composition.py
+++ b/services/api/jobos_api/composition.py
@@ -10,15 +10,32 @@ from jobos_api.sqlite_job_repository import SQLiteJobRepository
 
 def create_job_services(settings: Settings) -> tuple[JobRepository, ArtifactGateway]:
     if settings.job_provider == "sqlite":
-        return (
-            SQLiteJobRepository(settings.resolved_jobs_db_path(), initialize=False),
-            UnavailableArtifactGateway(),
+        job_repository: JobRepository = SQLiteJobRepository(
+            settings.resolved_jobs_db_path(), initialize=False
         )
-    if settings.job_provider == "job-hunter":
+    elif settings.job_provider == "job-hunter":
         if settings.job_hunter_db_path is None:
             raise Unavailable("The JobHunter provider requires JOBOS_JOB_HUNTER_DB_PATH")
         module = import_module("jobos_api.private_adapters.job_hunter")
-        return module.create_job_hunter_services(
-            settings.job_hunter_db_path, settings.hermes_job_hunter_cwd
+        job_repository = module.create_job_hunter_job_repository(
+            settings.job_hunter_db_path,
+            settings.hermes_job_hunter_cwd,
         )
-    raise Unavailable(f"Unsupported job provider {settings.job_provider}")
+    else:
+        raise Unavailable(f"Unsupported job provider {settings.job_provider}")
+
+    if settings.artifact_provider == "local":
+        artifact_gateway: ArtifactGateway = UnavailableArtifactGateway()
+    elif settings.artifact_provider == "gateway":
+        if settings.job_hunter_db_path is None:
+            raise Unavailable(
+                "The JobHunter artifact gateway requires JOBOS_JOB_HUNTER_DB_PATH"
+            )
+        module = import_module("jobos_api.private_adapters.job_hunter")
+        artifact_gateway = module.create_job_hunter_artifact_gateway(
+            settings.job_hunter_db_path,
+            settings.hermes_job_hunter_cwd,
+        )
+    else:
+        raise Unavailable(f"Unsupported artifact provider {settings.artifact_provider}")
+    return job_repository, artifact_gateway

--- a/services/api/jobos_api/documents.py
+++ b/services/api/jobos_api/documents.py
@@ -11,15 +11,24 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from jobos_api.artifact_repository import (
+    ALLOWED_MEDIA_TYPES,
+    MAX_CALLER_FILENAME_BYTES,
+    PDF_MEDIA_TYPE,
+    ArtifactRepositoryError,
+    ArtifactStorageError,
+    ArtifactValidationError,
+    OpenedDirectoryChain,
+    materialize_idempotent_file,
+    materialize_idempotent_pair,
+    open_directory_chain,
+    verify_artifact_file,
+)
+
 ARTIFACT_ID_PATTERN = re.compile(r"^art_[A-Za-z0-9_-]{16,80}$")
-PDF_MEDIA_TYPE = "application/pdf"
-DOCX_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-ALLOWED_MEDIA_TYPES = {PDF_MEDIA_TYPE, DOCX_MEDIA_TYPE}
 DOCUMENT_KEYS = {"resume", "cover_letter", "references"}
 
-
-class ArtifactTrustError(ValueError):
-    """Artifact metadata or bytes failed the document trust boundary."""
+ArtifactTrustError = ArtifactValidationError
 
 
 class ArtifactNotFound(KeyError):
@@ -133,6 +142,9 @@ class ArtifactPublishRequest(BaseModel):
     def require_plain_filename(cls, value: str) -> str:
         if value in {".", ".."} or Path(value).name != value or "\0" in value:
             raise ValueError("document filenames must not contain a path")
+        safe_name = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip(".-") or "document"
+        if len(safe_name.encode("utf-8")) > MAX_CALLER_FILENAME_BYTES:
+            raise ValueError("document filename is too long for content-addressed storage")
         return value
 
     def source_bytes(self) -> bytes:
@@ -192,18 +204,17 @@ def materialize_published_document(
 ) -> tuple[Path, Path]:
     if not re.fullmatch(r"[A-Za-z0-9._-]{1,256}", job_id):
         raise ArtifactTrustError("Job ID is not safe for document publication")
-    root = workspace_root.expanduser().resolve(strict=True)
-    publication_root = (root / "resume" / "exports" / "jobos" / job_id / "imports").resolve()
-    if root not in publication_root.parents:
-        raise ArtifactTrustError("Document publication root escapes the Job Hunter workspace")
-    publication_root.mkdir(parents=True, exist_ok=True)
-    source = _materialize_content_addressed(
-        publication_root, command.source_filename, command.source_bytes()
-    )
-    artifact = _materialize_content_addressed(
-        publication_root, command.artifact_filename, command.artifact_bytes()
-    )
-    return source, artifact
+    with open_directory_chain(
+        workspace_root, "resume", "exports", "jobos", job_id, "imports"
+    ) as publication_root:
+        source, artifact = materialize_idempotent_pair(
+            publication_root,
+            (
+                _content_addressed_item(command.source_filename, command.source_bytes()),
+                _content_addressed_item(command.artifact_filename, command.artifact_bytes()),
+            ),
+        )
+        return source, artifact
 
 
 def materialize_external_import(
@@ -237,33 +248,32 @@ def materialize_external_import(
         separators=(",", ":"),
         sort_keys=True,
     ).encode("utf-8")
-    root = workspace_root.expanduser().resolve(strict=True)
-    publication_root = (root / "resume" / "exports" / "jobos" / job_id / "imports").resolve()
-    if root not in publication_root.parents:
-        raise ArtifactTrustError("Document publication root escapes the Job Hunter workspace")
-    publication_root.mkdir(parents=True, exist_ok=True)
-    manifest_path = _materialize_content_addressed(
-        publication_root, f"{document_id}-import-source.json", manifest
-    )
-    artifact_path = _materialize_content_addressed(publication_root, source_filename, source_bytes)
-    return manifest_path, artifact_path
+    with open_directory_chain(
+        workspace_root, "resume", "exports", "jobos", job_id, "imports"
+    ) as publication_root:
+        manifest_path, artifact_path = materialize_idempotent_pair(
+            publication_root,
+            (
+                _content_addressed_item(f"{document_id}-import-source.json", manifest),
+                _content_addressed_item(source_filename, source_bytes),
+            ),
+        )
+        return manifest_path, artifact_path
 
 
-def _materialize_content_addressed(root: Path, filename: str, content: bytes) -> Path:
+def _materialize_content_addressed(
+    root: OpenedDirectoryChain, filename: str, content: bytes
+) -> Path:
+    stored_name, stored_content = _content_addressed_item(filename, content)
+    return materialize_idempotent_file(root, stored_name, stored_content)
+
+
+def _content_addressed_item(filename: str, content: bytes) -> tuple[str, bytes]:
     digest = sha256(content).hexdigest()
     safe_name = re.sub(r"[^A-Za-z0-9._-]+", "-", filename).strip(".-") or "document"
-    destination = root / f"{digest[:20]}-{safe_name}"
-    try:
-        with destination.open("xb") as output:
-            output.write(content)
-    except FileExistsError:
-        if (
-            destination.is_symlink()
-            or not destination.is_file()
-            or destination.read_bytes() != content
-        ):
-            raise ArtifactTrustError("Published document destination is not trustworthy") from None
-    return destination.resolve(strict=True)
+    if len(safe_name.encode("utf-8")) > MAX_CALLER_FILENAME_BYTES:
+        raise ArtifactTrustError("Document filename is too long for content-addressed storage")
+    return f"{digest[:20]}-{safe_name}", content
 
 
 def read_source_artifact(
@@ -314,21 +324,21 @@ def read_source_artifact(
     supplied_hash = raw.get("sha256")
     if not isinstance(supplied_path, (str, Path)) or not isinstance(supplied_hash, str):
         raise ArtifactTrustError("Successful artifact metadata is incomplete")
-    candidate = Path(supplied_path).expanduser().resolve(strict=True)
-    allowed = any(candidate == root or root in candidate.parents for root in roots)
-    if not roots or not allowed:
-        raise ArtifactTrustError("Artifact resolves outside configured roots")
-    if not candidate.is_file():
-        raise ArtifactTrustError("Artifact is not a regular file")
-    content = candidate.read_bytes()
+    try:
+        candidate, content = verify_artifact_file(
+            Path(supplied_path),
+            roots=roots,
+            media_type=media_type,
+            expected_sha256=supplied_hash,
+        )
+    except ArtifactStorageError:
+        raise
+    except ArtifactRepositoryError as error:
+        message = str(error)
+        if message == "Artifact SHA-256 does not match":
+            message = "Artifact SHA-256 does not match registered metadata"
+        raise ArtifactTrustError(message) from error
     computed_hash = sha256(content).hexdigest()
-    if not re.fullmatch(r"[a-f0-9]{64}", supplied_hash) or computed_hash != supplied_hash:
-        raise ArtifactTrustError("Artifact SHA-256 does not match registered metadata")
-    if media_type == PDF_MEDIA_TYPE:
-        if candidate.suffix.casefold() != ".pdf" or not content.startswith(b"%PDF-"):
-            raise ArtifactTrustError("Artifact bytes do not match PDF metadata")
-    elif candidate.suffix.casefold() != ".docx" or not content.startswith(b"PK"):
-        raise ArtifactTrustError("Artifact bytes do not match DOCX metadata")
     return VerifiedArtifact(
         job_id=raw["job_id"],
         document_key=document_key,

--- a/services/api/jobos_api/initialize.py
+++ b/services/api/jobos_api/initialize.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from uuid import uuid4
 
+from jobos_api.job_repository import NotFound
 from jobos_api.local_config import (
     LocalConfigError,
     config_path,
@@ -19,7 +20,13 @@ from jobos_api.local_config import (
 )
 from jobos_api.sqlite_job_repository import SQLiteJobRepository
 from jobos_api.state_store import JobOsStateStore
-from jobos_api.synthetic_demo import reset_demo, seed_demo_once
+from jobos_api.synthetic_demo import (
+    DEMO_JOB_ID,
+    reset_demo,
+    reset_demo_document,
+    seed_demo_document_once,
+    seed_demo_once,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -166,8 +173,16 @@ def _initialize_jobos_locked(
     seeded_job_id: str | None = None
     if reset_demo_requested:
         seeded_job_id = reset_demo(repository, ledger_path, confirmed=reset_confirmed)
+        reset_demo_document(state_store)
     elif bool(config.get("demoEnabled", False)):
         seeded_job_id = seed_demo_once(repository, ledger_path)
+        try:
+            demo = repository.get_job(DEMO_JOB_ID)
+        except NotFound:
+            pass
+        else:
+            if demo.synthetic_demo:
+                seed_demo_document_once(state_store)
     if ledger_path.exists():
         os.chmod(ledger_path, 0o600)
     if seeded_job_id is not None:

--- a/services/api/jobos_api/local_artifact_repository.py
+++ b/services/api/jobos_api/local_artifact_repository.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import errno
+import os
+import stat
+from contextlib import suppress
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from uuid import uuid4
+
+from jobos_api.artifact_repository import (
+    DOCX_MEDIA_TYPE,
+    MAX_ARTIFACT_BYTES,
+    MAX_STORED_FILENAME_BYTES,
+    PDF_MEDIA_TYPE,
+    ArtifactStorageError,
+    ArtifactValidationError,
+    ArtifactWrite,
+    StoredArtifact,
+    fsync_directory,
+    read_open_file,
+    resolve_repository_root,
+    validate_artifact_bytes,
+    validate_plain_filename,
+    validate_safe_segment,
+    verify_artifact_file,
+    write_new_file_at,
+)
+
+
+@dataclass(slots=True)
+class _OpenedDirectory:
+    path: Path
+    descriptors: list[int]
+    segments: tuple[str, ...]
+
+    @property
+    def descriptor(self) -> int:
+        return self.descriptors[-1]
+
+
+class LocalArtifactRepository:
+    """Content-addressed bytes below one explicitly configured application-data root."""
+
+    def __init__(self, root: Path) -> None:
+        supplied = root.expanduser()
+        if supplied.is_symlink():
+            raise ArtifactStorageError("Artifact repository root must not be a symbolic link")
+        self._root = supplied.resolve(strict=False)
+        self._ensure_root()
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def _ensure_root(self) -> None:
+        self._root = resolve_repository_root(self._root, create=True)
+        fsync_directory(self._root.parent)
+
+    @staticmethod
+    def _directory_flags() -> int:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_DIRECTORY"):
+            flags |= os.O_DIRECTORY
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        return flags
+
+    @classmethod
+    def _open_directory(cls, name: str | Path, *, dir_fd: int | None = None) -> int:
+        return os.open(name, cls._directory_flags(), dir_fd=dir_fd)
+
+    @staticmethod
+    def _same_directory(first: os.stat_result, second: os.stat_result) -> bool:
+        return (
+            first.st_dev == second.st_dev
+            and first.st_ino == second.st_ino
+            and stat.S_ISDIR(first.st_mode)
+            and stat.S_ISDIR(second.st_mode)
+        )
+
+    @staticmethod
+    def _same_identity(first: os.stat_result, second: os.stat_result) -> bool:
+        return (
+            first.st_dev == second.st_dev
+            and first.st_ino == second.st_ino
+            and stat.S_IFMT(first.st_mode) == stat.S_IFMT(second.st_mode)
+        )
+
+    @staticmethod
+    def _close_descriptors(descriptors: list[int]) -> None:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+    def _assert_attached(self, directory: _OpenedDirectory) -> None:
+        """Require every retained descriptor to remain at its repository-relative name."""
+        try:
+            named_root = os.stat(self._root, follow_symlinks=False)
+            opened_root = os.fstat(directory.descriptors[0])
+            if not self._same_directory(named_root, opened_root):
+                raise ArtifactStorageError("Configured artifact root changed during storage")
+            for index, segment in enumerate(directory.segments):
+                named = os.stat(
+                    segment,
+                    dir_fd=directory.descriptors[index],
+                    follow_symlinks=False,
+                )
+                opened = os.fstat(directory.descriptors[index + 1])
+                if not self._same_directory(named, opened):
+                    raise ArtifactStorageError(
+                        "Artifact repository directory changed during storage"
+                    )
+        except OSError as error:
+            if error.errno in {errno.ELOOP, errno.ENOENT, errno.ENOTDIR}:
+                raise ArtifactStorageError(
+                    "Artifact repository directory changed during storage"
+                ) from error
+            raise
+
+    def _open_directory_chain(self, *segments: str) -> _OpenedDirectory:
+        self._ensure_root()
+        safe_segments = tuple(
+            validate_safe_segment(segment, "Artifact path segment") for segment in segments
+        )
+        expected_root = os.stat(self._root, follow_symlinks=False)
+        descriptors: list[int] = []
+        try:
+            root_descriptor = self._open_directory(self._root)
+            descriptors.append(root_descriptor)
+            if not self._same_directory(expected_root, os.fstat(root_descriptor)):
+                raise ArtifactStorageError("Configured artifact root changed during storage")
+            current = root_descriptor
+            for segment in safe_segments:
+                created = False
+                try:
+                    os.mkdir(segment, mode=0o700, dir_fd=current)
+                    created = True
+                except FileExistsError:
+                    pass
+                if created:
+                    os.fsync(current)
+                descriptor = self._open_directory(segment, dir_fd=current)
+                if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+                    os.close(descriptor)
+                    raise ArtifactStorageError("Artifact repository ancestor is not a directory")
+                descriptors.append(descriptor)
+                current = descriptor
+            opened = _OpenedDirectory(
+                path=self._root.joinpath(*safe_segments),
+                descriptors=descriptors,
+                segments=safe_segments,
+            )
+            self._assert_attached(opened)
+            return opened
+        except OSError as error:
+            self._close_descriptors(descriptors)
+            if error.errno in {errno.ELOOP, errno.ENOENT, errno.ENOTDIR}:
+                raise ArtifactStorageError(
+                    "Artifact repository path contains a symbolic link or missing component"
+                ) from error
+            raise
+        except BaseException:
+            self._close_descriptors(descriptors)
+            raise
+
+    def _directory(self, *segments: str) -> Path:
+        opened = self._open_directory_chain(*segments)
+        try:
+            return opened.path
+        finally:
+            self._close_descriptors(opened.descriptors)
+
+    @classmethod
+    def _clean_owned_temporary_directory(
+        cls,
+        parent_descriptor: int,
+        name: str,
+        descriptor: int,
+        identity: os.stat_result,
+        owned_files: dict[str, os.stat_result],
+    ) -> None:
+        """Clean only files and a directory owned by this publication call."""
+        for child, child_identity in owned_files.items():
+            try:
+                metadata = os.stat(child, dir_fd=descriptor, follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            if cls._same_identity(child_identity, metadata):
+                os.unlink(child, dir_fd=descriptor)
+        os.fsync(descriptor)
+        try:
+            named = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if not cls._same_directory(identity, named):
+            return
+        try:
+            os.rmdir(name, dir_fd=parent_descriptor)
+        except OSError as error:
+            if error.errno not in {errno.ENOTEMPTY, errno.EEXIST}:
+                raise
+        os.fsync(parent_descriptor)
+
+    @classmethod
+    def _clean_owned_file(
+        cls,
+        directory_descriptor: int,
+        filename: str,
+        identity: os.stat_result,
+    ) -> None:
+        try:
+            named = os.stat(
+                filename,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            return
+        if cls._same_identity(identity, named):
+            os.unlink(filename, dir_fd=directory_descriptor)
+            os.fsync(directory_descriptor)
+
+    @staticmethod
+    def _validated_write(artifact: ArtifactWrite) -> ArtifactWrite:
+        validate_plain_filename(artifact.filename, artifact.media_type)
+        validate_artifact_bytes(
+            artifact.content,
+            media_type=artifact.media_type,
+            expected_sha256=artifact.sha256,
+        )
+        return artifact
+
+    @staticmethod
+    def _stored(path: Path, artifact: ArtifactWrite) -> StoredArtifact:
+        return StoredArtifact(
+            canonical_path=path,
+            filename=artifact.filename,
+            media_type=artifact.media_type,
+            sha256=artifact.sha256,
+            size=len(artifact.content),
+        )
+
+    def _verify_in(self, directory: _OpenedDirectory, artifact: ArtifactWrite) -> StoredArtifact:
+        stored_name = f"{artifact.sha256[:20]}-{artifact.filename}"
+        validate_plain_filename(
+            stored_name,
+            artifact.media_type,
+            maximum_bytes=MAX_STORED_FILENAME_BYTES,
+        )
+        self._assert_attached(directory)
+        flags = os.O_RDONLY
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor: int | None = None
+        try:
+            descriptor = os.open(stored_name, flags, dir_fd=directory.descriptor)
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise ArtifactStorageError("Stored artifact is not a regular file")
+            content = read_open_file(descriptor, metadata, maximum=MAX_ARTIFACT_BYTES)
+            try:
+                validate_artifact_bytes(
+                    content,
+                    media_type=artifact.media_type,
+                    expected_sha256=artifact.sha256,
+                )
+            except ArtifactValidationError as error:
+                raise ArtifactStorageError(
+                    "Stored artifact failed integrity validation"
+                ) from error
+            if content != artifact.content:
+                raise ArtifactStorageError("Stored artifact content does not match")
+            named = os.stat(
+                stored_name,
+                dir_fd=directory.descriptor,
+                follow_symlinks=False,
+            )
+            if not self._same_identity(os.fstat(descriptor), named):
+                raise ArtifactStorageError("Stored artifact changed during storage")
+        except OSError as error:
+            if error.errno in {errno.ELOOP, errno.ENOENT, errno.ENOTDIR}:
+                raise ArtifactStorageError(
+                    "Stored artifact path contains a symbolic link or missing component"
+                ) from error
+            raise
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+        self._assert_attached(directory)
+        return self._stored(directory.path / stored_name, artifact)
+
+    def _store_in(
+        self,
+        directory: _OpenedDirectory,
+        artifact: ArtifactWrite,
+    ) -> tuple[StoredArtifact, os.stat_result | None]:
+        artifact = self._validated_write(artifact)
+        stored_name = f"{artifact.sha256[:20]}-{artifact.filename}"
+        self._assert_attached(directory)
+        created_identity: os.stat_result | None = None
+        with suppress(FileExistsError):
+            created_identity = write_new_file_at(
+                directory.descriptor, stored_name, artifact.content
+            )
+        try:
+            # A prior process may have created this content-addressed entry but died
+            # before syncing the directory. Re-sync on both creation and replay.
+            os.fsync(directory.descriptor)
+            self._assert_attached(directory)
+            stored = self._verify_in(directory, artifact)
+            return stored, created_identity
+        except BaseException:
+            if created_identity is not None:
+                self._clean_owned_file(
+                    directory.descriptor,
+                    stored_name,
+                    created_identity,
+                )
+            raise
+
+    def store_import(
+        self, *, job_id: str, document_id: str, artifact: ArtifactWrite
+    ) -> StoredArtifact:
+        directory = self._open_directory_chain("imports", job_id, document_id)
+        try:
+            stored, _ = self._store_in(directory, artifact)
+            return stored
+        finally:
+            self._close_descriptors(directory.descriptors)
+
+    def store_publication_pair(
+        self,
+        *,
+        job_id: str,
+        document_id: str,
+        document_revision: int,
+        docx: ArtifactWrite,
+        pdf: ArtifactWrite,
+    ) -> tuple[StoredArtifact, StoredArtifact]:
+        if document_revision < 1:
+            raise ArtifactValidationError("Document revision must be positive")
+        docx = self._validated_write(docx)
+        pdf = self._validated_write(pdf)
+        if docx.media_type != DOCX_MEDIA_TYPE or pdf.media_type != PDF_MEDIA_TYPE:
+            raise ArtifactValidationError("Publication requires one DOCX and one PDF")
+
+        parent = self._open_directory_chain("publications", job_id, document_id)
+        pair_digest = sha256(
+            f"{document_revision}\0{docx.sha256}\0{pdf.sha256}".encode("ascii")
+        ).hexdigest()
+        destination_name = f"revision-{document_revision}-{pair_digest[:20]}"
+        destination_path = parent.path / destination_name
+        temporary_name = f".publication-{uuid4().hex}.tmp"
+        temporary_descriptor: int | None = None
+        temporary_identity: os.stat_result | None = None
+        published_descriptor: int | None = None
+        owned_files: dict[str, os.stat_result] = {}
+        renamed = False
+        completed = False
+        preserve_renamed_for_replay = False
+        try:
+            self._assert_attached(parent)
+            os.mkdir(temporary_name, mode=0o700, dir_fd=parent.descriptor)
+            temporary_descriptor = self._open_directory(
+                temporary_name, dir_fd=parent.descriptor
+            )
+            temporary_identity = os.fstat(temporary_descriptor)
+            os.fsync(parent.descriptor)
+            temporary = _OpenedDirectory(
+                path=parent.path / temporary_name,
+                descriptors=[*parent.descriptors, temporary_descriptor],
+                segments=(*parent.segments, temporary_name),
+            )
+            _, docx_identity = self._store_in(temporary, docx)
+            if docx_identity is not None:
+                docx_name = f"{docx.sha256[:20]}-{docx.filename}"
+                owned_files[docx_name] = docx_identity
+            _, pdf_identity = self._store_in(temporary, pdf)
+            if pdf_identity is not None:
+                pdf_name = f"{pdf.sha256[:20]}-{pdf.filename}"
+                owned_files[pdf_name] = pdf_identity
+            os.fsync(temporary_descriptor)
+            self._assert_attached(temporary)
+            try:
+                os.rename(
+                    temporary_name,
+                    destination_name,
+                    src_dir_fd=parent.descriptor,
+                    dst_dir_fd=parent.descriptor,
+                )
+            except OSError as error:
+                try:
+                    published_descriptor = self._open_directory(
+                        destination_name, dir_fd=parent.descriptor
+                    )
+                except OSError:
+                    raise error from None
+                try:
+                    os.fsync(parent.descriptor)
+                except OSError as fsync_error:
+                    raise ArtifactStorageError(
+                        "Could not synchronize published artifact directory"
+                    ) from fsync_error
+            else:
+                renamed = True
+                published_descriptor = temporary_descriptor
+                try:
+                    os.fsync(parent.descriptor)
+                except OSError as error:
+                    preserve_renamed_for_replay = True
+                    raise ArtifactStorageError(
+                        "Could not synchronize published artifact directory"
+                    ) from error
+
+            published = _OpenedDirectory(
+                path=destination_path,
+                descriptors=[*parent.descriptors, published_descriptor],
+                segments=(*parent.segments, destination_name),
+            )
+            self._assert_attached(published)
+            stored_docx = self._verify_in(published, docx)
+            stored_pdf = self._verify_in(published, pdf)
+            completed = True
+            return stored_docx, stored_pdf
+        finally:
+            try:
+                if (
+                    temporary_descriptor is not None
+                    and temporary_identity is not None
+                    and (
+                        not renamed
+                        or (not completed and not preserve_renamed_for_replay)
+                    )
+                ):
+                    self._clean_owned_temporary_directory(
+                        parent.descriptor,
+                        destination_name if renamed else temporary_name,
+                        temporary_descriptor,
+                        temporary_identity,
+                        owned_files,
+                    )
+            finally:
+                if (
+                    published_descriptor is not None
+                    and published_descriptor != temporary_descriptor
+                ):
+                    os.close(published_descriptor)
+                if temporary_descriptor is not None:
+                    os.close(temporary_descriptor)
+                self._close_descriptors(parent.descriptors)
+
+    def read(self, *, path: Path, media_type: str, expected_sha256: str) -> bytes:
+        _, content = verify_artifact_file(
+            path,
+            roots=(self._root,),
+            media_type=media_type,
+            expected_sha256=expected_sha256,
+        )
+        return content

--- a/services/api/jobos_api/local_config.py
+++ b/services/api/jobos_api/local_config.py
@@ -129,13 +129,19 @@ def settings_from_config(path: Path) -> Settings:
     if not isinstance(paths, dict):
         raise LocalConfigError("JobOS path configuration is invalid.")
     device_token, mcp_token = load_credentials(config, data_dir)
+    artifact_provider = config.get("artifactProvider", "local")
+    if artifact_provider not in {"local", "gateway"}:
+        raise LocalConfigError("JobOS artifact provider is unsupported.")
+    artifact_root = _resolved(data_dir, paths.get("artifacts"), "paths.artifacts")
     return Settings(
         device_token=device_token,
         mcp_token=mcp_token,
         device_id=str(config["deviceId"]),
         state_db_path=_resolved(data_dir, paths.get("stateDatabase"), "paths.stateDatabase"),
         jobs_db_path=_resolved(data_dir, paths.get("jobsDatabase"), "paths.jobsDatabase"),
-        artifact_roots=(_resolved(data_dir, paths.get("artifacts"), "paths.artifacts"),),
+        artifact_provider=artifact_provider,
+        local_artifact_root=artifact_root,
+        artifact_roots=(artifact_root,),
         job_provider=str(config.get("jobProvider", "sqlite")),
     )
 

--- a/services/api/jobos_api/macos_runtime.py
+++ b/services/api/jobos_api/macos_runtime.py
@@ -217,6 +217,7 @@ def build_service_environment(
         "JOBOS_DEVICE_ID": config.device_id,
         "JOBOS_STATE_DB_PATH": str(config.state_db_path),
         "JOBOS_JOB_PROVIDER": "job-hunter",
+        "JOBOS_ARTIFACT_PROVIDER": "gateway",
         "JOBOS_JOB_HUNTER_DB_PATH": str(config.job_hunter_db_path),
         "JOBOS_ARTIFACT_ROOTS": os.pathsep.join(map(str, config.artifact_roots)),
     }

--- a/services/api/jobos_api/main.py
+++ b/services/api/jobos_api/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from jobos_api.app import create_app
+from jobos_api.artifact_repository import ArtifactStorageError
 from jobos_api.local_config import (
     LocalConfigError,
     config_path,
@@ -26,7 +27,10 @@ def settings_from_environment() -> Settings:
         raise LocalConfigError(
             "JOBOS_DEVICE_TOKEN and JOBOS_MCP_TOKEN must be configured together."
         )
-    state_db_path = Path(os.environ.get("JOBOS_STATE_DB_PATH", "data/jobos.db"))
+    application_data = default_data_dir()
+    state_db_path = Path(
+        os.environ.get("JOBOS_STATE_DB_PATH", application_data / "state/jobos.db")
+    )
     jobs_db = os.environ.get("JOBOS_JOBS_DB_PATH")
     job_hunter_db = os.environ.get("JOBOS_JOB_HUNTER_DB_PATH")
     artifact_roots = tuple(
@@ -34,6 +38,7 @@ def settings_from_environment() -> Settings:
         for value in os.environ.get("JOBOS_ARTIFACT_ROOTS", "").split(os.pathsep)
         if value
     )
+    local_artifact_root = os.environ.get("JOBOS_LOCAL_ARTIFACT_ROOT")
     hermes_url = os.environ.get("JOBOS_HERMES_DASHBOARD_URL")
     hermes_token = os.environ.get("JOBOS_HERMES_DASHBOARD_TOKEN")
     hermes_cwd = os.environ.get("JOBOS_HERMES_JOB_HUNTER_CWD")
@@ -46,8 +51,12 @@ def settings_from_environment() -> Settings:
         ),
         state_db_path=state_db_path,
         job_provider=os.environ.get("JOBOS_JOB_PROVIDER", "sqlite"),
-        jobs_db_path=Path(jobs_db) if jobs_db else None,
+        jobs_db_path=Path(jobs_db) if jobs_db else application_data / "jobs/jobs.db",
         job_hunter_db_path=Path(job_hunter_db) if job_hunter_db else None,
+        artifact_provider=os.environ.get("JOBOS_ARTIFACT_PROVIDER", "local"),
+        local_artifact_root=(
+            Path(local_artifact_root) if local_artifact_root else application_data / "artifacts"
+        ),
         artifact_roots=artifact_roots,
         hermes_dashboard_url=hermes_url,
         hermes_dashboard_token=hermes_token,
@@ -76,5 +85,5 @@ def _configuration_error_app(error: Exception) -> FastAPI:
 
 try:
     app = create_application()
-except (LocalConfigError, OSError, ValueError) as error:
+except (ArtifactStorageError, LocalConfigError, OSError, ValueError) as error:
     app = _configuration_error_app(error)

--- a/services/api/jobos_api/private_adapters/job_hunter.py
+++ b/services/api/jobos_api/private_adapters/job_hunter.py
@@ -299,19 +299,44 @@ def adapt_job_hunter_facade(facade: Any) -> tuple[JobHunterJobRepository, Artifa
     return JobHunterJobRepository(facade), JobHunterArtifactGateway(facade)
 
 
+def _create_job_hunter_facade(database_path: Path, workspace_root: Path | None) -> tuple[Any, Any]:
+    facade_module = import_module("job_hunter.facade")
+    storage_module = import_module("job_hunter.storage")
+    storage = storage_module.JobStorage(database_path, initialize=False)
+    return facade_module.JobHunterFacade(storage, workspace_root=workspace_root), storage
+
+
 def create_job_hunter_services(
     database_path: Path, workspace_root: Path | None
 ) -> tuple[JobHunterJobRepository, ArtifactGateway]:
     """Dynamically load JobHunter only after private provider selection."""
     try:
-        facade_module = import_module("job_hunter.facade")
         models_module = import_module("job_hunter.models")
-        storage_module = import_module("job_hunter.storage")
-        storage = storage_module.JobStorage(database_path, initialize=False)
-        facade = facade_module.JobHunterFacade(storage, workspace_root=workspace_root)
+        facade, storage = _create_job_hunter_facade(database_path, workspace_root)
     except Exception as error:
         raise Unavailable("The selected JobHunter provider is unavailable") from error
     return (
         JobHunterJobRepository(facade, storage, models_module.JobRecord),
         JobHunterArtifactGateway(facade),
     )
+
+
+def create_job_hunter_job_repository(
+    database_path: Path, workspace_root: Path | None
+) -> JobHunterJobRepository:
+    try:
+        models_module = import_module("job_hunter.models")
+        facade, storage = _create_job_hunter_facade(database_path, workspace_root)
+    except Exception as error:
+        raise Unavailable("The selected JobHunter provider is unavailable") from error
+    return JobHunterJobRepository(facade, storage, models_module.JobRecord)
+
+
+def create_job_hunter_artifact_gateway(
+    database_path: Path, workspace_root: Path | None
+) -> ArtifactGateway:
+    try:
+        facade, _ = _create_job_hunter_facade(database_path, workspace_root)
+    except Exception as error:
+        raise Unavailable("The selected JobHunter artifact gateway is unavailable") from error
+    return JobHunterArtifactGateway(facade)

--- a/services/api/jobos_api/settings.py
+++ b/services/api/jobos_api/settings.py
@@ -47,6 +47,8 @@ class Settings(BaseModel):
     job_provider: Literal["sqlite", "job-hunter"] = "sqlite"
     jobs_db_path: Path | None = None
     job_hunter_db_path: Path | None = None
+    artifact_provider: Literal["local", "gateway"] = "local"
+    local_artifact_root: Path | None = None
     artifact_roots: tuple[Path, ...] = ()
     hermes_dashboard_url: str | None = None
     hermes_dashboard_token: str | None = Field(default=None, min_length=16, repr=False)
@@ -75,3 +77,10 @@ class Settings(BaseModel):
 
     def resolved_jobs_db_path(self) -> Path:
         return self.jobs_db_path or self.state_db_path.parent / "jobs.db"
+
+    def resolved_local_artifact_root(self) -> Path:
+        return self.local_artifact_root or self.state_db_path.parent / "artifacts"
+
+    def resolved_artifact_roots(self) -> tuple[Path, ...]:
+        roots = (self.resolved_local_artifact_root(), *self.artifact_roots)
+        return tuple(dict.fromkeys(roots))

--- a/services/api/jobos_api/state_store.py
+++ b/services/api/jobos_api/state_store.py
@@ -44,6 +44,10 @@ class EditableDocumentConflict(RuntimeError):
         super().__init__("Editable document revision conflict")
 
 
+class EditablePublicationConflict(RuntimeError):
+    """An editable revision was already registered with a different artifact pair."""
+
+
 def mutation_activity_source_id(
     *, actor_id: str, target_resource: str, command_name: str, idempotency_key: str
 ) -> str:
@@ -405,6 +409,274 @@ MIGRATIONS = (
             "DROP TABLE document_file_observations_v13",
         ),
     ),
+    Migration(
+        version=15,
+        statements=(
+            """
+            CREATE TEMP TABLE migration15_affected_publications AS
+            SELECT editable_document_id, editable_document_revision
+            FROM document_artifacts
+            WHERE editable_document_id IS NOT NULL
+                AND editable_document_revision IS NOT NULL
+            GROUP BY editable_document_id, editable_document_revision
+            """,
+            """
+            CREATE TEMP TABLE migration15_winning_pairs AS
+            WITH candidate_pairs AS (
+                SELECT
+                    docx.editable_document_id,
+                    docx.editable_document_revision,
+                    owner.job_id,
+                    docx.artifact_id AS docx_artifact_id,
+                    pdf.artifact_id AS pdf_artifact_id,
+                    (state.approved_artifact_id IN (
+                        docx.artifact_id, pdf.artifact_id
+                    )) AS is_approved,
+                    (state.current_artifact_id IN (
+                        docx.artifact_id, pdf.artifact_id
+                    )) AS is_current,
+                    (state.last_successful_artifact_id IN (
+                        docx.artifact_id, pdf.artifact_id
+                    )) AS is_last_successful,
+                    pdf.render_sequence AS newest_sequence
+                FROM document_artifacts AS docx
+                JOIN document_artifacts AS pdf
+                    ON pdf.editable_document_id = docx.editable_document_id
+                    AND pdf.editable_document_revision =
+                        docx.editable_document_revision
+                    AND pdf.job_id = docx.job_id
+                    AND pdf.source_revision = docx.source_revision
+                    AND pdf.render_sequence = docx.render_sequence + 1
+                JOIN editable_documents AS owner
+                    ON owner.document_id = docx.editable_document_id
+                    AND docx.job_id = owner.job_id
+                    AND pdf.job_id = owner.job_id
+                    AND docx.document_key = owner.document_key
+                    AND pdf.document_key = owner.document_key
+                JOIN migration15_affected_publications AS affected
+                    ON affected.editable_document_id = docx.editable_document_id
+                    AND affected.editable_document_revision =
+                        docx.editable_document_revision
+                LEFT JOIN job_document_state AS state ON state.job_id = docx.job_id
+                WHERE docx.render_status = 'succeeded'
+                    AND pdf.render_status = 'succeeded'
+                    AND docx.media_type =
+                        'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                    AND pdf.media_type = 'application/pdf'
+            ), ranked AS (
+                SELECT *, ROW_NUMBER() OVER (
+                    PARTITION BY editable_document_id, editable_document_revision
+                    ORDER BY
+                        is_approved DESC,
+                        is_current DESC,
+                        is_last_successful DESC,
+                        newest_sequence DESC,
+                        pdf_artifact_id DESC,
+                        docx_artifact_id DESC
+                ) AS pair_rank
+                FROM candidate_pairs
+            )
+            SELECT
+                editable_document_id,
+                editable_document_revision,
+                job_id,
+                docx_artifact_id,
+                pdf_artifact_id
+            FROM ranked
+            WHERE pair_rank = 1
+            """,
+            """
+            CREATE TEMP TABLE migration15_winning_artifacts AS
+            SELECT
+                editable_document_id,
+                editable_document_revision,
+                job_id,
+                docx_artifact_id AS artifact_id,
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                    AS media_type
+            FROM migration15_winning_pairs
+            UNION ALL
+            SELECT
+                editable_document_id,
+                editable_document_revision,
+                job_id,
+                pdf_artifact_id AS artifact_id,
+                'application/pdf' AS media_type
+            FROM migration15_winning_pairs
+            """,
+            """
+            UPDATE job_document_state
+            SET current_artifact_id = COALESCE(
+                (
+                    SELECT winner.artifact_id
+                    FROM document_artifacts AS losing
+                    JOIN migration15_winning_artifacts AS winner
+                        ON winner.editable_document_id = losing.editable_document_id
+                        AND winner.editable_document_revision =
+                            losing.editable_document_revision
+                        AND winner.media_type = losing.media_type
+                    JOIN editable_documents AS owner
+                        ON owner.document_id = losing.editable_document_id
+                    WHERE losing.artifact_id = job_document_state.current_artifact_id
+                        AND losing.job_id = owner.job_id
+                        AND winner.job_id = owner.job_id
+                        AND job_document_state.job_id = owner.job_id
+                ),
+                CASE
+                    WHEN current_artifact_id IN (
+                        SELECT artifact.artifact_id
+                        FROM document_artifacts AS artifact
+                        JOIN migration15_affected_publications AS affected
+                            ON affected.editable_document_id = artifact.editable_document_id
+                            AND affected.editable_document_revision =
+                                artifact.editable_document_revision
+                    ) THEN NULL
+                    ELSE current_artifact_id
+                END
+            ),
+            last_successful_artifact_id = COALESCE(
+                (
+                    SELECT winner.artifact_id
+                    FROM document_artifacts AS losing
+                    JOIN migration15_winning_artifacts AS winner
+                        ON winner.editable_document_id = losing.editable_document_id
+                        AND winner.editable_document_revision =
+                            losing.editable_document_revision
+                        AND winner.media_type = losing.media_type
+                    JOIN editable_documents AS owner
+                        ON owner.document_id = losing.editable_document_id
+                    WHERE losing.artifact_id =
+                        job_document_state.last_successful_artifact_id
+                        AND losing.job_id = owner.job_id
+                        AND winner.job_id = owner.job_id
+                        AND job_document_state.job_id = owner.job_id
+                ),
+                CASE
+                    WHEN last_successful_artifact_id IN (
+                        SELECT artifact.artifact_id
+                        FROM document_artifacts AS artifact
+                        JOIN migration15_affected_publications AS affected
+                            ON affected.editable_document_id = artifact.editable_document_id
+                            AND affected.editable_document_revision =
+                                artifact.editable_document_revision
+                    ) THEN NULL
+                    ELSE last_successful_artifact_id
+                END
+            ),
+            approved_artifact_id = CASE
+                WHEN approved_artifact_id IN (
+                    SELECT artifact.artifact_id
+                    FROM document_artifacts AS artifact
+                    JOIN migration15_affected_publications AS affected
+                        ON affected.editable_document_id = artifact.editable_document_id
+                        AND affected.editable_document_revision =
+                            artifact.editable_document_revision
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM migration15_winning_artifacts AS winner
+                        JOIN editable_documents AS owner
+                            ON owner.document_id = winner.editable_document_id
+                        WHERE winner.artifact_id = artifact.artifact_id
+                            AND winner.job_id = owner.job_id
+                            AND job_document_state.job_id = owner.job_id
+                    )
+                ) THEN NULL
+                ELSE approved_artifact_id
+            END,
+            approved_at = CASE
+                WHEN approved_artifact_id IN (
+                    SELECT artifact.artifact_id
+                    FROM document_artifacts AS artifact
+                    JOIN migration15_affected_publications AS affected
+                        ON affected.editable_document_id = artifact.editable_document_id
+                        AND affected.editable_document_revision =
+                            artifact.editable_document_revision
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM migration15_winning_artifacts AS winner
+                        JOIN editable_documents AS owner
+                            ON owner.document_id = winner.editable_document_id
+                        WHERE winner.artifact_id = artifact.artifact_id
+                            AND winner.job_id = owner.job_id
+                            AND job_document_state.job_id = owner.job_id
+                    )
+                ) THEN NULL
+                ELSE approved_at
+            END,
+            updated_at = CURRENT_TIMESTAMP
+            WHERE current_artifact_id IN (
+                    SELECT artifact.artifact_id
+                    FROM document_artifacts AS artifact
+                    JOIN migration15_affected_publications AS affected
+                        ON affected.editable_document_id = artifact.editable_document_id
+                        AND affected.editable_document_revision =
+                            artifact.editable_document_revision
+                )
+                OR last_successful_artifact_id IN (
+                    SELECT artifact.artifact_id
+                    FROM document_artifacts AS artifact
+                    JOIN migration15_affected_publications AS affected
+                        ON affected.editable_document_id = artifact.editable_document_id
+                        AND affected.editable_document_revision =
+                            artifact.editable_document_revision
+                )
+                OR approved_artifact_id IN (
+                    SELECT artifact.artifact_id
+                    FROM document_artifacts AS artifact
+                    JOIN migration15_affected_publications AS affected
+                        ON affected.editable_document_id = artifact.editable_document_id
+                        AND affected.editable_document_revision =
+                            artifact.editable_document_revision
+                )
+            """,
+            """
+            UPDATE editable_documents
+            SET published_revision = NULL,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE EXISTS (
+                SELECT 1
+                FROM migration15_affected_publications AS affected
+                WHERE affected.editable_document_id = editable_documents.document_id
+                    AND affected.editable_document_revision =
+                        editable_documents.published_revision
+            ) AND NOT EXISTS (
+                SELECT 1
+                FROM migration15_winning_artifacts AS winner
+                WHERE winner.editable_document_id = editable_documents.document_id
+                    AND winner.editable_document_revision =
+                        editable_documents.published_revision
+            )
+            """,
+            """
+            UPDATE document_artifacts
+            SET editable_document_id = NULL,
+                editable_document_revision = NULL
+            WHERE EXISTS (
+                    SELECT 1
+                    FROM migration15_affected_publications AS affected
+                    WHERE affected.editable_document_id =
+                        document_artifacts.editable_document_id
+                        AND affected.editable_document_revision =
+                            document_artifacts.editable_document_revision
+                )
+                AND artifact_id NOT IN (
+                    SELECT artifact_id FROM migration15_winning_artifacts
+                )
+            """,
+            """
+            CREATE UNIQUE INDEX document_artifacts_editable_publication_media
+            ON document_artifacts(
+                editable_document_id, editable_document_revision, media_type
+            )
+            WHERE editable_document_id IS NOT NULL
+                AND editable_document_revision IS NOT NULL
+                AND render_status = 'succeeded'
+            """,
+            "DROP TABLE migration15_winning_artifacts",
+            "DROP TABLE migration15_winning_pairs",
+            "DROP TABLE migration15_affected_publications",
+        ),
+    ),
 )
 SCHEMA_VERSION = MIGRATIONS[-1].version
 
@@ -685,10 +957,16 @@ class JobOsStateStore:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         with sqlite3.connect(self._path) as connection:
             self._ensure_migration_ledger(connection)
-            applied = self._applied_versions(connection)
-            self._assert_compatible(applied)
-            for migration in MIGRATIONS[len(applied) :]:
-                self._apply_migration(connection, migration)
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                applied = self._applied_versions(connection)
+                self._assert_compatible(applied)
+                for migration in MIGRATIONS[len(applied) :]:
+                    self._apply_migration_statements(connection, migration)
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
         return StateHealth(schema_version=SCHEMA_VERSION)
 
     @staticmethod
@@ -728,16 +1006,22 @@ class JobOsStateStore:
     def _apply_migration(connection: sqlite3.Connection, migration: Migration) -> None:
         try:
             connection.execute("BEGIN IMMEDIATE")
-            for statement in migration.statements:
-                connection.execute(statement)
-            connection.execute(
-                "INSERT INTO schema_migrations(version) VALUES (?)",
-                (migration.version,),
-            )
+            JobOsStateStore._apply_migration_statements(connection, migration)
             connection.commit()
         except Exception:
             connection.rollback()
             raise
+
+    @staticmethod
+    def _apply_migration_statements(
+        connection: sqlite3.Connection, migration: Migration
+    ) -> None:
+        for statement in migration.statements:
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO schema_migrations(version) VALUES (?)",
+            (migration.version,),
+        )
 
     def health(self) -> StateHealth:
         with sqlite3.connect(f"file:{self._path}?mode=ro", uri=True) as connection:
@@ -1537,13 +1821,13 @@ class JobOsStateStore:
         *,
         editable_document_id: str | None = None,
         editable_document_revision: int | None = None,
+        connection: sqlite3.Connection | None = None,
     ) -> tuple[str | None, str | None]:
         if (editable_document_id is None) != (editable_document_revision is None):
             raise ValueError("Editable document ID and revision must be supplied together")
         if any(artifact.job_id != job_id for artifact in artifacts):
             raise ValueError("Artifact job association does not match the requested job")
-        with sqlite3.connect(self._path) as connection:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._editable_write_connection(connection) as connection:
             state = connection.execute(
                 "SELECT current_artifact_id, last_successful_artifact_id "
                 "FROM job_document_state WHERE job_id = ?",
@@ -1643,7 +1927,6 @@ class JobOsStateStore:
                     """,
                     (job_id, current_id, last_successful_id),
                 )
-            connection.commit()
         return current_id, last_successful_id
 
     def list_document_artifacts(
@@ -1666,6 +1949,117 @@ class JobOsStateStore:
             state["last_successful_artifact_id"] if state else None,
             state["approved_artifact_id"] if state else None,
         )
+
+    def next_document_artifact_sequence(
+        self, job_id: str, *, connection: sqlite3.Connection | None = None
+    ) -> int:
+        if connection is not None:
+            row = connection.execute(
+                "SELECT COALESCE(MAX(render_sequence), 0) FROM document_artifacts WHERE job_id = ?",
+                (job_id,),
+            ).fetchone()
+        else:
+            with sqlite3.connect(f"file:{self._path}?mode=ro", uri=True) as read_connection:
+                row = read_connection.execute(
+                    "SELECT COALESCE(MAX(render_sequence), 0) "
+                    "FROM document_artifacts WHERE job_id = ?",
+                    (job_id,),
+                ).fetchone()
+        return int(row[0]) + 1 if row else 1
+
+    def editable_publication_artifacts(
+        self,
+        document_id: str,
+        document_revision: int,
+        *,
+        connection: sqlite3.Connection | None = None,
+    ) -> list[dict[str, object]]:
+        if connection is not None:
+            rows = connection.execute(
+                """
+                SELECT * FROM document_artifacts
+                WHERE editable_document_id = ? AND editable_document_revision = ?
+                    AND render_status = 'succeeded'
+                ORDER BY render_sequence
+                """,
+                (document_id, document_revision),
+            ).fetchall()
+        else:
+            with sqlite3.connect(f"file:{self._path}?mode=ro", uri=True) as read_connection:
+                read_connection.row_factory = sqlite3.Row
+                rows = read_connection.execute(
+                    """
+                    SELECT * FROM document_artifacts
+                    WHERE editable_document_id = ? AND editable_document_revision = ?
+                        AND render_status = 'succeeded'
+                    ORDER BY render_sequence
+                    """,
+                    (document_id, document_revision),
+                ).fetchall()
+        return [dict(row) for row in rows]
+
+    def register_editable_publication_pair(
+        self,
+        job_id: str,
+        artifacts: list[VerifiedArtifact],
+        *,
+        editable_document_id: str,
+        editable_document_revision: int,
+        connection: sqlite3.Connection,
+    ) -> bool:
+        expected = {artifact.media_type: artifact.sha256 for artifact in artifacts}
+        required = {
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/pdf",
+        }
+        if (
+            len(artifacts) != 2
+            or set(expected) != required
+            or any(artifact.render_status != "succeeded" for artifact in artifacts)
+        ):
+            raise ValueError("Publication requires one successful DOCX and one successful PDF")
+        prior = self.editable_publication_artifacts(
+            editable_document_id,
+            editable_document_revision,
+            connection=connection,
+        )
+        if prior:
+            registered = {str(row["media_type"]): str(row["sha256"]) for row in prior}
+            if len(prior) != 2 or registered != expected:
+                raise EditablePublicationConflict(
+                    "Editable revision already has a different local publication"
+                )
+            return False
+        try:
+            self.register_document_artifacts(
+                job_id,
+                artifacts,
+                editable_document_id=editable_document_id,
+                editable_document_revision=editable_document_revision,
+                connection=connection,
+            )
+        except sqlite3.IntegrityError as error:
+            raise EditablePublicationConflict(
+                "Editable revision already has a different local publication"
+            ) from error
+        return True
+
+    def delete_job_documents(self, job_id: str) -> None:
+        """Remove demo-owned document metadata; artifact bytes remain unregistered on disk."""
+        with sqlite3.connect(self._path) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute("DELETE FROM job_document_state WHERE job_id = ?", (job_id,))
+            connection.execute("DELETE FROM document_artifacts WHERE job_id = ?", (job_id,))
+            connection.execute(
+                """
+                DELETE FROM editable_document_snapshots
+                WHERE document_id IN (
+                    SELECT document_id FROM editable_documents WHERE job_id = ?
+                )
+                """,
+                (job_id,),
+            )
+            connection.execute("DELETE FROM editable_documents WHERE job_id = ?", (job_id,))
 
     def approve_document_artifact(self, job_id: str, artifact_id: str) -> None:
         with sqlite3.connect(self._path) as connection:

--- a/services/api/jobos_api/synthetic_demo.py
+++ b/services/api/jobos_api/synthetic_demo.py
@@ -8,6 +8,12 @@ from pathlib import Path
 from typing import TypedDict, cast
 from urllib.parse import urlsplit, urlunsplit
 
+from jobos_api.editable_documents import (
+    DocumentSettings,
+    blank_content,
+    default_settings,
+    validate_content,
+)
 from jobos_api.job_repository import (
     Conflict,
     CreateJobCommand,
@@ -15,6 +21,7 @@ from jobos_api.job_repository import (
     JobRepository,
     NotFound,
 )
+from jobos_api.state_store import JobOsStateStore
 
 
 class DemoFixture(TypedDict):
@@ -55,6 +62,48 @@ def _fixture_sha256(value: DemoFixture) -> str:
 
 
 DEMO_FIXTURE_SHA256 = _fixture_sha256(DEMO_FIXTURE)
+DEMO_DOCUMENT_KEY = "resume"
+
+
+def _starter_document_content() -> dict[str, object]:
+    content = blank_content(DEMO_DOCUMENT_KEY)
+    lines = (
+        "(FAKE) FICTIONAL JOBOS DEMO CANDIDATE — DO NOT APPLY",
+        "(FAKE) Synthetic resume for learning JobOS. This is not a real person or application.",
+        "(FAKE) Imaginary Kite Systems Workshop — demonstration experience only.",
+        "(FAKE) Example Learning Lab — fictional credential; do not verify or submit.",
+        "(FAKE) Demo editing, synthetic kite telemetry, and clearly fictional examples.",
+    )
+    sections = content["content"]
+    assert isinstance(sections, list)
+    for section, line in zip(sections, lines, strict=True):
+        paragraph = section["content"][0]
+        paragraph["content"] = [{"type": "text", "text": line}]
+    validate_content(content, DocumentSettings.model_validate(default_settings()), [])
+    return content
+
+
+def seed_demo_document_once(state_store: JobOsStateStore) -> str | None:
+    existing = state_store.get_job_editable_document(DEMO_JOB_ID, DEMO_DOCUMENT_KEY)
+    if existing is not None:
+        return None
+    row = state_store.create_editable_document(
+        job_id=DEMO_JOB_ID,
+        document_key=DEMO_DOCUMENT_KEY,
+        document_label="Resume",
+        content=_starter_document_content(),
+        settings=default_settings(),
+        comments=[],
+        import_report={"source_filename": None, "imported_at": None, "issues": []},
+    )
+    return str(row["document_id"])
+
+
+def reset_demo_document(state_store: JobOsStateStore) -> str:
+    state_store.delete_job_documents(DEMO_JOB_ID)
+    document_id = seed_demo_document_once(state_store)
+    assert document_id is not None
+    return document_id
 
 
 def _command(fixture_path: Path | None = None) -> CreateJobCommand:

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from io import BytesIO
+from xml.sax.saxutils import escape
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import pytest
+
+
+def build_minimal_docx(text: str = "Synthetic JobOS document") -> bytes:
+    output = BytesIO()
+    with ZipFile(output, "w", compression=ZIP_DEFLATED) as archive:
+        archive.writestr(
+            "[Content_Types].xml",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Override PartName="/word/document.xml"
+    ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>""",
+        )
+        archive.writestr(
+            "_rels/.rels",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+    Target="word/document.xml"/>
+</Relationships>""",
+        )
+        archive.writestr(
+            "word/document.xml",
+            f"""<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p><w:r><w:t>{escape(text)}</w:t></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440"
+      w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/></w:sectPr>
+  </w:body>
+</w:document>""",
+        )
+    return output.getvalue()
+
+
+def build_minimal_pdf(text: str = "(FAKE) Synthetic JobOS PDF") -> bytes:
+    safe_text = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    stream = f"BT /F1 12 Tf 72 720 Td ({safe_text}) Tj ET\n".encode("latin-1")
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+        ),
+        b"<< /Length %d >>\nstream\n" % len(stream) + stream + b"endstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+    output = bytearray(b"%PDF-1.7\n%\xe2\xe3\xcf\xd3\n")
+    offsets = [0]
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(output))
+        output.extend(f"{number} 0 obj\n".encode("ascii"))
+        output.extend(body)
+        output.extend(b"\nendobj\n")
+    xref_offset = len(output)
+    output.extend(f"xref\n0 {len(offsets)}\n".encode("ascii"))
+    output.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        output.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
+    output.extend(
+        f"trailer\n<< /Size {len(offsets)} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n".encode("ascii")
+    )
+    return bytes(output)
+
+
+@pytest.fixture
+def minimal_docx():
+    return build_minimal_docx
+
+
+@pytest.fixture
+def minimal_pdf():
+    return build_minimal_pdf

--- a/services/api/tests/test_document_materialization.py
+++ b/services/api/tests/test_document_materialization.py
@@ -1,0 +1,202 @@
+import base64
+import os
+from hashlib import sha256
+
+import jobos_api.artifact_repository as artifact_repository_module
+import pytest
+from jobos_api.artifact_repository import ArtifactStorageError
+from jobos_api.documents import (
+    ArtifactPublishRequest,
+    materialize_external_import,
+    materialize_published_document,
+)
+
+JOB_ID = "job-1"
+DOCUMENT_ID = "edoc_abcdefghijklmnopqrstuvwx"
+
+
+def publish_request(source: bytes, artifact: bytes) -> ArtifactPublishRequest:
+    return ArtifactPublishRequest.model_validate(
+        {
+            "document_key": "resume",
+            "document_label": "Resume",
+            "source_filename": "resume.docx",
+            "source_base64": base64.b64encode(source).decode("ascii"),
+            "artifact_filename": "resume.pdf",
+            "artifact_base64": base64.b64encode(artifact).decode("ascii"),
+            "origin": "mcp",
+            "idempotency_key": "materialize-test",
+        }
+    )
+
+
+def materialize(flow: str, workspace, source: bytes, artifact: bytes):
+    if flow == "published_document":
+        return materialize_published_document(
+            publish_request(source, artifact),
+            job_id=JOB_ID,
+            workspace_root=workspace,
+        )
+    return materialize_external_import(
+        job_id=JOB_ID,
+        document_id=DOCUMENT_ID,
+        document_key="resume",
+        source_filename="resume.docx",
+        source_sha256=sha256(source).hexdigest(),
+        source_bytes=source,
+        workspace_root=workspace,
+    )
+
+
+@pytest.mark.parametrize("flow", ["published_document", "external_import"])
+@pytest.mark.parametrize("swapped_segment", ["resume", "exports", "job"])
+def test_materialization_fails_closed_when_publication_ancestor_is_swapped(
+    tmp_path, monkeypatch, flow, swapped_segment
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "private.txt"
+    sentinel.write_bytes(b"outside-private")
+    source = b"source-docx-bytes"
+    artifact = b"artifact-pdf-bytes"
+    real_open = os.open
+    swapped = False
+
+    def racing_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if not swapped and flags & os.O_CREAT:
+            ancestors = {
+                "resume": workspace / "resume",
+                "exports": workspace / "resume" / "exports",
+                "job": workspace / "resume" / "exports" / "jobos" / JOB_ID,
+            }
+            ancestor = ancestors[swapped_segment]
+            held = ancestor.with_name(f"held-{ancestor.name}")
+            ancestor.rename(held)
+            ancestor.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(artifact_repository_module.os, "open", racing_open)
+
+    with pytest.raises(ArtifactStorageError, match="directory changed during storage"):
+        materialize(flow, workspace, source, artifact)
+
+    assert swapped
+    assert sentinel.read_bytes() == b"outside-private"
+    assert list(outside.iterdir()) == [sentinel]
+
+
+@pytest.mark.parametrize("flow", ["published_document", "external_import"])
+@pytest.mark.parametrize("swapped_segment", ["resume", "exports", "job", "imports"])
+def test_pair_materialization_cleans_first_file_after_between_write_ancestor_move(
+    tmp_path, monkeypatch, flow, swapped_segment
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "private.txt"
+    sentinel.write_bytes(b"outside-private")
+    source = b"source-docx-bytes"
+    artifact = b"artifact-pdf-bytes"
+    real_materialize = artifact_repository_module._materialize_idempotent_file
+    swapped = False
+    held = tmp_path / f"held-{swapped_segment}"
+
+    def move_after_first_materialization(directory, filename, content):
+        nonlocal swapped
+        result = real_materialize(directory, filename, content)
+        if not swapped:
+            ancestors = {
+                "resume": workspace / "resume",
+                "exports": workspace / "resume" / "exports",
+                "job": workspace / "resume" / "exports" / "jobos" / JOB_ID,
+                "imports": workspace
+                / "resume"
+                / "exports"
+                / "jobos"
+                / JOB_ID
+                / "imports",
+            }
+            ancestor = ancestors[swapped_segment]
+            ancestor.rename(held)
+            ancestor.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return result
+
+    monkeypatch.setattr(
+        artifact_repository_module,
+        "_materialize_idempotent_file",
+        move_after_first_materialization,
+    )
+
+    with pytest.raises(ArtifactStorageError, match="directory changed during storage"):
+        materialize(flow, workspace, source, artifact)
+
+    assert swapped
+    assert not any(path.is_file() for path in held.rglob("*"))
+    assert sentinel.read_bytes() == b"outside-private"
+    assert list(outside.iterdir()) == [sentinel]
+
+
+def test_pair_cleanup_never_claims_or_deletes_post_creation_replacement(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = b"source-docx-bytes"
+    artifact = b"artifact-pdf-bytes"
+    foreign = b"foreign-replacement"
+    real_materialize = artifact_repository_module._materialize_idempotent_file
+    calls = 0
+    replacement = None
+
+    def replace_after_first_creation(directory, filename, content):
+        nonlocal calls, replacement
+        calls += 1
+        path, created_identity = real_materialize(directory, filename, content)
+        if calls == 1:
+            held = path.with_name(f"held-{path.name}")
+            path.rename(held)
+            path.write_bytes(foreign)
+            replacement = path
+            return path, created_identity
+        raise ArtifactStorageError("forced second write failure")
+
+    monkeypatch.setattr(
+        artifact_repository_module,
+        "_materialize_idempotent_file",
+        replace_after_first_creation,
+    )
+
+    with pytest.raises(ArtifactStorageError, match="forced second write failure"):
+        materialize_published_document(
+            publish_request(source, artifact),
+            job_id=JOB_ID,
+            workspace_root=workspace,
+        )
+
+    assert replacement is not None
+    assert replacement.read_bytes() == foreign
+
+
+@pytest.mark.parametrize("flow", ["published_document", "external_import"])
+def test_materialization_idempotently_reuses_verified_content_addressed_files(
+    tmp_path, flow
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = b"source-docx-bytes"
+    artifact = b"artifact-pdf-bytes"
+
+    first = materialize(flow, workspace, source, artifact)
+    second = materialize(flow, workspace, source, artifact)
+
+    assert second == first
+    if flow == "published_document":
+        assert [path.read_bytes() for path in second] == [source, artifact]
+    else:
+        assert second[1].read_bytes() == source

--- a/services/api/tests/test_health_contract.py
+++ b/services/api/tests/test_health_contract.py
@@ -20,7 +20,7 @@ def test_health_reports_ready_phase_six_api_with_agent_connectivity_separate(tmp
         "status": "ready",
         "service": "jobos-api",
         "version": "0.1.0",
-        "state_schema": 14,
+        "state_schema": 15,
         "agent_connection": "offline",
     }
 

--- a/services/api/tests/test_initialize.py
+++ b/services/api/tests/test_initialize.py
@@ -146,6 +146,25 @@ def test_missing_configuration_has_an_actionable_service_error(tmp_path, monkeyp
         settings_from_environment()
 
 
+def test_token_configured_source_defaults_use_application_data_not_cwd(tmp_path, monkeypatch):
+    monkeypatch.setattr("jobos_api.local_config.sys.platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("JOBOS_DEVICE_TOKEN", "source-default-device-token")
+    monkeypatch.setenv("JOBOS_MCP_TOKEN", "source-default-mcp-token")
+    monkeypatch.delenv("JOBOS_STATE_DB_PATH", raising=False)
+    monkeypatch.delenv("JOBOS_LOCAL_ARTIFACT_ROOT", raising=False)
+
+    configured = settings_from_environment()
+
+    assert configured.state_db_path == tmp_path / "Library/Application Support/JobOS/state/jobos.db"
+    assert configured.resolved_jobs_db_path() == (
+        tmp_path / "Library/Application Support/JobOS/jobs/jobs.db"
+    )
+    assert configured.resolved_local_artifact_root() == (
+        tmp_path / "Library/Application Support/JobOS/artifacts"
+    )
+
+
 def test_file_credentials_reject_symlinks(tmp_path):
     target = tmp_path / "outside.json"
     target.write_text('{"deviceToken":"device","mcpToken":"mcp"}', encoding="utf-8")

--- a/services/api/tests/test_job_repository_composition.py
+++ b/services/api/tests/test_job_repository_composition.py
@@ -9,6 +9,7 @@ from jobos_api.app import create_app
 from jobos_api.artifact_gateway import UnavailableArtifactGateway
 from jobos_api.composition import create_job_services
 from jobos_api.job_repository import Conflict, NotFound, Unavailable, Validation
+from jobos_api.private_adapters import job_hunter as private_job_hunter
 from jobos_api.settings import Settings
 from jobos_api.sqlite_job_repository import SQLiteJobRepository
 
@@ -31,6 +32,48 @@ def test_public_default_uses_separate_local_sqlite_without_job_hunter(tmp_path):
     assert repository.database_path == tmp_path / "state" / "jobs.db"
     assert repository.database_path != configured.state_db_path
     assert "job_hunter" not in sys.modules
+
+
+def test_sqlite_jobs_can_select_the_private_artifact_gateway_independently(
+    tmp_path, monkeypatch
+):
+    gateway = object()
+    calls = []
+
+    def create_gateway(database_path, workspace_root):
+        calls.append((database_path, workspace_root))
+        return gateway
+
+    monkeypatch.setattr(
+        private_job_hunter, "create_job_hunter_artifact_gateway", create_gateway
+    )
+    configured = settings(
+        tmp_path,
+        job_provider="sqlite",
+        artifact_provider="gateway",
+        job_hunter_db_path=tmp_path / "private" / "jobs.db",
+        hermes_job_hunter_cwd=tmp_path / "private-workspace",
+    )
+
+    repository, artifact_gateway = create_job_services(configured)
+
+    assert isinstance(repository, SQLiteJobRepository)
+    assert artifact_gateway is gateway
+    assert calls == [
+        (tmp_path / "private" / "jobs.db", tmp_path / "private-workspace")
+    ]
+
+
+def test_private_artifact_gateway_validates_its_database_only_when_selected(tmp_path):
+    repository, gateway = create_job_services(settings(tmp_path, artifact_provider="local"))
+    assert isinstance(repository, SQLiteJobRepository)
+    assert isinstance(gateway, UnavailableArtifactGateway)
+
+    with pytest.raises(
+        Unavailable,
+        match="artifact gateway requires JOBOS_JOB_HUNTER_DB_PATH",
+    ):
+        create_job_services(settings(tmp_path, artifact_provider="gateway"))
 
 
 def test_explicit_jobs_path_and_public_runtime_create_mutable_jobs(tmp_path):
@@ -132,4 +175,5 @@ def test_private_installed_environment_explicitly_selects_job_hunter(tmp_path):
     )
 
     assert environment["JOBOS_JOB_PROVIDER"] == "job-hunter"
+    assert environment["JOBOS_ARTIFACT_PROVIDER"] == "gateway"
     assert environment["JOBOS_JOB_HUNTER_DB_PATH"] == str(tmp_path / "private-jobs.db")

--- a/services/api/tests/test_jobs_contract.py
+++ b/services/api/tests/test_jobs_contract.py
@@ -6,7 +6,9 @@ from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha256
 from pathlib import Path
 
+import jobos_api.artifact_repository as artifact_repository_module
 import pytest
+from conftest import build_minimal_pdf
 from fastapi.testclient import TestClient
 from jobos_api.app import create_app
 from jobos_api.documents import ArtifactPublishRequest
@@ -36,6 +38,27 @@ def test_publish_request_preserves_custom_existing_labels_and_fixes_references_l
     with pytest.raises(ValueError, match="References"):
         ArtifactPublishRequest.model_validate(
             {"document_key": "references", "document_label": "Reference Sheet", **common}
+        )
+
+
+def test_publish_request_reserves_content_addressed_filename_prefix():
+    common = {
+        "document_key": "resume",
+        "document_label": "Tailored Resume",
+        "source_base64": base64.b64encode(b"source").decode(),
+        "artifact_filename": "artifact.pdf",
+        "artifact_base64": base64.b64encode(b"artifact").decode(),
+        "origin": "mcp",
+        "idempotency_key": "publish-filename-contract",
+    }
+    accepted = ArtifactPublishRequest.model_validate(
+        {"source_filename": f"{'a' * 229}.docx", **common}
+    )
+    assert len(accepted.source_filename.encode("utf-8")) == 234
+
+    with pytest.raises(ValueError, match="too long for content-addressed storage"):
+        ArtifactPublishRequest.model_validate(
+            {"source_filename": f"{'a' * 230}.docx", **common}
         )
 
 
@@ -1360,7 +1383,7 @@ def test_registered_pdf_is_discoverable_and_streamed_with_trust_metadata(tmp_pat
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     pdf = tmp_path / "resume.pdf"
-    pdf.write_bytes(b"%PDF-1.7\ntrusted resume fixture\n%%EOF\n")
+    pdf.write_bytes(build_minimal_pdf("(FAKE) trusted resume fixture"))
     facade.artifacts["job-0"] = [artifact_metadata(pdf)]
 
     with make_client(tmp_path, facade) as client:
@@ -1386,7 +1409,9 @@ def test_registered_pdf_is_discoverable_and_streamed_with_trust_metadata(tmp_pat
     assert streamed.headers["content-disposition"].startswith("inline;")
 
 
-def test_trusted_mcp_can_publish_paired_pdf_and_docx_into_one_logical_revision(tmp_path):
+def test_trusted_mcp_can_publish_paired_pdf_and_docx_into_one_logical_revision(
+    tmp_path, minimal_docx
+):
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     source = b"# Tailored cover letter\n\nDear hiring team"
@@ -1407,9 +1432,15 @@ def test_trusted_mcp_can_publish_paired_pdf_and_docx_into_one_logical_revision(t
         pdf = client.post(
             "/v1/jobs/job-0/artifacts/publish",
             headers=auth_headers(),
-            json=payload("cover-letter.pdf", b"%PDF-1.7\nletter\n%%EOF\n", "publish-pdf"),
+            json=payload(
+                "cover-letter.pdf",
+                build_minimal_pdf("(FAKE) letter"),
+                "publish-pdf",
+            ),
         )
-        docx_payload = payload("cover-letter.docx", b"PK\x03\x04docx-fixture", "publish-docx")
+        docx_payload = payload(
+            "cover-letter.docx", minimal_docx("cover letter"), "publish-docx"
+        )
         docx = client.post(
             "/v1/jobs/job-0/artifacts/publish",
             headers=auth_headers(),
@@ -1423,7 +1454,7 @@ def test_trusted_mcp_can_publish_paired_pdf_and_docx_into_one_logical_revision(t
         untrusted = client.post(
             "/v1/jobs/job-0/artifacts/publish",
             headers={"Authorization": "Bearer test-device-token"},
-            json=payload("blocked.docx", b"PK\x03\x04blocked", "publish-blocked"),
+            json=payload("blocked.docx", minimal_docx("blocked"), "publish-blocked"),
         )
 
     assert pdf.status_code == 200
@@ -1445,7 +1476,9 @@ def test_trusted_mcp_can_publish_paired_pdf_and_docx_into_one_logical_revision(t
     )
 
 
-def test_editable_document_publish_pairs_docx_pdf_marks_revision_and_replays(tmp_path, monkeypatch):
+def test_editable_document_publish_pairs_docx_pdf_marks_revision_and_replays(
+    tmp_path, minimal_docx
+):
     facade = FakeJobHunterFacade()
     client = make_client(tmp_path, facade)
     client.__enter__()
@@ -1460,8 +1493,8 @@ def test_editable_document_publish_pairs_docx_pdf_marks_revision_and_replays(tmp
     )
     assert created.status_code == 201
     document = created.json()
-    docx = b"PK\x03\x04jobos-docx"
-    pdf = b"%PDF-1.4\njobos-pdf"
+    docx = minimal_docx("JobOS editable publication")
+    pdf = build_minimal_pdf("(FAKE) JobOS PDF")
     payload = {
         "expected_revision": document["revision"],
         "docx_filename": "Resume-r1.docx",
@@ -1473,31 +1506,6 @@ def test_editable_document_publish_pairs_docx_pdf_marks_revision_and_replays(tmp
         "idempotency_key": "publish-editable-r1",
     }
 
-    original_publish = facade.publish_document_artifact
-    failed_pdf_once = False
-
-    def flaky_publish(*args):
-        nonlocal failed_pdf_once
-        if str(args[-1]).endswith(".pdf") and not failed_pdf_once:
-            failed_pdf_once = True
-            raise OSError("injected PDF publication failure")
-        return original_publish(*args)
-
-    monkeypatch.setattr(facade, "publish_document_artifact", flaky_publish)
-    partial = client.post(
-        f"/v1/editable-documents/{document['document_id']}/publish",
-        headers=auth_headers(),
-        json=payload,
-    )
-    assert partial.status_code == 422
-    assert len(facade.artifacts["job-0"]) == 1
-    partial_snapshots = client.get(
-        f"/v1/editable-documents/{document['document_id']}/snapshots",
-        headers=auth_headers(),
-    )
-    assert partial_snapshots.status_code == 200
-    assert [item["reason"] for item in partial_snapshots.json()["snapshots"]] == ["before_publish"]
-
     published = client.post(
         f"/v1/editable-documents/{document['document_id']}/publish",
         headers=auth_headers(),
@@ -1505,25 +1513,44 @@ def test_editable_document_publish_pairs_docx_pdf_marks_revision_and_replays(tmp
     )
     assert published.status_code == 200, published.text
     assert published.json()["published_revision"] == 1
-    assert {row["media_type"] for row in facade.artifacts["job-0"]} == {
+    assert facade.publish_calls == []
+    listed = client.get("/v1/jobs/job-0/artifacts", headers=auth_headers()).json()
+    assert {row["media_type"] for row in listed["artifacts"]} == {
         "application/pdf",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     }
-    source_paths = {Path(call["source_path"]) for call in facade.publish_calls}
-    assert len(source_paths) == 1
-    publication_source_path = source_paths.pop()
-    assert publication_source_path.name.endswith("-publication-source.json")
-    publication_source = json.loads(publication_source_path.read_text())
-    assert publication_source["document_id"] == document["document_id"]
-    assert publication_source["document_revision"] == document["revision"]
-    assert {row["source_revision"] for row in facade.artifacts["job-0"]} == {
-        sha256(publication_source_path.read_bytes()).hexdigest()
+    assert {row["sha256"] for row in listed["artifacts"]} == {
+        sha256(docx).hexdigest(),
+        sha256(pdf).hexdigest(),
     }
+    downloaded = {
+        row["media_type"]: client.get(
+            f"/v1/artifacts/{row['artifact_id']}/download", headers=auth_headers()
+        )
+        for row in listed["artifacts"]
+    }
+    assert downloaded["application/pdf"].content == pdf
+    assert (
+        downloaded[
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ].content
+        == docx
+    )
+    assert all(
+        response.headers["x-content-sha256"] == sha256(response.content).hexdigest()
+        for response in downloaded.values()
+    )
     with sqlite3.connect(tmp_path / "jobos.db") as connection:
         linked_rows = connection.execute(
-            "SELECT editable_document_id, editable_document_revision FROM document_artifacts"
+            """
+            SELECT editable_document_id, editable_document_revision, canonical_path
+            FROM document_artifacts
+            """
         ).fetchall()
-    assert linked_rows == [(document["document_id"], document["revision"])] * 2
+    assert [(row[0], row[1]) for row in linked_rows] == [
+        (document["document_id"], document["revision"])
+    ] * 2
+    assert all(Path(row[2]).is_relative_to(tmp_path / "artifacts") for row in linked_rows)
     snapshots = client.get(
         f"/v1/editable-documents/{document['document_id']}/snapshots",
         headers=auth_headers(),
@@ -1552,21 +1579,23 @@ def test_editable_document_publish_pairs_docx_pdf_marks_revision_and_replays(tmp
     )
     assert replay.status_code == 200
     assert replay.json() == published.json()
-    assert len(facade.artifacts["job-0"]) == 2
+    assert facade.publish_calls == []
     client.__exit__(None, None, None)
 
 
-def test_authenticated_desktop_can_publish_without_an_mcp_token(tmp_path):
+def test_authenticated_desktop_can_publish_without_an_mcp_token(tmp_path, minimal_docx):
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
-    source = b"PK\x03\x04canonical-docx"
+    source = minimal_docx("canonical DOCX")
     payload = {
         "document_key": "resume",
         "document_label": "Resume",
         "source_filename": "resume-r7.docx",
         "source_base64": base64.b64encode(source).decode("ascii"),
         "artifact_filename": "resume-r7.pdf",
-        "artifact_base64": base64.b64encode(b"%PDF-1.7\nrevision seven\n%%EOF\n").decode("ascii"),
+        "artifact_base64": base64.b64encode(
+            build_minimal_pdf("(FAKE) revision seven")
+        ).decode("ascii"),
         "origin": "user",
         "idempotency_key": "desktop-publish-resume-r7-pdf",
     }
@@ -1587,8 +1616,8 @@ def test_newer_success_and_failed_render_preserve_last_successful_preview(tmp_pa
     facade.jobs = facade.jobs[:1]
     first = tmp_path / "resume-1.pdf"
     second = tmp_path / "resume-2.pdf"
-    first.write_bytes(b"%PDF-1.7\nrevision one\n%%EOF\n")
-    second.write_bytes(b"%PDF-1.7\nrevision two\n%%EOF\n")
+    first.write_bytes(build_minimal_pdf("(FAKE) revision one"))
+    second.write_bytes(build_minimal_pdf("(FAKE) revision two"))
     facade.artifacts["job-0"] = [artifact_metadata(first)]
 
     with make_client(tmp_path, facade) as client:
@@ -1638,7 +1667,7 @@ def test_approval_persists_the_exact_successful_artifact_for_the_job(tmp_path):
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     pdf = tmp_path / "resume.pdf"
-    pdf.write_bytes(b"%PDF-1.7\napproved resume\n%%EOF\n")
+    pdf.write_bytes(build_minimal_pdf("(FAKE) approved resume"))
     facade.artifacts["job-0"] = [artifact_metadata(pdf)]
 
     with make_client(tmp_path, facade) as client:
@@ -1676,7 +1705,7 @@ def test_approval_rejects_artifact_bytes_that_no_longer_match_registration(
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     pdf = tmp_path / "resume.pdf"
-    pdf.write_bytes(b"%PDF-1.7\ntrusted resume\n%%EOF\n")
+    pdf.write_bytes(build_minimal_pdf("(FAKE) trusted resume"))
     facade.artifacts["job-0"] = [artifact_metadata(pdf)]
 
     with make_client(tmp_path, facade) as client:
@@ -1685,7 +1714,7 @@ def test_approval_rejects_artifact_bytes_that_no_longer_match_registration(
         ).json()
         artifact_id = registered["last_successful_artifact_id"]
         if damage == "tampered":
-            pdf.write_bytes(b"%PDF-1.7\ntampered resume\n%%EOF\n")
+            pdf.write_bytes(build_minimal_pdf("(FAKE) tampered resume"))
         else:
             pdf.unlink()
         rejected = client.post(
@@ -1700,10 +1729,8 @@ def test_approval_rejects_artifact_bytes_that_no_longer_match_registration(
             "/v1/jobs/job-0/artifacts", headers=auth_headers()
         ).json()
 
-    assert rejected.status_code == 409
-    assert rejected.json()["detail"] == (
-        "Registered artifact no longer matches trusted metadata"
-    )
+    assert rejected.status_code == 503
+    assert rejected.json()["detail"] == "Local artifact storage is unavailable"
     assert restored["approved_artifact_id"] is None
 
 
@@ -1721,7 +1748,7 @@ def test_failed_or_cross_job_artifact_cannot_be_approved(tmp_path):
     }
     facade.artifacts["job-0"] = [failed]
     pdf = tmp_path / "other.pdf"
-    pdf.write_bytes(b"%PDF-1.7\nother job\n%%EOF\n")
+    pdf.write_bytes(build_minimal_pdf("(FAKE) other job"))
     facade.artifacts["job-1"] = [artifact_metadata(pdf, job_id="job-1")]
 
     with make_client(tmp_path, facade) as client:
@@ -1784,16 +1811,112 @@ def test_failed_render_stays_in_audit_without_injecting_chat_activity(tmp_path):
     assert outcome == "failed"
 
 
+@pytest.mark.parametrize("route", ["render", "register"])
+@pytest.mark.parametrize("damage", ["disappeared", "symlink", "replaced"])
+def test_gateway_artifact_storage_races_are_stable_503(tmp_path, route, damage):
+    pdf = tmp_path / "resume.pdf"
+    pdf.write_bytes(build_minimal_pdf("(FAKE) gateway artifact"))
+    raw = {**artifact_metadata(pdf), "artifact_reference": "resume-ref"}
+
+    class DamagingFacade(FakeJobHunterFacade):
+        def successful_artifact(self):
+            held = tmp_path / f"held-{route}-{damage}.pdf"
+            if damage == "disappeared":
+                pdf.unlink()
+            elif damage == "symlink":
+                pdf.rename(held)
+                pdf.symlink_to(held)
+            else:
+                pdf.rename(held)
+                pdf.write_bytes(build_minimal_pdf("(FAKE) foreign replacement"))
+            return raw
+
+        def render_resume(self, job_id, source_id, output_options):
+            return self.successful_artifact()
+
+        def register_artifact(self, job_id, artifact_reference):
+            return self.successful_artifact()
+
+    facade = DamagingFacade()
+    facade.jobs = facade.jobs[:1]
+    if route == "render":
+        endpoint = "/v1/jobs/job-0/artifacts/render"
+        payload = {
+            "source_id": "job-0-tailored",
+            "output_format": "pdf",
+            "origin": "mcp",
+            "idempotency_key": f"storage-race-{route}-{damage}",
+        }
+    else:
+        endpoint = "/v1/jobs/job-0/artifacts/register"
+        payload = {
+            "artifact_reference": "resume-ref",
+            "origin": "mcp",
+            "idempotency_key": f"storage-race-{route}-{damage}",
+        }
+
+    with make_client(tmp_path, facade) as client:
+        response = client.post(endpoint, headers=auth_headers(), json=payload)
+        listed = client.get("/v1/jobs/job-0/artifacts", headers=auth_headers())
+
+    assert (response.status_code, response.json()["detail"]) == (
+        503,
+        "Local artifact storage is unavailable",
+    )
+    assert listed.json()["artifacts"] == []
+
+
+@pytest.mark.parametrize("route", ["render", "register"])
+def test_gateway_artifact_trust_validation_remains_422(tmp_path, route):
+    class InvalidMetadataFacade(FakeJobHunterFacade):
+        def invalid_artifact(self, job_id):
+            return {
+                "job_id": job_id,
+                "source_revision": "source-invalid",
+                "artifact_revision": "render-invalid",
+                "media_type": "text/plain",
+                "render_status": "succeeded",
+                "render_sequence": 1,
+            }
+
+        def render_resume(self, job_id, source_id, output_options):
+            return self.invalid_artifact(job_id)
+
+        def register_artifact(self, job_id, artifact_reference):
+            return self.invalid_artifact(job_id)
+
+    if route == "render":
+        endpoint = "/v1/jobs/job-0/artifacts/render"
+        payload = {
+            "source_id": "job-0-tailored",
+            "output_format": "pdf",
+            "origin": "mcp",
+            "idempotency_key": f"trust-validation-{route}",
+        }
+    else:
+        endpoint = "/v1/jobs/job-0/artifacts/register"
+        payload = {
+            "artifact_reference": "resume-ref",
+            "origin": "mcp",
+            "idempotency_key": f"trust-validation-{route}",
+        }
+
+    with make_client(tmp_path, InvalidMetadataFacade()) as client:
+        response = client.post(endpoint, headers=auth_headers(), json=payload)
+
+    assert response.status_code == 422
+
+
 @pytest.mark.parametrize("manifest_order", ["oldest-first", "newest-first"])
 def test_facade_render_sequence_determines_current_and_last_successful(
-    tmp_path, manifest_order
+    tmp_path, manifest_order, minimal_docx
 ):
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     older_pdf = tmp_path / "resume-old.pdf"
     last_good_docx = tmp_path / "resume-current.docx"
-    older_pdf.write_bytes(b"%PDF-1.7\nolder PDF\n%%EOF\n")
-    last_good_docx.write_bytes(b"PK\x03\x04last successful DOCX")
+    older_pdf.write_bytes(build_minimal_pdf("(FAKE) older PDF"))
+    last_good_docx.write_bytes(minimal_docx("last successful DOCX"))
     artifacts = [
         artifact_metadata(
             older_pdf, source="source-1", revision="render-1", sequence=1
@@ -1849,8 +1972,8 @@ def test_duplicate_facade_render_sequences_are_rejected(tmp_path):
     facade.jobs = facade.jobs[:1]
     first = tmp_path / "resume-1.pdf"
     second = tmp_path / "resume-2.pdf"
-    first.write_bytes(b"%PDF-1.7\nfirst\n%%EOF\n")
-    second.write_bytes(b"%PDF-1.7\nsecond\n%%EOF\n")
+    first.write_bytes(build_minimal_pdf("(FAKE) first"))
+    second.write_bytes(build_minimal_pdf("(FAKE) second"))
     facade.artifacts["job-0"] = [
         artifact_metadata(first, revision="render-1", sequence=7),
         artifact_metadata(second, revision="render-2", sequence=7),
@@ -1869,7 +1992,7 @@ def test_explicit_resume_identity_does_not_duplicate_a_legacy_registered_artifac
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     pdf = tmp_path / "resume.pdf"
-    pdf.write_bytes(b"%PDF-1.7\nlegacy resume\n%%EOF\n")
+    pdf.write_bytes(build_minimal_pdf("(FAKE) legacy resume"))
     legacy = artifact_metadata(pdf)
     facade.artifacts["job-0"] = [legacy]
 
@@ -1911,8 +2034,8 @@ def test_artifact_response_hashes_and_serves_one_byte_snapshot(tmp_path, monkeyp
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     pdf = tmp_path / "resume.pdf"
-    original_bytes = b"%PDF-1.7\ntrusted snapshot\n%%EOF\n"
-    replacement_bytes = b"%PDF-1.7\nreplacement snapshot\n%%EOF\n"
+    original_bytes = build_minimal_pdf("(FAKE) trusted snapshot")
+    replacement_bytes = build_minimal_pdf("(FAKE) replacement snapshot")
     pdf.write_bytes(original_bytes)
     facade.artifacts["job-0"] = [artifact_metadata(pdf)]
 
@@ -1920,22 +2043,26 @@ def test_artifact_response_hashes_and_serves_one_byte_snapshot(tmp_path, monkeyp
         artifact = client.post(
             "/v1/jobs/job-0/artifacts/refresh", headers=auth_headers()
         ).json()["artifacts"][0]
-        original_read_bytes = Path.read_bytes
+        original_read = artifact_repository_module.os.read
         calls = 0
+        held = tmp_path / "held-resume.pdf"
 
-        def replacing_read_bytes(path):
+        def replacing_read(descriptor, maximum):
             nonlocal calls
             calls += 1
-            return original_bytes if calls == 1 else replacement_bytes
+            content = original_read(descriptor, maximum)
+            if calls == 1:
+                pdf.rename(held)
+                pdf.write_bytes(replacement_bytes)
+            return content
 
-        monkeypatch.setattr(Path, "read_bytes", replacing_read_bytes)
+        monkeypatch.setattr(artifact_repository_module.os, "read", replacing_read)
         streamed = client.get(
             f"/v1/artifacts/{artifact['artifact_id']}/content",
             headers=auth_headers(),
         )
-        monkeypatch.setattr(Path, "read_bytes", original_read_bytes)
 
-    assert calls == 1
+    assert calls == 2
     assert streamed.status_code == 200
     assert streamed.content == original_bytes
     assert streamed.headers["x-content-sha256"] == sha256(original_bytes).hexdigest()
@@ -1947,11 +2074,11 @@ def test_artifact_refresh_rejects_root_media_and_metadata_mismatches(tmp_path, a
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     root_pdf = tmp_path / "resume.pdf"
-    root_pdf.write_bytes(b"%PDF-1.7\ntrusted\n%%EOF\n")
+    root_pdf.write_bytes(build_minimal_pdf("(FAKE) trusted"))
     raw = artifact_metadata(root_pdf)
     if attack == "root_escape":
         outside = tmp_path.parent / "outside-jobos-artifact.pdf"
-        outside.write_bytes(b"%PDF-1.7\noutside\n%%EOF\n")
+        outside.write_bytes(build_minimal_pdf("(FAKE) outside"))
         raw = artifact_metadata(outside)
     elif attack == "wrong_media":
         raw["media_type"] = "text/plain"
@@ -1965,17 +2092,17 @@ def test_artifact_refresh_rejects_root_media_and_metadata_mismatches(tmp_path, a
         )
         listed = client.get("/v1/jobs/job-0/artifacts", headers=auth_headers())
 
-    assert response.status_code == 422
+    assert response.status_code == (422 if attack == "wrong_media" else 503)
     assert listed.json()["artifacts"] == []
     if attack == "root_escape":
         outside.unlink(missing_ok=True)
 
 
-def test_unregistered_ids_paths_and_docx_preview_are_rejected(tmp_path):
+def test_unregistered_ids_paths_and_docx_preview_are_rejected(tmp_path, minimal_docx):
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     docx = tmp_path / "resume.docx"
-    docx.write_bytes(b"PK\x03\x04fixture docx")
+    docx.write_bytes(minimal_docx("preview fixture DOCX"))
     facade.artifacts["job-0"] = [
         {
             **artifact_metadata(docx),
@@ -2007,17 +2134,19 @@ def test_unregistered_ids_paths_and_docx_preview_are_rejected(tmp_path):
     assert arbitrary_path.status_code in {404, 422}
 
 
-def test_multiple_document_formats_keep_identity_and_resume_only_approval(tmp_path):
+def test_multiple_document_formats_keep_identity_and_resume_only_approval(
+    tmp_path, minimal_docx
+):
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     resume_pdf = tmp_path / "resume.pdf"
     resume_docx = tmp_path / "resume.docx"
     cover_pdf = tmp_path / "cover-letter.pdf"
     cover_docx = tmp_path / "cover-letter.docx"
-    resume_pdf.write_bytes(b"%PDF-1.7\nresume\n%%EOF\n")
-    resume_docx.write_bytes(b"PK\x03\x04resume docx")
-    cover_pdf.write_bytes(b"%PDF-1.7\ncover letter\n%%EOF\n")
-    cover_docx.write_bytes(b"PK\x03\x04cover letter docx")
+    resume_pdf.write_bytes(build_minimal_pdf("(FAKE) resume"))
+    resume_docx.write_bytes(minimal_docx("resume DOCX"))
+    cover_pdf.write_bytes(build_minimal_pdf("(FAKE) cover letter"))
+    cover_docx.write_bytes(minimal_docx("cover letter DOCX"))
     docx_media = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     facade.artifacts["job-0"] = [
         {**artifact_metadata(resume_pdf, source="resume-source", sequence=1),
@@ -2074,7 +2203,7 @@ def test_workspace_restores_only_an_active_artifact_owned_by_the_selected_job(tm
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:2]
     pdf = tmp_path / "resume.pdf"
-    pdf.write_bytes(b"%PDF-1.7\nowned resume\n%%EOF\n")
+    pdf.write_bytes(build_minimal_pdf("(FAKE) owned resume"))
     facade.artifacts["job-0"] = [artifact_metadata(pdf)]
 
     with make_client(tmp_path, facade) as client:
@@ -2119,7 +2248,7 @@ def test_workspace_rejects_cross_job_stale_and_unselected_active_artifacts(tmp_p
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:2]
     pdf = tmp_path / "resume.pdf"
-    pdf.write_bytes(b"%PDF-1.7\njob zero resume\n%%EOF\n")
+    pdf.write_bytes(build_minimal_pdf("(FAKE) job zero resume"))
     facade.artifacts["job-0"] = [artifact_metadata(pdf)]
 
     with make_client(tmp_path, facade) as client:
@@ -2227,7 +2356,7 @@ def test_mutation_replay_does_not_recreate_agent_chat_activity(
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:1]
     pdf = tmp_path / "resume.pdf"
-    pdf.write_bytes(b"%PDF-1.7\nchronology\n%%EOF\n")
+    pdf.write_bytes(build_minimal_pdf("(FAKE) chronology"))
     facade.artifacts["job-0"] = [
         {**artifact_metadata(pdf), "artifact_reference": "resume-ref"}
     ]
@@ -2299,7 +2428,7 @@ def test_concurrent_identical_artifact_registration_executes_the_facade_once(tmp
     facade = BlockingFacade()
     facade.jobs = facade.jobs[:1]
     pdf = tmp_path / "resume.pdf"
-    pdf.write_bytes(b"%PDF-1.7\nconcurrent\n%%EOF\n")
+    pdf.write_bytes(build_minimal_pdf("(FAKE) concurrent"))
     facade.artifacts["job-0"] = [
         {**artifact_metadata(pdf), "artifact_reference": "resume-ref"}
     ]
@@ -2522,14 +2651,16 @@ def external_document_payload(document_key, content, *, key="external-create-1",
     }
 
 
-def test_registered_import_requires_successful_same_job_docx_and_persists_snapshot(tmp_path):
+def test_registered_import_requires_successful_same_job_docx_and_persists_snapshot(
+    tmp_path, minimal_docx
+):
     facade = FakeJobHunterFacade()
     pdf = tmp_path / "wrong-media.pdf"
     good = tmp_path / "references.docx"
     other = tmp_path / "other-job.docx"
-    pdf.write_bytes(b"%PDF-1.7\nfixture\n%%EOF\n")
-    good.write_bytes(b"PK\x03\x04registered references")
-    other.write_bytes(b"PK\x03\x04other job")
+    pdf.write_bytes(build_minimal_pdf("(FAKE) fixture"))
+    good.write_bytes(minimal_docx("registered references"))
+    other.write_bytes(minimal_docx("other job"))
     docx_media = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     facade.artifacts["job-0"] = [
         {
@@ -2609,12 +2740,14 @@ def test_registered_import_requires_successful_same_job_docx_and_persists_snapsh
         ]
 
 
-def test_external_import_uses_manifest_replays_persists_and_preserves_approval(tmp_path):
+def test_external_import_uses_local_repository_replays_and_preserves_approval(
+    tmp_path, minimal_docx
+):
     facade = FakeJobHunterFacade()
     approved_pdf = tmp_path / "approved-resume.pdf"
-    approved_pdf.write_bytes(b"%PDF-1.7\napproved\n%%EOF\n")
+    approved_pdf.write_bytes(build_minimal_pdf("(FAKE) approved"))
     facade.artifacts["job-0"] = [artifact_metadata(approved_pdf, revision="approved-pdf")]
-    source = b"PK\x03\x04external cover letter"
+    source = minimal_docx("external cover letter")
     payload = external_document_payload("cover_letter", source)
 
     with make_client(tmp_path, facade) as client:
@@ -2624,11 +2757,14 @@ def test_external_import_uses_manifest_replays_persists_and_preserves_approval(t
             json={"origin": "user", "idempotency_key": "refresh-approved"},
         ).json()["artifacts"]
         approved_id = artifacts[0]["artifact_id"]
-        assert client.post(
-            f"/v1/jobs/job-0/artifacts/{approved_id}/approve",
-            headers=auth_headers(),
-            json={"origin": "user", "idempotency_key": "approve-before-import"},
-        ).status_code == 200
+        assert (
+            client.post(
+                f"/v1/jobs/job-0/artifacts/{approved_id}/approve",
+                headers=auth_headers(),
+                json={"origin": "user", "idempotency_key": "approve-before-import"},
+            ).status_code
+            == 200
+        )
 
         created = client.post(
             "/v1/jobs/job-0/editable-documents", headers=auth_headers(), json=payload
@@ -2641,18 +2777,19 @@ def test_external_import_uses_manifest_replays_persists_and_preserves_approval(t
         document = created.json()
         assert document["source_filename"] == "cover_letter.docx"
         assert document["source_sha256"] == sha256(source).hexdigest()
-        manifest = json.loads(Path(facade.publish_calls[-1]["source_path"]).read_text())
-        assert manifest["document_id"] == document["document_id"]
-        assert manifest["original_sha256"] == sha256(source).hexdigest()
-        assert facade.artifacts["job-0"][-1]["source_revision"] != sha256(source).hexdigest()
         listed = client.get("/v1/jobs/job-0/artifacts", headers=auth_headers()).json()
         assert listed["approved_artifact_id"] == approved_id
         published_docx = [
-            row
-            for row in facade.artifacts["job-0"]
-            if row["media_type"].endswith("document")
+            row for row in listed["artifacts"] if row["media_type"].endswith("document")
         ]
         assert len(published_docx) == 1
+        imported = client.get(
+            f"/v1/artifacts/{published_docx[0]['artifact_id']}/download",
+            headers=auth_headers(),
+        )
+        assert imported.content == source
+        assert imported.headers["x-content-sha256"] == sha256(source).hexdigest()
+        assert facade.publish_calls == []
 
         bad_checksum = client.post(
             "/v1/jobs/job-0/editable-documents",
@@ -2660,14 +2797,17 @@ def test_external_import_uses_manifest_replays_persists_and_preserves_approval(t
             json=external_document_payload("references", source, digest="0" * 64),
         )
         assert bad_checksum.status_code == 422
-        before_duplicate = len(facade.artifacts["job-0"])
+        before_duplicate = len(listed["artifacts"])
         duplicate = client.post(
             "/v1/jobs/job-0/editable-documents",
             headers=auth_headers(),
             json=external_document_payload("cover_letter", source, key="external-duplicate"),
         )
         assert duplicate.status_code == 409
-        assert len(facade.artifacts["job-0"]) == before_duplicate
+        assert (
+            len(client.get("/v1/jobs/job-0/artifacts", headers=auth_headers()).json()["artifacts"])
+            == before_duplicate
+        )
 
     with make_client(tmp_path, facade) as restarted:
         restarted_replay = restarted.post(
@@ -2678,16 +2818,18 @@ def test_external_import_uses_manifest_replays_persists_and_preserves_approval(t
         )
         assert restarted_replay.status_code == 201
         assert restarted_replay.json() == document
-        assert len(facade.publish_calls) == 1
+        assert facade.publish_calls == []
         assert persisted.status_code == 200
         assert persisted.json()["source_sha256"] == sha256(source).hexdigest()
         assert persisted.json()["import_report"] == document["import_report"]
 
 
-def test_replace_from_docx_snapshots_once_conflicts_and_protects_source_metadata(tmp_path):
+def test_replace_from_docx_snapshots_once_conflicts_and_protects_source_metadata(
+    tmp_path, minimal_docx
+):
     facade = FakeJobHunterFacade()
     replacement = tmp_path / "replacement.docx"
-    replacement.write_bytes(b"PK\x03\x04replacement references")
+    replacement.write_bytes(minimal_docx("replacement references"))
     facade.artifacts["job-0"] = [
         {
             **artifact_metadata(replacement, revision="replacement-docx"),

--- a/services/api/tests/test_local_artifact_repository.py
+++ b/services/api/tests/test_local_artifact_repository.py
@@ -1,0 +1,853 @@
+from __future__ import annotations
+
+import os
+import stat
+from hashlib import sha256
+from io import BytesIO
+from pathlib import Path
+from threading import Event, Thread
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import jobos_api.artifact_repository as artifact_repository_module
+import jobos_api.local_artifact_repository as local_repository_module
+import pytest
+from jobos_api.artifact_repository import (
+    DOCX_MEDIA_TYPE,
+    MAX_CALLER_FILENAME_BYTES,
+    PDF_MEDIA_TYPE,
+    ArtifactRepositoryError,
+    ArtifactStorageError,
+    ArtifactValidationError,
+    ArtifactWrite,
+    verify_artifact_file,
+)
+from jobos_api.local_artifact_repository import LocalArtifactRepository
+
+
+def write(filename: str, media_type: str, content: bytes) -> ArtifactWrite:
+    return ArtifactWrite(filename, media_type, content, sha256(content).hexdigest())
+
+
+def test_local_repository_atomically_stores_and_reopens_a_publication_pair(
+    tmp_path, minimal_docx, minimal_pdf
+):
+    repository = LocalArtifactRepository(tmp_path / "application-data/artifacts")
+    docx = write("(FAKE)-Resume.docx", DOCX_MEDIA_TYPE, minimal_docx())
+    pdf = write("(FAKE)-Resume.pdf", PDF_MEDIA_TYPE, minimal_pdf())
+
+    first = repository.store_publication_pair(
+        job_id="job-1",
+        document_id="edoc_abcdefghijklmnopqrstuvwx",
+        document_revision=3,
+        docx=docx,
+        pdf=pdf,
+    )
+    replay = repository.store_publication_pair(
+        job_id="job-1",
+        document_id="edoc_abcdefghijklmnopqrstuvwx",
+        document_revision=3,
+        docx=docx,
+        pdf=pdf,
+    )
+
+    assert replay == first
+    assert first[0].canonical_path.parent == first[1].canonical_path.parent
+    assert (
+        repository.read(
+            path=first[0].canonical_path,
+            media_type=DOCX_MEDIA_TYPE,
+            expected_sha256=docx.sha256,
+        )
+        == docx.content
+    )
+    assert (
+        repository.read(
+            path=first[1].canonical_path,
+            media_type=PDF_MEDIA_TYPE,
+            expected_sha256=pdf.sha256,
+        )
+        == pdf.content
+    )
+    assert all(
+        stat.S_ISREG(item.canonical_path.stat().st_mode)
+        and stat.S_IMODE(item.canonical_path.stat().st_mode) == 0o600
+        for item in first
+    )
+    assert list(first[0].canonical_path.parent.parent.glob(".publication-*.tmp")) == []
+
+
+def test_local_repository_rejects_bad_media_hash_paths_and_symlinks(tmp_path, minimal_docx):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    good = write("source.docx", DOCX_MEDIA_TYPE, minimal_docx())
+    stored = repository.store_import(
+        job_id="job-1",
+        document_id="edoc_abcdefghijklmnopqrstuvwx",
+        artifact=good,
+    )
+
+    with pytest.raises(ArtifactRepositoryError, match="PDF header"):
+        repository.store_import(
+            job_id="job-1",
+            document_id="edoc_abcdefghijklmnopqrstuvwx",
+            artifact=write("wrong.pdf", PDF_MEDIA_TYPE, b"PK\x03\x04not-pdf"),
+        )
+    with pytest.raises(ArtifactRepositoryError, match="PDF header"):
+        repository.store_publication_pair(
+            job_id="job-1",
+            document_id="edoc_abcdefghijklmnopqrstuvwx",
+            document_revision=1,
+            docx=good,
+            pdf=write("pair.pdf", PDF_MEDIA_TYPE, b"PK\x03\x04not-pdf"),
+        )
+    assert not (repository.root / "publications").exists()
+    with pytest.raises(ArtifactRepositoryError, match="plain filename"):
+        repository.store_import(
+            job_id="job-1",
+            document_id="edoc_abcdefghijklmnopqrstuvwx",
+            artifact=write("../escape.docx", DOCX_MEDIA_TYPE, minimal_docx("escape")),
+        )
+    oversized = b"PK" + b"x" * 20_000_000
+    with pytest.raises(ArtifactRepositoryError, match="size"):
+        repository.store_import(
+            job_id="job-1",
+            document_id="edoc_abcdefghijklmnopqrstuvwx",
+            artifact=write("oversized.docx", DOCX_MEDIA_TYPE, oversized),
+        )
+    with pytest.raises(ArtifactStorageError, match="integrity"):
+        repository.read(
+            path=stored.canonical_path,
+            media_type=DOCX_MEDIA_TYPE,
+            expected_sha256="0" * 64,
+        )
+    outside = tmp_path / "outside.docx"
+    outside.write_bytes(good.content)
+    with pytest.raises(ArtifactRepositoryError, match="outside configured roots"):
+        repository.read(
+            path=outside,
+            media_type=DOCX_MEDIA_TYPE,
+            expected_sha256=good.sha256,
+        )
+
+    stored.canonical_path.unlink()
+    stored.canonical_path.symlink_to(outside)
+    with pytest.raises(ArtifactRepositoryError, match="symbolic link"):
+        repository.read(
+            path=stored.canonical_path,
+            media_type=DOCX_MEDIA_TYPE,
+            expected_sha256=good.sha256,
+        )
+
+
+@pytest.mark.parametrize(
+    "content, message",
+    [
+        (b"PK\x03\x04not-a-zip", "valid DOCX"),
+        (b"not-a-zip", "valid DOCX"),
+    ],
+)
+def test_local_repository_rejects_malformed_docx(tmp_path, content, message):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    with pytest.raises(ArtifactRepositoryError, match=message):
+        repository.store_import(
+            job_id="job-1",
+            document_id="edoc_abcdefghijklmnopqrstuvwx",
+            artifact=write("malformed.docx", DOCX_MEDIA_TYPE, content),
+        )
+
+
+def test_docx_validation_rejects_missing_traversal_and_excessive_expansion(tmp_path):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+
+    def archive(entries: list[tuple[str, bytes]]) -> bytes:
+        output = BytesIO()
+        with ZipFile(output, "w", compression=ZIP_DEFLATED) as value:
+            for name, content in entries:
+                value.writestr(name, content)
+        return output.getvalue()
+
+    content_types = (
+        b'<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>'
+    )
+    document = (
+        b'<w:document xmlns:w="http://schemas.openxmlformats.org/'
+        b'wordprocessingml/2006/main"/>'
+    )
+    invalid = [
+        archive([("[Content_Types].xml", content_types)]),
+        archive(
+            [
+                ("[Content_Types].xml", content_types),
+                ("word/document.xml", document),
+                ("../private.txt", b"outside"),
+            ]
+        ),
+        archive(
+            [
+                ("[Content_Types].xml", content_types),
+                ("word/document.xml", document),
+                ("word/highly-compressed.bin", b"x" * 2_000_000),
+            ]
+        ),
+    ]
+
+    for index, content in enumerate(invalid):
+        with pytest.raises(ArtifactRepositoryError):
+            repository.store_import(
+                job_id="job-1",
+                document_id="edoc_abcdefghijklmnopqrstuvwx",
+                artifact=write(f"invalid-{index}.docx", DOCX_MEDIA_TYPE, content),
+            )
+
+
+def test_docx_validation_requires_a_coherent_word_ooxml_package(tmp_path, minimal_docx):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+
+    def rewrite(name: str, replacement: bytes | None) -> bytes:
+        source = BytesIO(minimal_docx("(FAKE) valid Word package"))
+        output = BytesIO()
+        with ZipFile(source) as original, ZipFile(
+            output, "w", compression=ZIP_DEFLATED
+        ) as changed:
+            for entry in original.infolist():
+                if entry.filename == name:
+                    if replacement is not None:
+                        changed.writestr(name, replacement)
+                else:
+                    changed.writestr(entry, original.read(entry.filename))
+        return output.getvalue()
+
+    invalid_packages = [
+        rewrite("_rels/.rels", None),
+        rewrite(
+            "_rels/.rels",
+            b'<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            b'<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/'
+            b'officeDocument/2006/relationships/officeDocument" Target="../outside.xml"/>'
+            b"</Relationships>",
+        ),
+        rewrite(
+            "[Content_Types].xml",
+            b'<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+            b'<Override PartName="/word/document.xml" ContentType="application/xml"/>'
+            b"</Types>",
+        ),
+        rewrite("word/document.xml", b"<w:document>"),
+        rewrite(
+            "word/document.xml",
+            b'<w:document xmlns:w="http://schemas.openxmlformats.org/'
+            b'wordprocessingml/2006/main"/>',
+        ),
+        rewrite(
+            "word/document.xml",
+            b'<w:document xmlns:w="http://schemas.openxmlformats.org/'
+            b'wordprocessingml/2006/main"><w:body/><w:body/></w:document>',
+        ),
+    ]
+    for index, content in enumerate(invalid_packages):
+        with pytest.raises(ArtifactValidationError):
+            repository.store_import(
+                job_id="job-1",
+                document_id="edoc_abcdefghijklmnopqrstuvwx",
+                artifact=write(f"invalid-ooxml-{index}.docx", DOCX_MEDIA_TYPE, content),
+            )
+
+
+def test_docx_validation_retains_the_existing_fake_word_fixture(tmp_path):
+    fixture = (
+        Path(__file__).parents[3]
+        / "packages/docx-engine/tests/fixtures/(FAKE)-polished-resume.docx"
+    )
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+
+    stored = repository.store_import(
+        job_id="job-1",
+        document_id="edoc_abcdefghijklmnopqrstuvwx",
+        artifact=write(fixture.name, DOCX_MEDIA_TYPE, fixture.read_bytes()),
+    )
+
+    assert stored.size == fixture.stat().st_size
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        b"prefix%PDF-1.7\nnot a pdf",
+        b"%PDF-1.x\n1 0 obj\n<< /Type /Catalog >>\nendobj\n%%EOF\n",
+        b"%PDF-1.7\narbitrary bytes\n%%EOF\n",
+        b"%PDF-1.7\nstartxref\n999999\n%%EOF\n",
+    ],
+)
+def test_pdf_validation_rejects_prefixes_and_unparseable_structure(tmp_path, content):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    with pytest.raises(ArtifactValidationError):
+        repository.store_import(
+            job_id="job-1",
+            document_id="edoc_abcdefghijklmnopqrstuvwx",
+            artifact=write("invalid.pdf", PDF_MEDIA_TYPE, content),
+        )
+
+
+def test_pdf_validation_rejects_cross_reference_streams(tmp_path):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    content = bytearray(b"%PDF-1.7\n")
+    content.extend(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+    xref_offset = len(content)
+    content.extend(
+        b"3 0 obj\n"
+        b"<< /Type /XRef /Size 4 /Root 1 0 R /W [1 4 2] /Index [0 4] /Length 1 >>\n"
+        b"stream\nX\nendstream\nendobj\n"
+    )
+    content.extend(f"startxref\n{xref_offset}\n%%EOF\n".encode("ascii"))
+
+    with pytest.raises(ArtifactValidationError, match="streams are not supported"):
+        repository.store_import(
+            job_id="job-1",
+            document_id="edoc_abcdefghijklmnopqrstuvwx",
+            artifact=write("xref-stream.pdf", PDF_MEDIA_TYPE, bytes(content)),
+        )
+
+
+def test_caller_filename_limit_reserves_the_hash_prefix(tmp_path, minimal_docx):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    accepted = "a" * (MAX_CALLER_FILENAME_BYTES - len(".docx")) + ".docx"
+    rejected = "a" * (MAX_CALLER_FILENAME_BYTES - len(".docx") + 1) + ".docx"
+
+    stored = repository.store_import(
+        job_id="job-1",
+        document_id="edoc_abcdefghijklmnopqrstuvwx",
+        artifact=write(accepted, DOCX_MEDIA_TYPE, minimal_docx("(FAKE) boundary")),
+    )
+    assert len(stored.canonical_path.name.encode("utf-8")) == 255
+    with pytest.raises(ArtifactValidationError, match="plain filename"):
+        repository.store_import(
+            job_id="job-1",
+            document_id="edoc_abcdefghijklmnopqrstuvwx",
+            artifact=write(rejected, DOCX_MEDIA_TYPE, minimal_docx("(FAKE) too long")),
+        )
+
+
+def test_repository_fsyncs_import_creation_and_publication_rename(
+    tmp_path, minimal_docx, minimal_pdf, monkeypatch
+):
+    fsync_calls: list[tuple[int, int]] = []
+    rename_calls: list[tuple[int | None, int | None]] = []
+    real_fsync = os.fsync
+    real_rename = os.rename
+
+    def record_fsync(descriptor):
+        metadata = os.fstat(descriptor)
+        fsync_calls.append((metadata.st_dev, metadata.st_ino))
+        real_fsync(descriptor)
+
+    def record_rename(source, destination, *, src_dir_fd=None, dst_dir_fd=None):
+        rename_calls.append((src_dir_fd, dst_dir_fd))
+        return real_rename(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+        )
+
+    monkeypatch.setattr(local_repository_module.os, "fsync", record_fsync)
+    monkeypatch.setattr(local_repository_module.os, "rename", record_rename)
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    imported = write("source.docx", DOCX_MEDIA_TYPE, minimal_docx("import"))
+    repository.store_import(
+        job_id="job-1",
+        document_id="edoc_abcdefghijklmnopqrstuvwx",
+        artifact=imported,
+    )
+    pair = repository.store_publication_pair(
+        job_id="job-1",
+        document_id="edoc_abcdefghijklmnopqrstuvwx",
+        document_revision=1,
+        docx=write("resume.docx", DOCX_MEDIA_TYPE, minimal_docx("publication")),
+        pdf=write("resume.pdf", PDF_MEDIA_TYPE, minimal_pdf()),
+    )
+
+    assert len(fsync_calls) >= 10
+    assert rename_calls and all(
+        source is not None and destination is not None for source, destination in rename_calls
+    )
+    assert pair[0].canonical_path.is_file()
+    assert pair[1].canonical_path.is_file()
+
+
+def test_repository_surfaces_parent_fsync_failure_after_successful_publication_rename(
+    tmp_path, minimal_docx, minimal_pdf, monkeypatch
+):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    real_fsync = os.fsync
+    real_rename = os.rename
+    rename_succeeded = False
+
+    def rename_then_mark(source, destination, *, src_dir_fd=None, dst_dir_fd=None):
+        nonlocal rename_succeeded
+        result = real_rename(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+        )
+        rename_succeeded = True
+        return result
+
+    def fail_after_rename(descriptor):
+        if rename_succeeded:
+            raise OSError("synthetic post-rename parent fsync failure")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(local_repository_module.os, "rename", rename_then_mark)
+    monkeypatch.setattr(local_repository_module.os, "fsync", fail_after_rename)
+
+    with pytest.raises(ArtifactStorageError, match="synchronize published"):
+        repository.store_publication_pair(
+            job_id="job-1",
+            document_id="edoc_abcdefghijklmnopqrstuvwx",
+            document_revision=1,
+            docx=write("resume.docx", DOCX_MEDIA_TYPE, minimal_docx("publication")),
+            pdf=write("resume.pdf", PDF_MEDIA_TYPE, minimal_pdf()),
+        )
+
+    assert rename_succeeded
+    destinations = list(
+        (repository.root / "publications/job-1/edoc_abcdefghijklmnopqrstuvwx").glob(
+            "revision-*"
+        )
+    )
+    assert len(destinations) == 1
+
+    replay_parent = destinations[0].parent
+    replay_parent_identity = (replay_parent.stat().st_dev, replay_parent.stat().st_ino)
+    replay_parent_synced = False
+
+    def record_replay_fsync(descriptor):
+        nonlocal replay_parent_synced
+        identity = os.fstat(descriptor)
+        if (identity.st_dev, identity.st_ino) == replay_parent_identity:
+            replay_parent_synced = True
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(local_repository_module.os, "fsync", record_replay_fsync)
+    replay = repository.store_publication_pair(
+        job_id="job-1",
+        document_id="edoc_abcdefghijklmnopqrstuvwx",
+        document_revision=1,
+        docx=write("resume.docx", DOCX_MEDIA_TYPE, minimal_docx("publication")),
+        pdf=write("resume.pdf", PDF_MEDIA_TYPE, minimal_pdf()),
+    )
+
+    assert replay_parent_synced
+    assert replay[0].canonical_path.parent == destinations[0]
+
+
+def test_publication_replay_fsyncs_retained_parent_and_surfaces_failure(
+    tmp_path, minimal_docx, minimal_pdf, monkeypatch
+):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    document_id = "edoc_abcdefghijklmnopqrstuvwx"
+    docx = write("resume.docx", DOCX_MEDIA_TYPE, minimal_docx("publication"))
+    pdf = write("resume.pdf", PDF_MEDIA_TYPE, minimal_pdf())
+    expected = repository.store_publication_pair(
+        job_id="job-1",
+        document_id=document_id,
+        document_revision=1,
+        docx=docx,
+        pdf=pdf,
+    )
+    parent = repository.root / "publications" / "job-1" / document_id
+    parent_identity = (parent.stat().st_dev, parent.stat().st_ino)
+    real_fsync = os.fsync
+    real_rename = os.rename
+    rename_failed = False
+    fsync_failed = False
+
+    def mark_failed_rename(source, destination, *, src_dir_fd=None, dst_dir_fd=None):
+        nonlocal rename_failed
+        try:
+            return real_rename(
+                source,
+                destination,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+            )
+        except OSError:
+            rename_failed = True
+            raise
+
+    def fail_replay_parent_fsync(descriptor):
+        nonlocal fsync_failed
+        identity = os.fstat(descriptor)
+        if (
+            rename_failed
+            and not fsync_failed
+            and (identity.st_dev, identity.st_ino) == parent_identity
+        ):
+            fsync_failed = True
+            raise OSError("synthetic replay parent fsync failure")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(local_repository_module.os, "rename", mark_failed_rename)
+    monkeypatch.setattr(local_repository_module.os, "fsync", fail_replay_parent_fsync)
+
+    with pytest.raises(ArtifactStorageError, match="synchronize published"):
+        repository.store_publication_pair(
+            job_id="job-1",
+            document_id=document_id,
+            document_revision=1,
+            docx=docx,
+            pdf=pdf,
+        )
+
+    assert rename_failed
+    assert fsync_failed
+    assert all(item.canonical_path.is_file() for item in expected)
+
+
+def test_import_cleanup_is_descriptor_relative_and_identity_bound_after_late_verify_swap(
+    tmp_path, minimal_docx, monkeypatch
+):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    document_id = "edoc_abcdefghijklmnopqrstuvwx"
+    artifact = write("source.docx", DOCX_MEDIA_TYPE, minimal_docx("private import"))
+    stored_name = f"{artifact.sha256[:20]}-{artifact.filename}"
+    directory = repository.root / "imports" / "job-1" / document_id
+    held = tmp_path / "held-import"
+    foreign = b"foreign replacement"
+    real_read = local_repository_module.read_open_file
+    swapped = False
+
+    def move_after_verify_read(descriptor, metadata, *, maximum):
+        nonlocal swapped
+        content = real_read(descriptor, metadata, maximum=maximum)
+        if not swapped:
+            directory.rename(held)
+            directory.mkdir()
+            (directory / stored_name).write_bytes(foreign)
+            swapped = True
+        return content
+
+    monkeypatch.setattr(local_repository_module, "read_open_file", move_after_verify_read)
+
+    with pytest.raises(ArtifactStorageError, match="directory changed during storage"):
+        repository.store_import(
+            job_id="job-1",
+            document_id=document_id,
+            artifact=artifact,
+        )
+
+    assert swapped
+    assert list(held.iterdir()) == []
+    assert (directory / stored_name).read_bytes() == foreign
+
+
+@pytest.mark.parametrize("operation", ["import", "pair"])
+def test_post_open_file_replacement_never_succeeds_or_deletes_foreign_file(
+    tmp_path, minimal_docx, minimal_pdf, monkeypatch, operation
+):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    document_id = "edoc_abcdefghijklmnopqrstuvwx"
+    docx = write("resume.docx", DOCX_MEDIA_TYPE, minimal_docx("opened artifact"))
+    stored_name = f"{docx.sha256[:20]}-{docx.filename}"
+    foreign = b"foreign replacement"
+    held = tmp_path / f"held-{operation}.docx"
+    real_read = local_repository_module.read_open_file
+    replaced_path: Path | None = None
+
+    def replace_after_open_read(descriptor, metadata, *, maximum):
+        nonlocal replaced_path
+        content = real_read(descriptor, metadata, maximum=maximum)
+        if replaced_path is None:
+            if operation == "import":
+                target = (
+                    repository.root
+                    / "imports"
+                    / "job-1"
+                    / document_id
+                    / stored_name
+                )
+            else:
+                targets = list(
+                    repository.root.glob(
+                        f"publications/job-1/{document_id}/.publication-*.tmp/{stored_name}"
+                    )
+                )
+                assert len(targets) == 1
+                target = targets[0]
+            target.rename(held)
+            target.write_bytes(foreign)
+            replaced_path = target
+        return content
+
+    monkeypatch.setattr(
+        local_repository_module, "read_open_file", replace_after_open_read
+    )
+
+    with pytest.raises(ArtifactStorageError):
+        if operation == "import":
+            repository.store_import(
+                job_id="job-1", document_id=document_id, artifact=docx
+            )
+        else:
+            repository.store_publication_pair(
+                job_id="job-1",
+                document_id=document_id,
+                document_revision=1,
+                docx=docx,
+                pdf=write("resume.pdf", PDF_MEDIA_TYPE, minimal_pdf()),
+            )
+
+    assert replaced_path is not None
+    assert replaced_path.read_bytes() == foreign
+    assert held.read_bytes() == docx.content
+
+
+def test_publication_cleanup_removes_owned_renamed_pair_after_late_parent_swap(
+    tmp_path, minimal_docx, minimal_pdf, monkeypatch
+):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    document_id = "edoc_abcdefghijklmnopqrstuvwx"
+    docx = write("resume.docx", DOCX_MEDIA_TYPE, minimal_docx("private publication"))
+    pdf = write("resume.pdf", PDF_MEDIA_TYPE, minimal_pdf())
+    parent = repository.root / "publications" / "job-1" / document_id
+    held = tmp_path / "held-publication-parent"
+    foreign = b"foreign replacement"
+    real_rename = os.rename
+    real_read = local_repository_module.read_open_file
+    destination_name: str | None = None
+    swapped = False
+
+    def mark_publication_rename(source, destination, *, src_dir_fd=None, dst_dir_fd=None):
+        nonlocal destination_name
+        result = real_rename(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+        )
+        if src_dir_fd is not None and dst_dir_fd is not None:
+            destination_name = destination
+        return result
+
+    def move_parent_after_published_read(descriptor, metadata, *, maximum):
+        nonlocal swapped
+        content = real_read(descriptor, metadata, maximum=maximum)
+        if destination_name is not None and not swapped:
+            parent.rename(held)
+            replacement = parent / destination_name
+            replacement.mkdir(parents=True)
+            (replacement / f"{docx.sha256[:20]}-{docx.filename}").write_bytes(foreign)
+            swapped = True
+        return content
+
+    monkeypatch.setattr(local_repository_module.os, "rename", mark_publication_rename)
+    monkeypatch.setattr(
+        local_repository_module,
+        "read_open_file",
+        move_parent_after_published_read,
+    )
+
+    with pytest.raises(ArtifactStorageError, match="directory changed during storage"):
+        repository.store_publication_pair(
+            job_id="job-1",
+            document_id=document_id,
+            document_revision=1,
+            docx=docx,
+            pdf=pdf,
+        )
+
+    assert swapped
+    assert not any(path.is_file() for path in held.rglob("*"))
+    replacement = parent / destination_name
+    assert (replacement / f"{docx.sha256[:20]}-{docx.filename}").read_bytes() == foreign
+
+
+def test_repository_initialization_never_deletes_another_process_publication_temp(tmp_path):
+    root = tmp_path / "artifacts"
+    parent = root / "publications/job-1/edoc_abcdefghijklmnopqrstuvwx"
+    orphan = parent / ".publication-0123456789abcdef0123456789abcdef.tmp"
+    orphan.mkdir(parents=True)
+    (orphan / "partial.docx").write_bytes(b"partial")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    private = outside / "private.txt"
+    private.write_bytes(b"private")
+    linked = parent / ".publication-fedcba9876543210fedcba9876543210.tmp"
+    linked.symlink_to(outside, target_is_directory=True)
+
+    LocalArtifactRepository(root)
+
+    assert orphan.is_dir()
+    assert (orphan / "partial.docx").read_bytes() == b"partial"
+    assert linked.is_symlink()
+    assert private.read_bytes() == b"private"
+
+
+def test_repository_construction_during_active_publication_cannot_delete_it(
+    tmp_path, minimal_docx, minimal_pdf, monkeypatch
+):
+    root = tmp_path / "artifacts"
+    publisher = LocalArtifactRepository(root)
+    entered = Event()
+    release = Event()
+    real_store = publisher._store_in
+
+    def pause_first_store(directory, artifact):
+        if directory.path.name.startswith(".publication-") and not entered.is_set():
+            entered.set()
+            assert release.wait(timeout=5)
+        return real_store(directory, artifact)
+
+    monkeypatch.setattr(publisher, "_store_in", pause_first_store)
+    outcome: list[object] = []
+
+    def publish() -> None:
+        try:
+            outcome.append(
+                publisher.store_publication_pair(
+                    job_id="job-1",
+                    document_id="edoc_abcdefghijklmnopqrstuvwx",
+                    document_revision=1,
+                    docx=write("resume.docx", DOCX_MEDIA_TYPE, minimal_docx()),
+                    pdf=write("resume.pdf", PDF_MEDIA_TYPE, minimal_pdf()),
+                )
+            )
+        except BaseException as error:  # surfaced by the assertion below
+            outcome.append(error)
+
+    thread = Thread(target=publish)
+    thread.start()
+    assert entered.wait(timeout=5)
+    active = list(root.glob("publications/*/*/.publication-*.tmp"))
+    assert len(active) == 1
+
+    LocalArtifactRepository(root)
+
+    assert active[0].is_dir()
+    release.set()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert len(outcome) == 1 and isinstance(outcome[0], tuple)
+
+
+def test_publication_write_does_not_follow_a_renamed_temp_path_replaced_by_symlink(
+    tmp_path, minimal_docx, minimal_pdf, monkeypatch
+):
+    repository = LocalArtifactRepository(tmp_path / "artifacts")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    private = outside / "private.txt"
+    private.write_bytes(b"private")
+    held = tmp_path / "held-publication-temp"
+    real_store = repository._store_in
+    swapped = False
+
+    def attempt_after_swap(directory, artifact):
+        nonlocal swapped
+        if not swapped and directory.path.name.startswith(".publication-"):
+            swapped = True
+            directory.path.rename(held)
+            directory.path.symlink_to(outside, target_is_directory=True)
+        return real_store(directory, artifact)
+
+    monkeypatch.setattr(repository, "_store_in", attempt_after_swap)
+    with pytest.raises(ArtifactStorageError, match="directory changed during storage"):
+        repository.store_publication_pair(
+            job_id="job-1",
+            document_id="edoc_abcdefghijklmnopqrstuvwx",
+            document_revision=1,
+            docx=write("resume.docx", DOCX_MEDIA_TYPE, minimal_docx()),
+            pdf=write("resume.pdf", PDF_MEDIA_TYPE, minimal_pdf()),
+        )
+
+    assert swapped
+    assert private.read_bytes() == b"private"
+    assert held.is_dir()
+    assert list(held.iterdir()) == []
+    assert list(outside.iterdir()) == [private]
+
+
+def test_local_repository_rejects_a_symlink_root(tmp_path):
+    target = tmp_path / "real-artifacts"
+    target.mkdir()
+    link = tmp_path / "linked-artifacts"
+    os.symlink(target, link)
+
+    with pytest.raises(ArtifactRepositoryError, match="root must not be a symbolic link"):
+        LocalArtifactRepository(link)
+
+
+def test_descriptor_read_does_not_follow_a_post_open_file_swap(
+    tmp_path, minimal_docx, monkeypatch
+):
+    root = tmp_path / "artifacts"
+    root.mkdir()
+    original = minimal_docx("inside")
+    outside_bytes = minimal_docx("outside private bytes")
+    target = root / "resume.docx"
+    target.write_bytes(original)
+    outside = tmp_path / "outside.docx"
+    outside.write_bytes(outside_bytes)
+    held = root / "held.docx"
+    real_open = os.open
+    swapped = False
+
+    def racing_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        descriptor = real_open(path, flags, mode, dir_fd=dir_fd)
+        if path == target.name and dir_fd is not None and not swapped:
+            swapped = True
+            target.rename(held)
+            target.symlink_to(outside)
+        return descriptor
+
+    monkeypatch.setattr(artifact_repository_module.os, "open", racing_open)
+    _, content = verify_artifact_file(
+        target,
+        roots=(root,),
+        media_type=DOCX_MEDIA_TYPE,
+        expected_sha256=sha256(original).hexdigest(),
+    )
+
+    assert swapped
+    assert content == original
+    assert content != outside_bytes
+
+
+def test_descriptor_read_does_not_follow_a_post_open_ancestor_swap(
+    tmp_path, minimal_docx, monkeypatch
+):
+    root = tmp_path / "artifacts"
+    nested = root / "job-1"
+    nested.mkdir(parents=True)
+    original = minimal_docx("inside ancestor")
+    target = nested / "resume.docx"
+    target.write_bytes(original)
+    outside_directory = tmp_path / "outside"
+    outside_directory.mkdir()
+    outside_bytes = minimal_docx("outside ancestor bytes")
+    (outside_directory / target.name).write_bytes(outside_bytes)
+    held = root / "held-job-1"
+    real_open = os.open
+    swapped = False
+
+    def racing_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        descriptor = real_open(path, flags, mode, dir_fd=dir_fd)
+        if path == nested.name and dir_fd is not None and not swapped:
+            swapped = True
+            nested.rename(held)
+            nested.symlink_to(outside_directory, target_is_directory=True)
+        return descriptor
+
+    monkeypatch.setattr(artifact_repository_module.os, "open", racing_open)
+    _, content = verify_artifact_file(
+        target,
+        roots=(root,),
+        media_type=DOCX_MEDIA_TYPE,
+        expected_sha256=sha256(original).hexdigest(),
+    )
+
+    assert swapped
+    assert content == original
+    assert content != outside_bytes

--- a/services/api/tests/test_local_artifact_transactions.py
+++ b/services/api/tests/test_local_artifact_transactions.py
@@ -1,0 +1,556 @@
+from __future__ import annotations
+
+import base64
+from concurrent.futures import ThreadPoolExecutor
+from hashlib import sha256
+from pathlib import Path
+from threading import Barrier
+
+import jobos_api.local_artifact_repository as local_repository_module
+from fastapi.testclient import TestClient
+from jobos_api.app import LOCAL_ARTIFACT_STORAGE_UNAVAILABLE, create_app
+from jobos_api.artifact_repository import ArtifactWrite
+from jobos_api.editable_documents import blank_content, default_settings
+from jobos_api.local_artifact_repository import LocalArtifactRepository
+from jobos_api.settings import Settings
+from jobos_api.state_store import JobOsStateStore
+
+HEADERS = {"Authorization": "Bearer local-device-token"}
+
+
+def configured_settings(tmp_path: Path) -> Settings:
+    return Settings(
+        device_token="local-device-token",
+        mcp_token="local-mcp-test-token",
+        state_db_path=tmp_path / "state/jobos.db",
+        jobs_db_path=tmp_path / "jobs/jobs.db",
+        local_artifact_root=tmp_path / "artifacts",
+    )
+
+
+def create_job(client: TestClient, suffix: str = "transaction") -> dict[str, object]:
+    response = client.post(
+        "/v1/jobs",
+        headers=HEADERS,
+        json={
+            "company_name": f"(FAKE) {suffix} Company",
+            "title": f"(FAKE) {suffix} Role",
+            "canonical_url": f"https://example.com/{suffix}",
+            "location_text": "Example City",
+            "description_text": "Synthetic transaction coverage.",
+            "application_url": f"https://example.com/{suffix}/apply",
+            "idempotency_key": f"job-{suffix}",
+        },
+    )
+    assert response.status_code == 200
+    return response.json()["job"]
+
+
+def create_blank_document(client: TestClient, job_id: str) -> dict[str, object]:
+    response = client.post(
+        f"/v1/jobs/{job_id}/editable-documents",
+        headers=HEADERS,
+        json={
+            "mode": "blank",
+            "document_key": "resume",
+            "idempotency_key": f"blank-{job_id}",
+        },
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def external_import_payload(
+    *,
+    source: bytes,
+    content: dict[str, object],
+    settings: dict[str, object],
+    idempotency_key: str,
+) -> dict[str, object]:
+    return {
+        "mode": "import_external_docx",
+        "document_key": "resume",
+        "source_filename": "(FAKE)-Imported.docx",
+        "source_base64": base64.b64encode(source).decode(),
+        "source_sha256": sha256(source).hexdigest(),
+        "content": content,
+        "settings": settings,
+        "import_report": {
+            "source_filename": "(FAKE)-Imported.docx",
+            "imported_at": "2026-08-15T12:00:00Z",
+            "issues": [],
+        },
+        "idempotency_key": idempotency_key,
+    }
+
+
+def publication_payload(
+    *, docx: bytes, pdf: bytes, revision: int, idempotency_key: str
+) -> dict[str, object]:
+    return {
+        "expected_revision": revision,
+        "docx_filename": "(FAKE)-Resume.docx",
+        "docx_base64": base64.b64encode(docx).decode(),
+        "docx_sha256": sha256(docx).hexdigest(),
+        "pdf_filename": "(FAKE)-Resume.pdf",
+        "pdf_base64": base64.b64encode(pdf).decode(),
+        "pdf_sha256": sha256(pdf).hexdigest(),
+        "idempotency_key": idempotency_key,
+    }
+
+
+class CallbackImportRepository(LocalArtifactRepository):
+    callback = None
+
+    def store_import(self, *, job_id: str, document_id: str, artifact: ArtifactWrite):
+        stored = super().store_import(
+            job_id=job_id, document_id=document_id, artifact=artifact
+        )
+        if self.callback is not None:
+            callback, self.callback = self.callback, None
+            callback()
+        return stored
+
+
+class FailingArtifactRepository(LocalArtifactRepository):
+    def store_import(self, *, job_id: str, document_id: str, artifact: ArtifactWrite):
+        raise PermissionError("synthetic storage failure")
+
+    def store_publication_pair(self, **kwargs):
+        raise OSError("synthetic fsync failure")
+
+
+def test_external_replace_conflict_rolls_back_artifact_metadata(tmp_path, minimal_docx):
+    settings = configured_settings(tmp_path)
+    state_store = JobOsStateStore(settings.state_db_path)
+    repository = CallbackImportRepository(settings.resolved_local_artifact_root())
+    app = create_app(settings, state_store=state_store, artifact_repository=repository)
+    with TestClient(app) as client:
+        job = create_job(client, "replace-conflict")
+        document = create_blank_document(client, str(job["job_id"]))
+
+        def concurrent_edit() -> None:
+            state_store.save_editable_document(
+                str(document["document_id"]),
+                expected_revision=int(document["revision"]),
+                content=document["content"],
+                settings=document["settings"],
+                comments=[],
+            )
+
+        repository.callback = concurrent_edit
+        source = minimal_docx("replace conflict")
+        response = client.post(
+            f"/v1/editable-documents/{document['document_id']}/import",
+            headers=HEADERS,
+            json={
+                "base_revision": document["revision"],
+                "source": external_import_payload(
+                    source=source,
+                    content=document["content"],
+                    settings=document["settings"],
+                    idempotency_key="replace-conflict-source",
+                ),
+                "idempotency_key": "replace-conflict",
+            },
+        )
+        artifacts = client.get(
+            f"/v1/jobs/{job['job_id']}/artifacts", headers=HEADERS
+        ).json()["artifacts"]
+
+    assert response.status_code == 409
+    assert artifacts == []
+
+
+def test_external_create_conflict_rolls_back_artifact_metadata(tmp_path, minimal_docx):
+    settings = configured_settings(tmp_path)
+    state_store = JobOsStateStore(settings.state_db_path)
+    repository = CallbackImportRepository(settings.resolved_local_artifact_root())
+    app = create_app(settings, state_store=state_store, artifact_repository=repository)
+    with TestClient(app) as client:
+        job = create_job(client, "create-conflict")
+        content = blank_content("resume")
+        settings_value = default_settings()
+
+        def competing_create() -> None:
+            state_store.create_editable_document(
+                job_id=str(job["job_id"]),
+                document_key="resume",
+                document_label="Resume",
+                content=content,
+                settings=settings_value,
+                comments=[],
+                import_report={"source_filename": None, "imported_at": None, "issues": []},
+            )
+
+        repository.callback = competing_create
+        source = minimal_docx("create conflict")
+        response = client.post(
+            f"/v1/jobs/{job['job_id']}/editable-documents",
+            headers=HEADERS,
+            json=external_import_payload(
+                source=source,
+                content=content,
+                settings=settings_value,
+                idempotency_key="create-conflict",
+            ),
+        )
+        artifacts = client.get(
+            f"/v1/jobs/{job['job_id']}/artifacts", headers=HEADERS
+        ).json()["artifacts"]
+
+    assert response.status_code == 409
+    assert artifacts == []
+
+
+def test_import_and_publication_storage_failures_are_stable_503(
+    tmp_path, minimal_docx, minimal_pdf
+):
+    settings = configured_settings(tmp_path)
+    repository = FailingArtifactRepository(settings.resolved_local_artifact_root())
+    with TestClient(create_app(settings, artifact_repository=repository)) as client:
+        job = create_job(client, "storage-errors")
+        content = blank_content("resume")
+        settings_value = default_settings()
+        source = minimal_docx("storage error")
+        imported = client.post(
+            f"/v1/jobs/{job['job_id']}/editable-documents",
+            headers=HEADERS,
+            json=external_import_payload(
+                source=source,
+                content=content,
+                settings=settings_value,
+                idempotency_key="storage-import",
+            ),
+        )
+        document = create_blank_document(client, str(job["job_id"]))
+        published = client.post(
+            f"/v1/editable-documents/{document['document_id']}/publish",
+            headers=HEADERS,
+            json=publication_payload(
+                docx=source,
+                pdf=minimal_pdf(),
+                revision=int(document["revision"]),
+                idempotency_key="storage-publish",
+            ),
+        )
+
+    assert (imported.status_code, imported.json()["detail"]) == (
+        503,
+        LOCAL_ARTIFACT_STORAGE_UNAVAILABLE,
+    )
+    assert (published.status_code, published.json()["detail"]) == (
+        503,
+        LOCAL_ARTIFACT_STORAGE_UNAVAILABLE,
+    )
+
+
+def test_import_and_publication_validation_failures_remain_422(tmp_path, minimal_pdf):
+    settings = configured_settings(tmp_path)
+    with TestClient(create_app(settings)) as client:
+        job = create_job(client, "validation-errors")
+        content = blank_content("resume")
+        settings_value = default_settings()
+        malformed = b"PK\x03\x04not-a-docx"
+        imported = client.post(
+            f"/v1/jobs/{job['job_id']}/editable-documents",
+            headers=HEADERS,
+            json=external_import_payload(
+                source=malformed,
+                content=content,
+                settings=settings_value,
+                idempotency_key="validation-import",
+            ),
+        )
+        document = create_blank_document(client, str(job["job_id"]))
+        published = client.post(
+            f"/v1/editable-documents/{document['document_id']}/publish",
+            headers=HEADERS,
+            json=publication_payload(
+                docx=malformed,
+                pdf=minimal_pdf(),
+                revision=int(document["revision"]),
+                idempotency_key="validation-publish",
+            ),
+        )
+
+    assert imported.status_code == 422
+    assert published.status_code == 422
+
+
+def test_replaced_repository_root_and_destination_mismatch_are_stable_503(
+    tmp_path, minimal_docx, minimal_pdf
+):
+    settings = configured_settings(tmp_path)
+    repository = LocalArtifactRepository(settings.resolved_local_artifact_root())
+    with TestClient(create_app(settings, artifact_repository=repository)) as client:
+        job = create_job(client, "repository-integrity")
+        source = minimal_docx("(FAKE) replaced root")
+        held_root = tmp_path / "held-artifacts"
+        repository.root.rename(held_root)
+        outside = tmp_path / "outside-artifacts"
+        outside.mkdir()
+        repository.root.symlink_to(outside, target_is_directory=True)
+        replaced_root = client.post(
+            f"/v1/jobs/{job['job_id']}/editable-documents",
+            headers=HEADERS,
+            json=external_import_payload(
+                source=source,
+                content=blank_content("resume"),
+                settings=default_settings(),
+                idempotency_key="replaced-root",
+            ),
+        )
+
+    settings = configured_settings(tmp_path / "destination")
+    repository = LocalArtifactRepository(settings.resolved_local_artifact_root())
+    with TestClient(create_app(settings, artifact_repository=repository)) as client:
+        job = create_job(client, "destination-mismatch")
+        document = create_blank_document(client, str(job["job_id"]))
+        docx = minimal_docx("(FAKE) destination mismatch")
+        pdf = minimal_pdf("(FAKE) destination mismatch")
+        docx_hash = sha256(docx).hexdigest()
+        pdf_hash = sha256(pdf).hexdigest()
+        pair_hash = sha256(
+            f"{document['revision']}\0{docx_hash}\0{pdf_hash}".encode("ascii")
+        ).hexdigest()
+        parent = repository._directory(
+            "publications", str(job["job_id"]), str(document["document_id"])
+        )
+        (parent / f"revision-{document['revision']}-{pair_hash[:20]}").write_bytes(
+            b"not a publication directory"
+        )
+        mismatch = client.post(
+            f"/v1/editable-documents/{document['document_id']}/publish",
+            headers=HEADERS,
+            json=publication_payload(
+                docx=docx,
+                pdf=pdf,
+                revision=int(document["revision"]),
+                idempotency_key="destination-mismatch",
+            ),
+        )
+
+    assert (replaced_root.status_code, replaced_root.json()["detail"]) == (
+        503,
+        LOCAL_ARTIFACT_STORAGE_UNAVAILABLE,
+    )
+    assert (mismatch.status_code, mismatch.json()["detail"]) == (
+        503,
+        LOCAL_ARTIFACT_STORAGE_UNAVAILABLE,
+    )
+
+
+def test_too_long_caller_filename_is_422(tmp_path, minimal_docx):
+    settings = configured_settings(tmp_path)
+    with TestClient(create_app(settings)) as client:
+        job = create_job(client, "filename-boundary")
+        payload = external_import_payload(
+            source=minimal_docx("(FAKE) filename boundary"),
+            content=blank_content("resume"),
+            settings=default_settings(),
+            idempotency_key="filename-boundary",
+        )
+        payload["source_filename"] = "a" * 230 + ".docx"
+        response = client.post(
+            f"/v1/jobs/{job['job_id']}/editable-documents",
+            headers=HEADERS,
+            json=payload,
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Artifact filename must be a plain filename"
+
+
+def test_import_fsync_failure_never_registers_metadata_and_retry_resyncs(
+    tmp_path, minimal_docx, monkeypatch
+):
+    settings = configured_settings(tmp_path)
+    app = create_app(settings)
+    with TestClient(app) as client:
+        job = create_job(client, "fsync-retry")
+        source = minimal_docx("fsync retry")
+        payload = external_import_payload(
+            source=source,
+            content=blank_content("resume"),
+            settings=default_settings(),
+            idempotency_key="fsync-retry",
+        )
+        real_write_new_file_at = local_repository_module.write_new_file_at
+
+        def fail_after_write(directory_descriptor, filename, content):
+            real_write_new_file_at(directory_descriptor, filename, content)
+            raise OSError("synthetic directory fsync failure")
+
+        monkeypatch.setattr(
+            local_repository_module, "write_new_file_at", fail_after_write
+        )
+        failed = client.post(
+            f"/v1/jobs/{job['job_id']}/editable-documents",
+            headers=HEADERS,
+            json=payload,
+        )
+        after_failure = client.get(
+            f"/v1/jobs/{job['job_id']}/artifacts", headers=HEADERS
+        ).json()["artifacts"]
+        monkeypatch.setattr(
+            local_repository_module, "write_new_file_at", real_write_new_file_at
+        )
+        retried = client.post(
+            f"/v1/jobs/{job['job_id']}/editable-documents",
+            headers=HEADERS,
+            json=payload,
+        )
+        after_retry = client.get(
+            f"/v1/jobs/{job['job_id']}/artifacts", headers=HEADERS
+        ).json()["artifacts"]
+
+    assert (failed.status_code, failed.json()["detail"]) == (
+        503,
+        LOCAL_ARTIFACT_STORAGE_UNAVAILABLE,
+    )
+    assert after_failure == []
+    assert retried.status_code == 201
+    assert len(after_retry) == 1
+
+
+def test_post_rename_publication_fsync_failure_is_503_without_success_registration(
+    tmp_path, minimal_docx, minimal_pdf, monkeypatch
+):
+    settings = configured_settings(tmp_path)
+    state_store = JobOsStateStore(settings.state_db_path)
+    repository = LocalArtifactRepository(settings.resolved_local_artifact_root())
+    app = create_app(settings, state_store=state_store, artifact_repository=repository)
+    with TestClient(app) as client:
+        job = create_job(client, "publication-post-rename-fsync")
+        document = create_blank_document(client, str(job["job_id"]))
+        real_fsync = local_repository_module.os.fsync
+        real_rename = local_repository_module.os.rename
+        rename_succeeded = False
+
+        def rename_then_mark(source, destination, *, src_dir_fd=None, dst_dir_fd=None):
+            nonlocal rename_succeeded
+            result = real_rename(
+                source,
+                destination,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+            )
+            rename_succeeded = True
+            return result
+
+        def fail_after_rename(descriptor):
+            if rename_succeeded:
+                raise OSError("synthetic post-rename parent fsync failure")
+            real_fsync(descriptor)
+
+        monkeypatch.setattr(local_repository_module.os, "rename", rename_then_mark)
+        monkeypatch.setattr(local_repository_module.os, "fsync", fail_after_rename)
+        failed = client.post(
+            f"/v1/editable-documents/{document['document_id']}/publish",
+            headers=HEADERS,
+            json=publication_payload(
+                docx=minimal_docx("post-rename fsync failure"),
+                pdf=minimal_pdf("(FAKE) post-rename fsync failure"),
+                revision=int(document["revision"]),
+                idempotency_key="post-rename-fsync-failure",
+            ),
+        )
+
+    artifacts, current, last_successful, approved = state_store.list_document_artifacts(
+        str(job["job_id"])
+    )
+    persisted_document = state_store.get_editable_document(str(document["document_id"]))
+    assert rename_succeeded
+    assert (failed.status_code, failed.json()["detail"]) == (
+        503,
+        LOCAL_ARTIFACT_STORAGE_UNAVAILABLE,
+    )
+    assert artifacts == []
+    assert (current, last_successful, approved) == (None, None, None)
+    assert persisted_document is not None
+    assert persisted_document["published_revision"] is None
+
+
+def test_concurrent_different_publication_pairs_accept_exactly_one(
+    tmp_path, minimal_docx, minimal_pdf
+):
+    settings = configured_settings(tmp_path)
+    app = create_app(settings)
+    with TestClient(app) as client:
+        job = create_job(client, "publication-race")
+        document = create_blank_document(client, str(job["job_id"]))
+        payloads = [
+            publication_payload(
+                docx=minimal_docx(f"publication {index}"),
+                pdf=minimal_pdf(f"(FAKE) publication {index}"),
+                revision=int(document["revision"]),
+                idempotency_key=f"publication-race-{index}",
+            )
+            for index in range(2)
+        ]
+        barrier = Barrier(2)
+
+        def publish(payload: dict[str, object]):
+            barrier.wait()
+            return client.post(
+                f"/v1/editable-documents/{document['document_id']}/publish",
+                headers=HEADERS,
+                json=payload,
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            responses = list(executor.map(publish, payloads))
+        artifacts = client.get(
+            f"/v1/jobs/{job['job_id']}/artifacts", headers=HEADERS
+        ).json()["artifacts"]
+
+    assert sorted(response.status_code for response in responses) == [200, 409]
+    assert len(artifacts) == 2
+    successful_index = next(
+        index for index, response in enumerate(responses) if response.status_code == 200
+    )
+    successful = payloads[successful_index]
+    assert {artifact["sha256"] for artifact in artifacts} == {
+        successful["docx_sha256"],
+        successful["pdf_sha256"],
+    }
+
+
+def test_concurrent_identical_publication_pair_is_idempotent(
+    tmp_path, minimal_docx, minimal_pdf
+):
+    settings = configured_settings(tmp_path)
+    app = create_app(settings)
+    with TestClient(app) as client:
+        job = create_job(client, "publication-replay")
+        document = create_blank_document(client, str(job["job_id"]))
+        docx = minimal_docx("identical publication")
+        pdf = minimal_pdf("(FAKE) identical publication")
+        payloads = [
+            publication_payload(
+                docx=docx,
+                pdf=pdf,
+                revision=int(document["revision"]),
+                idempotency_key=f"publication-replay-{index}",
+            )
+            for index in range(2)
+        ]
+        barrier = Barrier(2)
+
+        def publish(payload: dict[str, object]):
+            barrier.wait()
+            return client.post(
+                f"/v1/editable-documents/{document['document_id']}/publish",
+                headers=HEADERS,
+                json=payload,
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            responses = list(executor.map(publish, payloads))
+        artifacts = client.get(
+            f"/v1/jobs/{job['job_id']}/artifacts", headers=HEADERS
+        ).json()["artifacts"]
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert len(artifacts) == 2

--- a/services/api/tests/test_macos_runtime.py
+++ b/services/api/tests/test_macos_runtime.py
@@ -93,6 +93,7 @@ def test_service_environment_and_uvicorn_command_are_fixed_and_loopback_only(tmp
         "JOBOS_DEVICE_ID": "mini-device",
         "JOBOS_STATE_DB_PATH": str(tmp_path / "state/jobos.db"),
         "JOBOS_JOB_PROVIDER": "job-hunter",
+        "JOBOS_ARTIFACT_PROVIDER": "gateway",
         "JOBOS_JOB_HUNTER_DB_PATH": str(tmp_path / "job-hunter/data/jobs/jobs.db"),
         "JOBOS_ARTIFACT_ROOTS": str(tmp_path / "job-hunter/resume/exports"),
         "JOBOS_HERMES_DASHBOARD_URL": "ws://127.0.0.1:9119/api/ws",

--- a/services/api/tests/test_main_error_boundary.py
+++ b/services/api/tests/test_main_error_boundary.py
@@ -1,0 +1,26 @@
+import importlib
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def test_untrusted_local_artifact_root_returns_setup_required(tmp_path, monkeypatch):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.symlink_to(outside, target_is_directory=True)
+    monkeypatch.setenv("JOBOS_DEVICE_TOKEN", "local-device-token")
+    monkeypatch.setenv("JOBOS_MCP_TOKEN", "local-mcp-test-token")
+    monkeypatch.setenv("JOBOS_STATE_DB_PATH", str(tmp_path / "state/jobos.db"))
+    monkeypatch.setenv("JOBOS_JOBS_DB_PATH", str(tmp_path / "jobs/jobs.db"))
+    monkeypatch.setenv("JOBOS_LOCAL_ARTIFACT_ROOT", str(artifact_root))
+    sys.modules.pop("jobos_api.main", None)
+
+    main = importlib.import_module("jobos_api.main")
+    with TestClient(main.app) as client:
+        response = client.get("/v1/health")
+
+    assert response.status_code == 503
+    assert response.json()["status"] == "setup_required"
+    assert "artifact" in response.json()["detail"].casefold()
+    sys.modules.pop("jobos_api.main", None)

--- a/services/api/tests/test_public_composition.py
+++ b/services/api/tests/test_public_composition.py
@@ -1,6 +1,15 @@
+import base64
+from hashlib import sha256
+
 from fastapi.testclient import TestClient
 from jobos_api.app import create_app
+from jobos_api.artifact_gateway import UnavailableArtifactGateway
 from jobos_api.settings import Settings
+
+
+class FailingRefreshArtifactGateway(UnavailableArtifactGateway):
+    def list_job_artifacts(self, job_id: str):
+        raise OSError("synthetic artifact read failure")
 
 
 def test_public_composition_starts_without_private_services(tmp_path):
@@ -24,3 +33,305 @@ def test_public_composition_starts_without_private_services(tmp_path):
     assert response.status_code == 200
     assert response.json()["status"] == "ready"
     assert response.json()["agent_connection"] == "offline"
+
+
+def test_sqlite_local_editable_lifecycle_survives_restart_and_downloads_pair(
+    tmp_path, minimal_docx, minimal_pdf
+):
+    settings = Settings(
+        device_token="local-device-token",
+        mcp_token="local-mcp-test-token",
+        state_db_path=tmp_path / "application-data/state/jobos.db",
+        jobs_db_path=tmp_path / "application-data/jobs/jobs.db",
+        local_artifact_root=tmp_path / "application-data/artifacts",
+    )
+    headers = {"Authorization": "Bearer local-device-token"}
+    with TestClient(create_app(settings)) as client:
+        job = client.post(
+            "/v1/jobs",
+            headers=headers,
+            json={
+                "company_name": "(FAKE) Local Lifecycle Company",
+                "title": "(FAKE) Local Lifecycle Role",
+                "canonical_url": "https://example.com/(FAKE)-local-lifecycle",
+                "location_text": "Example City",
+                "description_text": "Synthetic local lifecycle test job.",
+                "application_url": "https://example.com/(FAKE)-local-lifecycle/apply",
+                "idempotency_key": "local-lifecycle-job",
+            },
+        ).json()["job"]
+        created = client.post(
+            f"/v1/jobs/{job['job_id']}/editable-documents",
+            headers=headers,
+            json={
+                "mode": "blank",
+                "document_key": "resume",
+                "idempotency_key": "local-lifecycle-create",
+            },
+        ).json()
+        content = created["content"]
+        content["content"][1]["content"][0]["content"] = [
+            {"type": "text", "text": "(FAKE) Autosave-like local edit."}
+        ]
+        saved = client.put(
+            f"/v1/editable-documents/{created['document_id']}",
+            headers=headers,
+            json={
+                "base_revision": created["revision"],
+                "content": content,
+                "settings": created["settings"],
+                "comments": [],
+                "idempotency_key": "local-lifecycle-save",
+            },
+        ).json()
+        snapshot = client.post(
+            f"/v1/editable-documents/{created['document_id']}/snapshots",
+            headers=headers,
+            json={
+                "base_revision": saved["revision"],
+                "label": "(FAKE) Before local publication",
+                "idempotency_key": "local-lifecycle-snapshot",
+            },
+        )
+        assert snapshot.status_code == 201
+
+    with TestClient(create_app(settings)) as restarted:
+        reopened = restarted.get(
+            f"/v1/editable-documents/{created['document_id']}", headers=headers
+        ).json()
+        assert reopened == saved
+        imported_docx = minimal_docx("(FAKE) local import")
+        imported = restarted.post(
+            f"/v1/editable-documents/{created['document_id']}/import",
+            headers=headers,
+            json={
+                "base_revision": reopened["revision"],
+                "source": {
+                    "mode": "import_external_docx",
+                    "document_key": "resume",
+                    "source_filename": "(FAKE)-Imported-Resume.docx",
+                    "source_base64": base64.b64encode(imported_docx).decode(),
+                    "source_sha256": sha256(imported_docx).hexdigest(),
+                    "content": reopened["content"],
+                    "settings": reopened["settings"],
+                    "import_report": {
+                        "source_filename": "(FAKE)-Imported-Resume.docx",
+                        "imported_at": "2026-08-15T12:00:00Z",
+                        "issues": [],
+                    },
+                    "idempotency_key": "local-lifecycle-import-source",
+                },
+                "idempotency_key": "local-lifecycle-import",
+            },
+        )
+        assert imported.status_code == 200
+        imported_document = imported.json()
+        assert imported_document["revision"] == reopened["revision"] + 1
+        docx = minimal_docx("(FAKE) local lifecycle DOCX")
+        pdf = minimal_pdf("(FAKE) local lifecycle PDF")
+        publish = restarted.post(
+            f"/v1/editable-documents/{created['document_id']}/publish",
+            headers=headers,
+            json={
+                "expected_revision": imported_document["revision"],
+                "docx_filename": "(FAKE)-Local-Resume.docx",
+                "docx_base64": base64.b64encode(docx).decode(),
+                "docx_sha256": sha256(docx).hexdigest(),
+                "pdf_filename": "(FAKE)-Local-Resume.pdf",
+                "pdf_base64": base64.b64encode(pdf).decode(),
+                "pdf_sha256": sha256(pdf).hexdigest(),
+                "idempotency_key": "local-lifecycle-publish",
+            },
+        )
+        assert publish.status_code == 200
+        assert publish.json()["published_revision"] == imported_document["revision"]
+
+    with TestClient(create_app(settings)) as restarted_again:
+        artifacts = restarted_again.get(
+            f"/v1/jobs/{job['job_id']}/artifacts", headers=headers
+        ).json()["artifacts"]
+        assert len(artifacts) == 3
+        expected = {
+            sha256(pdf).hexdigest(): pdf,
+            sha256(docx).hexdigest(): docx,
+            sha256(imported_docx).hexdigest(): imported_docx,
+        }
+        for artifact in artifacts:
+            response = restarted_again.get(
+                f"/v1/artifacts/{artifact['artifact_id']}/download", headers=headers
+            )
+            assert response.status_code == 200
+            assert response.content == expected[artifact["sha256"]]
+            assert response.headers["x-content-sha256"] == sha256(response.content).hexdigest()
+
+
+def test_private_artifact_capabilities_report_stable_unconfigured_errors(
+    tmp_path, minimal_docx, minimal_pdf
+):
+    settings = Settings(
+        device_token="local-device-token",
+        mcp_token="local-mcp-test-token",
+        state_db_path=tmp_path / "state/jobos.db",
+    )
+    headers = {"Authorization": "Bearer local-device-token"}
+    with TestClient(create_app(settings)) as client:
+        job = client.post(
+            "/v1/jobs",
+            headers=headers,
+            json={
+                "company_name": "(FAKE) Capability Company",
+                "title": "(FAKE) Capability Role",
+                "canonical_url": "https://example.com/(FAKE)-capability",
+                "location_text": "Example City",
+                "description_text": "Synthetic capability test job.",
+                "application_url": "https://example.com/(FAKE)-capability/apply",
+                "idempotency_key": "capability-job",
+            },
+        ).json()["job"]
+        refreshed = client.post(f"/v1/jobs/{job['job_id']}/artifacts/refresh", headers=headers)
+        rendered = client.post(
+            f"/v1/jobs/{job['job_id']}/artifacts/render",
+            headers=headers,
+            json={
+                "source_id": "source-1",
+                "origin": "user",
+                "idempotency_key": "capability-render",
+            },
+        )
+        registered = client.post(
+            f"/v1/jobs/{job['job_id']}/artifacts/register",
+            headers=headers,
+            json={
+                "artifact_reference": "private-artifact-reference",
+                "origin": "user",
+                "idempotency_key": "capability-register",
+            },
+        )
+        published = client.post(
+            f"/v1/jobs/{job['job_id']}/artifacts/publish",
+            headers=headers,
+            json={
+                "document_key": "resume",
+                "document_label": "Resume",
+                "source_filename": "source.docx",
+                "source_base64": base64.b64encode(minimal_docx("source")).decode(),
+                "artifact_filename": "resume.pdf",
+                "artifact_base64": base64.b64encode(minimal_pdf()).decode(),
+                "origin": "user",
+                "idempotency_key": "capability-publish",
+            },
+        )
+
+    assert (refreshed.status_code, refreshed.json()["detail"]) == (
+        503,
+        "JobHunter artifact refresh is unconfigured",
+    )
+    assert (rendered.status_code, rendered.json()["detail"]) == (
+        503,
+        "JobHunter artifact rendering is unconfigured",
+    )
+    assert (registered.status_code, registered.json()["detail"]) == (
+        503,
+        "JobHunter artifact registration is unconfigured",
+    )
+    assert (published.status_code, published.json()["detail"]) == (
+        503,
+        "JobHunter artifact publication is unconfigured",
+    )
+
+
+def test_artifact_refresh_maps_filesystem_failures_to_stable_503(tmp_path):
+    settings = Settings(
+        device_token="local-device-token",
+        mcp_token="local-mcp-test-token",
+        state_db_path=tmp_path / "state/jobos.db",
+    )
+    headers = {"Authorization": "Bearer local-device-token"}
+    app = create_app(settings, artifact_gateway=FailingRefreshArtifactGateway())
+    with TestClient(app) as client:
+        job = client.post(
+            "/v1/jobs",
+            headers=headers,
+            json={
+                "company_name": "(FAKE) Refresh Failure Company",
+                "title": "(FAKE) Refresh Failure Role",
+                "canonical_url": "https://example.com/(FAKE)-refresh-failure",
+                "location_text": "Example City",
+                "description_text": "Synthetic artifact failure test.",
+                "application_url": "https://example.com/(FAKE)-refresh-failure/apply",
+                "idempotency_key": "refresh-failure-job",
+            },
+        ).json()["job"]
+        response = client.post(
+            f"/v1/jobs/{job['job_id']}/artifacts/refresh", headers=headers
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Local artifact storage is unavailable"
+
+
+def test_local_artifact_download_maps_filesystem_failures_to_stable_503(
+    tmp_path, minimal_docx, minimal_pdf, monkeypatch
+):
+    settings = Settings(
+        device_token="local-device-token",
+        mcp_token="local-mcp-test-token",
+        state_db_path=tmp_path / "state/jobos.db",
+        jobs_db_path=tmp_path / "jobs/jobs.db",
+        local_artifact_root=tmp_path / "artifacts",
+    )
+    headers = {"Authorization": "Bearer local-device-token"}
+    with TestClient(create_app(settings)) as client:
+        job = client.post(
+            "/v1/jobs",
+            headers=headers,
+            json={
+                "company_name": "(FAKE) Download Failure Company",
+                "title": "(FAKE) Download Failure Role",
+                "canonical_url": "https://example.com/(FAKE)-download-failure",
+                "location_text": "Example City",
+                "description_text": "Synthetic download failure test.",
+                "application_url": "https://example.com/(FAKE)-download-failure/apply",
+                "idempotency_key": "download-failure-job",
+            },
+        ).json()["job"]
+        document = client.post(
+            f"/v1/jobs/{job['job_id']}/editable-documents",
+            headers=headers,
+            json={
+                "mode": "blank",
+                "document_key": "resume",
+                "idempotency_key": "download-failure-document",
+            },
+        ).json()
+        docx = minimal_docx("(FAKE) local download failure")
+        pdf = minimal_pdf("(FAKE) local download failure")
+        published = client.post(
+            f"/v1/editable-documents/{document['document_id']}/publish",
+            headers=headers,
+            json={
+                "expected_revision": document["revision"],
+                "docx_filename": "(FAKE)-Resume.docx",
+                "docx_base64": base64.b64encode(docx).decode(),
+                "docx_sha256": sha256(docx).hexdigest(),
+                "pdf_filename": "(FAKE)-Resume.pdf",
+                "pdf_base64": base64.b64encode(pdf).decode(),
+                "pdf_sha256": sha256(pdf).hexdigest(),
+                "idempotency_key": "download-failure-publish",
+            },
+        )
+        assert published.status_code == 200
+        artifact_id = client.get(
+            f"/v1/jobs/{job['job_id']}/artifacts", headers=headers
+        ).json()["artifacts"][0]["artifact_id"]
+
+        def fail_read(*args, **kwargs):
+            raise OSError("synthetic local artifact read failure")
+
+        monkeypatch.setattr(
+            "jobos_api.local_artifact_repository.LocalArtifactRepository.read", fail_read
+        )
+        response = client.get(f"/v1/artifacts/{artifact_id}/download", headers=headers)
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Local artifact storage is unavailable"

--- a/services/api/tests/test_state_store.py
+++ b/services/api/tests/test_state_store.py
@@ -1,6 +1,8 @@
 import json
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier
 
 import pytest
 from jobos_api.browser_policy import (
@@ -8,6 +10,7 @@ from jobos_api.browser_policy import (
     safe_browser_url,
     sanitize_browser_title,
 )
+from jobos_api.documents import VerifiedArtifact
 from jobos_api.state_store import (
     MIGRATIONS,
     SCHEMA_VERSION,
@@ -137,10 +140,48 @@ def test_initialization_applies_every_migration_once(tmp_path):
     first = store.initialize()
     second = store.initialize()
 
-    assert first.schema_version == SCHEMA_VERSION == 14
+    assert first.schema_version == SCHEMA_VERSION == 15
     assert second.schema_version == SCHEMA_VERSION
-    assert applied_versions(database) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+    assert applied_versions(database) == [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+    ]
     assert metadata_columns(database) == {"key", "value", "updated_at"}
+
+
+def test_concurrent_initialization_applies_pending_migrations_once(tmp_path):
+    database = tmp_path / "jobos.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT)"
+        )
+        for migration in MIGRATIONS[:14]:
+            JobOsStateStore._apply_migration(connection, migration)
+
+    ready = Barrier(2)
+
+    def initialize() -> int:
+        ready.wait(timeout=5)
+        return JobOsStateStore(database).initialize().schema_version
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: initialize(), range(2)))
+
+    assert results == [SCHEMA_VERSION, SCHEMA_VERSION]
+    assert applied_versions(database) == list(range(1, SCHEMA_VERSION + 1))
 
 
 def test_initialization_upgrades_a_behind_database(tmp_path):
@@ -154,8 +195,419 @@ def test_initialization_upgrades_a_behind_database(tmp_path):
     result = JobOsStateStore(database).initialize()
 
     assert result.schema_version == SCHEMA_VERSION
-    assert applied_versions(database) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+    assert applied_versions(database) == [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+    ]
     assert metadata_columns(database) == {"key", "value", "updated_at"}
+
+
+def test_migration_15_reconciles_dirty_v14_publications_deterministically(tmp_path):
+    database = tmp_path / "jobos.db"
+    document_id = "edoc_abcdefghijklmnopqrstuvwx"
+    docx_media = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT)"
+        )
+        for migration in MIGRATIONS[:14]:
+            JobOsStateStore._apply_migration(connection, migration)
+        connection.execute(
+            """
+            INSERT INTO editable_documents(
+                document_id, job_id, document_key, document_label, schema_version,
+                revision, content_json, settings_json, comments_json, import_report_json,
+                published_revision
+            ) VALUES (?, 'job-dirty', 'resume', 'Resume', 1, 3, '{}', '{}', '[]', '{}', 3)
+            """,
+            (document_id,),
+        )
+        rows = [
+            ("art_old_docx_123456", "old-docx", 10, "source-shared", docx_media, "1" * 64),
+            ("art_old_pdf_1234567", "old-pdf", 11, "source-shared", "application/pdf", "2" * 64),
+            ("art_new_docx_123456", "new-docx", 20, "source-shared", docx_media, "3" * 64),
+            ("art_new_pdf_1234567", "new-pdf", 21, "source-shared", "application/pdf", "4" * 64),
+        ]
+        connection.executemany(
+            """
+            INSERT INTO document_artifacts(
+                artifact_id, registry_key, job_id, document_key, document_label,
+                render_sequence, source_revision, artifact_revision, media_type,
+                sha256, render_status, canonical_path, filename,
+                editable_document_id, editable_document_revision
+            ) VALUES (?, ?, 'job-dirty', 'resume', 'Resume', ?, ?, ?, ?, ?, 'succeeded',
+                '/synthetic/path', 'synthetic', ?, 3)
+            """,
+            [
+                (
+                    artifact_id,
+                    registry_key,
+                    sequence,
+                    source_revision,
+                    digest,
+                    media_type,
+                    digest,
+                    document_id,
+                )
+                for artifact_id, registry_key, sequence, source_revision, media_type, digest in rows
+            ],
+        )
+        connection.execute(
+            """
+            INSERT INTO job_document_state(
+                job_id, current_artifact_id, last_successful_artifact_id,
+                approved_artifact_id, approved_at
+            ) VALUES ('job-dirty', 'art_new_pdf_1234567', 'art_new_pdf_1234567',
+                'art_old_pdf_1234567', CURRENT_TIMESTAMP)
+            """
+        )
+
+    health = JobOsStateStore(database).initialize()
+
+    with sqlite3.connect(database) as connection:
+        associated = connection.execute(
+            """
+            SELECT artifact_id, media_type, source_revision
+            FROM document_artifacts
+            WHERE editable_document_id = ? AND editable_document_revision = 3
+            ORDER BY media_type
+            """,
+            (document_id,),
+        ).fetchall()
+        detached = connection.execute(
+            """
+            SELECT artifact_id
+            FROM document_artifacts
+            WHERE artifact_id LIKE 'art_new_%'
+                AND editable_document_id IS NULL
+                AND editable_document_revision IS NULL
+            ORDER BY artifact_id
+            """
+        ).fetchall()
+        state = connection.execute(
+            """
+            SELECT current_artifact_id, last_successful_artifact_id, approved_artifact_id
+            FROM job_document_state WHERE job_id = 'job-dirty'
+            """
+        ).fetchone()
+        published = connection.execute(
+            "SELECT published_revision FROM editable_documents WHERE document_id = ?",
+            (document_id,),
+        ).fetchone()
+
+    assert health.schema_version == 15
+    assert associated == [
+        ("art_old_pdf_1234567", "application/pdf", "source-shared"),
+        ("art_old_docx_123456", docx_media, "source-shared"),
+    ]
+    assert detached == [("art_new_docx_123456",), ("art_new_pdf_1234567",)]
+    assert state == (
+        "art_old_pdf_1234567",
+        "art_old_pdf_1234567",
+        "art_old_pdf_1234567",
+    )
+    assert published == (3,)
+
+
+def test_migration_15_preserves_valid_owner_and_clears_mixed_wrong_owner_pointers(
+    tmp_path,
+):
+    database = tmp_path / "jobos.db"
+    document_id = "edoc_abcdefghijklmnopqrstuvwx"
+    docx_media = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT)"
+        )
+        for migration in MIGRATIONS[:14]:
+            JobOsStateStore._apply_migration(connection, migration)
+        connection.execute(
+            """
+            INSERT INTO editable_documents(
+                document_id, job_id, document_key, document_label, schema_version,
+                revision, content_json, settings_json, comments_json, import_report_json,
+                published_revision
+            ) VALUES (?, 'job-owner', 'resume', 'Resume', 1, 3, '{}', '{}', '[]', '{}', 3)
+            """,
+            (document_id,),
+        )
+        rows = [
+            ("art_owner_docx_12345", "job-owner", 10, docx_media, "1" * 64),
+            ("art_owner_pdf_123456", "job-owner", 11, "application/pdf", "2" * 64),
+            ("art_wrong_docx_12345", "job-wrong", 20, docx_media, "3" * 64),
+            ("art_wrong_pdf_123456", "job-wrong", 21, "application/pdf", "4" * 64),
+        ]
+        connection.executemany(
+            """
+            INSERT INTO document_artifacts(
+                artifact_id, registry_key, job_id, document_key, document_label,
+                render_sequence, source_revision, artifact_revision, media_type,
+                sha256, render_status, canonical_path, filename,
+                editable_document_id, editable_document_revision
+            ) VALUES (?, 'legacy-' || ?, ?, 'resume', 'Resume', ?, 'source-shared', ?, ?, ?,
+                'succeeded', '/synthetic/path', 'synthetic', ?, 3)
+            """,
+            [
+                (artifact_id, artifact_id, job_id, sequence, digest, media_type, digest,
+                 document_id)
+                for artifact_id, job_id, sequence, media_type, digest in rows
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO job_document_state(
+                job_id, current_artifact_id, last_successful_artifact_id,
+                approved_artifact_id, approved_at
+            ) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+            """,
+            [
+                (
+                    "job-owner",
+                    "art_owner_pdf_123456",
+                    "art_owner_pdf_123456",
+                    "art_owner_pdf_123456",
+                ),
+                (
+                    "job-wrong",
+                    "art_wrong_pdf_123456",
+                    "art_owner_docx_12345",
+                    "art_owner_pdf_123456",
+                ),
+            ],
+        )
+
+    health = JobOsStateStore(database).initialize()
+
+    with sqlite3.connect(database) as connection:
+        owner_state = connection.execute(
+            """
+            SELECT current_artifact_id, last_successful_artifact_id, approved_artifact_id
+            FROM job_document_state WHERE job_id = 'job-owner'
+            """
+        ).fetchone()
+        wrong_state = connection.execute(
+            """
+            SELECT current_artifact_id, last_successful_artifact_id,
+                approved_artifact_id, approved_at
+            FROM job_document_state WHERE job_id = 'job-wrong'
+            """
+        ).fetchone()
+        associated = connection.execute(
+            """
+            SELECT artifact_id FROM document_artifacts
+            WHERE editable_document_id = ?
+            ORDER BY artifact_id
+            """,
+            (document_id,),
+        ).fetchall()
+
+    assert health.schema_version == 15
+    assert owner_state == (
+        "art_owner_pdf_123456",
+        "art_owner_pdf_123456",
+        "art_owner_pdf_123456",
+    )
+    assert wrong_state == (None, None, None, None)
+    assert associated == [("art_owner_docx_12345",), ("art_owner_pdf_123456",)]
+
+
+@pytest.mark.parametrize(
+    ("legacy_rows", "artifact_job_id", "artifact_document_keys"),
+    [
+        (
+            [("art_only_docx_123456", 10, "source-a", "docx")],
+            "job-malformed",
+            ("resume",),
+        ),
+        (
+            [("art_only_pdf_1234567", 10, "source-a", "pdf")],
+            "job-malformed",
+            ("resume",),
+        ),
+        (
+            [
+                ("art_mismatch_docx_1", 10, "source-a", "docx"),
+                ("art_mismatch_pdf_12", 11, "source-b", "pdf"),
+            ],
+            "job-malformed",
+            ("resume", "resume"),
+        ),
+        (
+            [
+                ("art_gap_docx_1234567", 10, "source-a", "docx"),
+                ("art_gap_pdf_12345678", 12, "source-a", "pdf"),
+            ],
+            "job-malformed",
+            ("resume", "resume"),
+        ),
+        (
+            [
+                ("art_wrong_job_docx_1", 10, "source-a", "docx"),
+                ("art_wrong_job_pdf_12", 11, "source-a", "pdf"),
+            ],
+            "job-wrong-owner",
+            ("resume", "resume"),
+        ),
+        (
+            [
+                ("art_wrong_key_docx_1", 10, "source-a", "docx"),
+                ("art_wrong_key_pdf_12", 11, "source-a", "pdf"),
+            ],
+            "job-malformed",
+            ("resume", "cover_letter"),
+        ),
+    ],
+    ids=(
+        "docx-only",
+        "pdf-only",
+        "mismatched-source",
+        "nonadjacent-sequences",
+        "owner-job-mismatch",
+        "owner-document-key-mismatch",
+    ),
+)
+def test_migration_15_detaches_every_malformed_v14_publication_and_allows_republish(
+    tmp_path, legacy_rows, artifact_job_id, artifact_document_keys
+):
+    database = tmp_path / "jobos.db"
+    document_id = "edoc_abcdefghijklmnopqrstuvwx"
+    docx_media = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    media_types = {"docx": docx_media, "pdf": "application/pdf"}
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT)"
+        )
+        for migration in MIGRATIONS[:14]:
+            JobOsStateStore._apply_migration(connection, migration)
+        connection.execute(
+            """
+            INSERT INTO editable_documents(
+                document_id, job_id, document_key, document_label, schema_version,
+                revision, content_json, settings_json, comments_json, import_report_json,
+                published_revision
+            ) VALUES (?, 'job-malformed', 'resume', 'Resume', 1, 3, '{}', '{}', '[]', '{}', 3)
+            """,
+            (document_id,),
+        )
+        for index, ((artifact_id, sequence, source_revision, media), document_key) in enumerate(
+            zip(legacy_rows, artifact_document_keys, strict=True)
+        ):
+            digest = str(index + 1) * 64
+            connection.execute(
+                """
+                INSERT INTO document_artifacts(
+                    artifact_id, registry_key, job_id, document_key, document_label,
+                    render_sequence, source_revision, artifact_revision, media_type,
+                    sha256, render_status, canonical_path, filename,
+                    editable_document_id, editable_document_revision
+                ) VALUES (?, ?, ?, ?, 'Resume', ?, ?, ?, ?, ?,
+                    'succeeded', '/synthetic/path', 'synthetic', ?, 3)
+                """,
+                (
+                    artifact_id,
+                    f"legacy-{index}",
+                    artifact_job_id,
+                    document_key,
+                    sequence,
+                    source_revision,
+                    digest,
+                    media_types[media],
+                    digest,
+                    document_id,
+                ),
+            )
+        pointed_artifact = legacy_rows[0][0]
+        connection.execute(
+            """
+            INSERT INTO job_document_state(
+                job_id, current_artifact_id, last_successful_artifact_id,
+                approved_artifact_id, approved_at
+            ) VALUES ('job-malformed', ?, ?, ?, CURRENT_TIMESTAMP)
+            """,
+            (pointed_artifact, pointed_artifact, pointed_artifact),
+        )
+
+    store = JobOsStateStore(database)
+    health = store.initialize()
+
+    with sqlite3.connect(database) as connection:
+        detached = connection.execute(
+            """
+            SELECT artifact_id
+            FROM document_artifacts
+            WHERE registry_key LIKE 'legacy-%'
+                AND editable_document_id IS NULL
+                AND editable_document_revision IS NULL
+            ORDER BY artifact_id
+            """
+        ).fetchall()
+        state = connection.execute(
+            """
+            SELECT current_artifact_id, last_successful_artifact_id,
+                approved_artifact_id, approved_at
+            FROM job_document_state WHERE job_id = 'job-malformed'
+            """
+        ).fetchone()
+        published = connection.execute(
+            "SELECT published_revision FROM editable_documents WHERE document_id = ?",
+            (document_id,),
+        ).fetchone()
+        republished = store.register_editable_publication_pair(
+            "job-malformed",
+            [
+                VerifiedArtifact(
+                    job_id="job-malformed",
+                    document_key="resume",
+                    document_label="Resume",
+                    source_revision="source-republish",
+                    artifact_revision="republish-docx",
+                    media_type=docx_media,
+                    sha256="a" * 64,
+                    render_status="succeeded",
+                    render_sequence=30,
+                    canonical_path="/synthetic/republish.docx",
+                    filename="republish.docx",
+                    failure_message=None,
+                ),
+                VerifiedArtifact(
+                    job_id="job-malformed",
+                    document_key="resume",
+                    document_label="Resume",
+                    source_revision="source-republish",
+                    artifact_revision="republish-pdf",
+                    media_type="application/pdf",
+                    sha256="b" * 64,
+                    render_status="succeeded",
+                    render_sequence=31,
+                    canonical_path="/synthetic/republish.pdf",
+                    filename="republish.pdf",
+                    failure_message=None,
+                ),
+            ],
+            editable_document_id=document_id,
+            editable_document_revision=3,
+            connection=connection,
+        )
+
+    assert health.schema_version == 15
+    assert detached == sorted((row[0],) for row in legacy_rows)
+    assert state == (None, None, None, None)
+    assert published == (None,)
+    assert republished is True
+    assert len(store.editable_publication_artifacts(document_id, 3)) == 2
 
 
 def test_document_identity_migration_clears_legacy_docx_approval(tmp_path):
@@ -216,7 +668,10 @@ def test_document_identity_migration_clears_legacy_docx_approval(tmp_path):
     assert identity == ("resume", "Resume", 1)
 
 
-@pytest.mark.parametrize("versions", ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], [2]))
+@pytest.mark.parametrize(
+    "versions",
+    ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [2]),
+)
 def test_initialization_rejects_ahead_or_incompatible_history(tmp_path, versions):
     database = tmp_path / "jobos.db"
     with sqlite3.connect(database) as connection:

--- a/services/api/tests/test_synthetic_demo.py
+++ b/services/api/tests/test_synthetic_demo.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 from job_repository_contract import command
 from jobos_api.app import create_app
+from jobos_api.editable_documents import plain_text
 from jobos_api.initialize import initialize_jobos
 from jobos_api.job_repository import Conflict
 from jobos_api.local_config import load_credentials, read_config, settings_from_config
@@ -48,10 +49,22 @@ def test_demo_seed_mutation_restart_deletion_and_confirmed_reset(tmp_path, monke
     assert demo.dataset_version == "jobos-demo-v1"
     assert "Fictional Demo" in demo.company
     assert demo.canonical_url.startswith("https://jobs.example.com/")
+    state_store = JobOsStateStore(tmp_path / "state/jobos.db")
+    starter = state_store.get_job_editable_document(DEMO_JOB_ID, "resume")
+    assert starter is not None
+    starter_id = starter["document_id"]
+    assert "(FAKE)" in plain_text(starter["content"])
+    assert "DO NOT APPLY" in plain_text(starter["content"])
 
     repository.update_description(demo.job_id, "My edited fictional demo.", source="test")
     initialize_jobos(tmp_path)
     assert _repository(tmp_path).get_job(demo.job_id).description == "My edited fictional demo."
+    assert (
+        JobOsStateStore(tmp_path / "state/jobos.db").get_job_editable_document(
+            DEMO_JOB_ID, "resume"
+        )["document_id"]
+        == starter_id
+    )
 
     repository.delete_job(demo.job_id)
     initialize_jobos(tmp_path)
@@ -102,6 +115,17 @@ def test_demo_metadata_and_intentional_removal_use_public_api_contract(tmp_path,
     config = read_config(tmp_path / "config.json")
     device_token, _ = load_credentials(config, tmp_path)
     headers = {"Authorization": f"Bearer {device_token}"}
+    state_store = JobOsStateStore(tmp_path / "state/jobos.db")
+    starter = state_store.get_job_editable_document(DEMO_JOB_ID, "resume")
+    assert starter is not None
+    assert isinstance(starter["revision"], int)
+    state_store.create_editable_snapshot(
+        str(starter["document_id"]),
+        expected_revision=starter["revision"],
+        reason="manual",
+        actor="user",
+        label="Contains edited private content",
+    )
     app = create_app(settings_from_config(tmp_path / "config.json"))
     with TestClient(app) as client:
         listed = client.get("/v1/jobs", headers=headers)
@@ -129,9 +153,33 @@ def test_demo_metadata_and_intentional_removal_use_public_api_contract(tmp_path,
         assert replayed.status_code == 200
         assert replayed.json() == removed.json()
         assert client.get("/v1/jobs", headers=headers).json() == {"jobs": []}
+        assert (
+            JobOsStateStore(tmp_path / "state/jobos.db").get_job_editable_document(
+                DEMO_JOB_ID, "resume"
+            )
+            is None
+        )
+        with sqlite3.connect(tmp_path / "state/jobos.db") as connection:
+            assert connection.execute(
+                "SELECT COUNT(*) FROM editable_document_snapshots"
+            ).fetchone()[0] == 0
 
     initialize_jobos(tmp_path)
     assert _repository(tmp_path).list_jobs() == ()
+    assert (
+        JobOsStateStore(tmp_path / "state/jobos.db").get_job_editable_document(
+            DEMO_JOB_ID, "resume"
+        )
+        is None
+    )
+
+    initialize_jobos(tmp_path, reset_demo_requested=True, reset_confirmed=True)
+    restored = JobOsStateStore(tmp_path / "state/jobos.db").get_job_editable_document(
+        DEMO_JOB_ID, "resume"
+    )
+    assert restored is not None
+    assert "fictional" in plain_text(restored["content"]).casefold()
+    assert "do not apply" in plain_text(restored["content"]).casefold()
 
 
 def test_removing_demo_preserves_a_different_workspace_selection(tmp_path, monkeypatch):

--- a/services/mcp/jobos_mcp/server.py
+++ b/services/mcp/jobos_mcp/server.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
-import re
+import stat
 import subprocess
 import sys
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
@@ -37,13 +39,64 @@ def local_mcp_token() -> str:
 
 
 def _document_import_roots() -> tuple[Path, ...]:
-    profile = os.environ.get("HERMES_PROFILE", "job-hunter")
-    if not re.fullmatch(r"[A-Za-z0-9._-]{1,100}", profile):
-        raise RuntimeError("Hermes profile name is invalid")
-    return (
-        Path.cwd().resolve(),
-        (Path.home() / ".hermes" / "profiles" / profile / "cache" / "documents").resolve(),
+    configured_roots = tuple(
+        Path(value).expanduser()
+        for value in os.environ.get("JOBOS_DOCUMENT_ROOTS", "").split(os.pathsep)
+        if value
     )
+    if configured_roots:
+        roots = configured_roots
+    else:
+        configured_path = os.environ.get("JOBOS_CONFIG_PATH")
+        if configured_path:
+            path = Path(configured_path).expanduser()
+        else:
+            data_dir = os.environ.get("JOBOS_DATA_DIR")
+            if data_dir:
+                path = Path(data_dir).expanduser() / "config.json"
+            elif sys.platform == "darwin":
+                path = Path.home() / "Library/Application Support/JobOS/config.json"
+            else:
+                xdg_data = os.environ.get("XDG_DATA_HOME")
+                base = Path(xdg_data).expanduser() if xdg_data else Path.home() / ".local/share"
+                path = base / "JobOS/config.json"
+        try:
+            config = json.loads(path.read_text(encoding="utf-8"))
+            if (
+                not isinstance(config, dict)
+                or config.get("schemaVersion") != 1
+                or not isinstance(config.get("paths"), dict)
+            ):
+                raise ValueError
+            paths = config["paths"]
+            raw_artifacts = paths.get("artifacts")
+            if not isinstance(raw_artifacts, str) or not raw_artifacts:
+                raise ValueError
+        except (
+            FileNotFoundError,
+            OSError,
+            KeyError,
+            TypeError,
+            ValueError,
+            json.JSONDecodeError,
+        ) as error:
+            raise RuntimeError(
+                "Document publication requires JOBOS_DOCUMENT_ROOTS or a valid JobOS local config"
+            ) from error
+        artifact_root = Path(raw_artifacts).expanduser()
+        roots = (artifact_root if artifact_root.is_absolute() else path.parent / artifact_root,)
+
+    resolved: list[Path] = []
+    for root in roots:
+        if not root.is_absolute():
+            raise RuntimeError("Configured document roots must be absolute paths")
+        if root.is_symlink():
+            raise RuntimeError("Configured document roots must not be symbolic links")
+        candidate = root.resolve(strict=True)
+        if not candidate.is_dir():
+            raise RuntimeError("Configured document roots must be directories")
+        resolved.append(candidate)
+    return tuple(dict.fromkeys(resolved))
 
 
 def _read_document_input(
@@ -53,19 +106,105 @@ def _read_document_input(
     maximum: int,
     suffixes: set[str] | None = None,
 ) -> tuple[str, bytes]:
-    supplied = Path(raw_path).expanduser()
-    if supplied.is_symlink():
-        raise ValueError("Document input must not be a symbolic link")
-    candidate = supplied.resolve(strict=True)
-    if not any(candidate == root or root in candidate.parents for root in roots):
-        raise ValueError("Document input is outside the Job Hunter workspace and output cache")
-    if not candidate.is_file():
-        raise ValueError("Document input must be a regular file")
+    def stable_metadata(value: os.stat_result) -> tuple[int, int, int, int, int, int]:
+        return (
+            value.st_dev,
+            value.st_ino,
+            stat.S_IFMT(value.st_mode),
+            value.st_size,
+            value.st_mtime_ns,
+            value.st_ctime_ns,
+        )
+
+    def descriptor_bytes(descriptor: int) -> bytes:
+        chunks: list[bytes] = []
+        remaining = maximum + 1
+        while remaining:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    requested = Path(raw_path)
+    if not requested.is_absolute():
+        raise ValueError("Document input path must be absolute")
+    supplied = Path(os.path.abspath(requested))
+    selected: tuple[Path, tuple[str, ...], os.stat_result] | None = None
+    for root in sorted(roots, key=lambda value: len(value.parts), reverse=True):
+        expanded = root.expanduser()
+        if expanded.is_symlink():
+            raise ValueError("Configured document roots must not be symbolic links")
+        resolved = expanded.resolve(strict=True)
+        try:
+            relative = supplied.relative_to(resolved)
+        except ValueError:
+            continue
+        if relative.parts and all(part not in {"", ".", ".."} for part in relative.parts):
+            selected = resolved, relative.parts, os.stat(resolved, follow_symlinks=False)
+            break
+    if selected is None:
+        raise ValueError("Document input is outside configured document roots")
+    root, parts, expected_root = selected
+    directory_flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        directory_flags |= os.O_DIRECTORY
+    if hasattr(os, "O_CLOEXEC"):
+        directory_flags |= os.O_CLOEXEC
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    descriptors: list[int] = []
+    descriptor: int | None = None
+    try:
+        current = os.open(root, directory_flags | nofollow)
+        descriptors.append(current)
+        opened_root = os.fstat(current)
+        if (
+            not stat.S_ISDIR(opened_root.st_mode)
+            or opened_root.st_dev != expected_root.st_dev
+            or opened_root.st_ino != expected_root.st_ino
+        ):
+            raise ValueError("Configured document root changed during access")
+        for part in parts[:-1]:
+            current = os.open(part, directory_flags | nofollow, dir_fd=current)
+            descriptors.append(current)
+            if not stat.S_ISDIR(os.fstat(current).st_mode):
+                raise ValueError("Document input ancestor must be a directory")
+        descriptor = os.open(parts[-1], os.O_RDONLY | nofollow, dir_fd=current)
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise ValueError("Document input must be a regular file")
+        if before.st_size <= 0 or before.st_size > maximum:
+            raise ValueError("Document input size is invalid")
+        content = descriptor_bytes(descriptor)
+        after = os.fstat(descriptor)
+        if (
+            stable_metadata(before) != stable_metadata(after)
+            or len(content) != before.st_size
+            or len(content) > maximum
+        ):
+            raise ValueError("Document input changed during access")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        confirmation = descriptor_bytes(descriptor)
+        confirmed = os.fstat(descriptor)
+        if (
+            stable_metadata(after) != stable_metadata(confirmed)
+            or len(confirmation) != before.st_size
+            or sha256(content).digest() != sha256(confirmation).digest()
+        ):
+            raise ValueError("Document input changed during access")
+    except OSError as error:
+        raise ValueError(
+            "Document input contains a symbolic link or inaccessible component"
+        ) from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        for opened in reversed(descriptors):
+            os.close(opened)
+    candidate = root.joinpath(*parts)
     if suffixes is not None and candidate.suffix.casefold() not in suffixes:
         raise ValueError("Published artifact must be a PDF or DOCX")
-    content = candidate.read_bytes()
-    if not content or len(content) > maximum:
-        raise ValueError("Document input size is invalid")
     return candidate.name, content
 
 

--- a/services/mcp/tests/test_jobs_tools.py
+++ b/services/mcp/tests/test_jobs_tools.py
@@ -1,10 +1,12 @@
 import base64
 import json
+import os
 
 import httpx
+import jobos_mcp.server as server_module
 import pytest
 from jobos_mcp.jobs import JobOsMcpClient
-from jobos_mcp.server import _read_document_input, create_server
+from jobos_mcp.server import _document_import_roots, _read_document_input, create_server
 
 
 @pytest.mark.parametrize("value", ["../job", "job/other", "job\\other", "job\nother", ""])
@@ -167,6 +169,137 @@ def test_document_publish_input_is_limited_to_explicit_roots(tmp_path):
         _read_document_input(
             str(outside), roots=(allowed,), maximum=100, suffixes={".docx"}
         )
+
+
+def test_document_publish_input_rejects_relative_path_with_cwd_inside_allowed_root(
+    tmp_path, monkeypatch
+):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    artifact = allowed / "letter.docx"
+    artifact.write_bytes(b"PK\x03\x04fixture")
+    monkeypatch.chdir(allowed)
+
+    with pytest.raises(ValueError, match="must be absolute"):
+        _read_document_input(
+            artifact.name, roots=(allowed,), maximum=100, suffixes={".docx"}
+        )
+
+
+def test_document_input_descriptor_read_cannot_leak_post_open_symlink_bytes(
+    tmp_path, monkeypatch
+):
+    allowed = tmp_path / "allowed"
+    nested = allowed / "nested"
+    nested.mkdir(parents=True)
+    original = b"inside document bytes"
+    outside_bytes = b"outside private bytes"
+    target = nested / "letter.docx"
+    target.write_bytes(original)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / target.name).write_bytes(outside_bytes)
+    held = allowed / "held-nested"
+    real_open = os.open
+    swapped = False
+
+    def racing_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        descriptor = real_open(path, flags, mode, dir_fd=dir_fd)
+        if path == nested.name and dir_fd is not None and not swapped:
+            swapped = True
+            nested.rename(held)
+            nested.symlink_to(outside, target_is_directory=True)
+        return descriptor
+
+    monkeypatch.setattr(server_module.os, "open", racing_open)
+    filename, content = _read_document_input(
+        str(target), roots=(allowed,), maximum=100, suffixes={".docx"}
+    )
+
+    assert swapped
+    assert filename == target.name
+    assert content == original
+    assert content != outside_bytes
+
+
+def test_document_input_rejects_same_inode_same_size_in_place_mutation(
+    tmp_path, monkeypatch
+):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    target = allowed / "resume.pdf"
+    original = b"A" * 256
+    replacement = b"B" * len(original)
+    target.write_bytes(original)
+    identity = target.stat()
+    real_read = os.read
+    mutated = False
+
+    def racing_read(descriptor, size):
+        nonlocal mutated
+        chunk = real_read(descriptor, size)
+        if chunk and not mutated:
+            mutated = True
+            target.write_bytes(replacement)
+        return chunk
+
+    monkeypatch.setattr(server_module.os, "read", racing_read)
+    with pytest.raises(ValueError, match="changed during access"):
+        _read_document_input(
+            str(target), roots=(allowed,), maximum=1_024, suffixes={".pdf"}
+        )
+
+    changed = target.stat()
+    assert mutated
+    assert changed.st_ino == identity.st_ino
+    assert changed.st_size == identity.st_size
+
+
+def test_document_roots_use_explicit_local_config_and_never_cwd_or_hermes(tmp_path, monkeypatch):
+    working = tmp_path / "working"
+    working.mkdir()
+    hermes = tmp_path / ".hermes/profiles/job-hunter/cache/documents"
+    hermes.mkdir(parents=True)
+    monkeypatch.chdir(working)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("JOBOS_CONFIG_PATH", str(tmp_path / "missing-config.json"))
+    monkeypatch.delenv("JOBOS_DOCUMENT_ROOTS", raising=False)
+
+    with pytest.raises(RuntimeError, match="JOBOS_DOCUMENT_ROOTS or a valid JobOS local config"):
+        _document_import_roots()
+
+    artifacts = tmp_path / "application-data/artifacts"
+    artifacts.mkdir(parents=True)
+    config = tmp_path / "application-data/config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "paths": {"artifacts": "artifacts"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("JOBOS_CONFIG_PATH", str(config))
+    assert _document_import_roots() == (artifacts.resolve(),)
+    assert working.resolve() not in _document_import_roots()
+    assert hermes.resolve() not in _document_import_roots()
+
+
+def test_document_roots_reject_symlink_configuration(tmp_path, monkeypatch):
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    os.symlink(target, link)
+    monkeypatch.setenv("JOBOS_DOCUMENT_ROOTS", str(link))
+
+    with pytest.raises(RuntimeError, match="symbolic links"):
+        _document_import_roots()
+
+    monkeypatch.setenv("JOBOS_DOCUMENT_ROOTS", "relative/documents")
+    with pytest.raises(RuntimeError, match="absolute paths"):
+        _document_import_roots()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- add built-in local ownership for generated and imported document bytes
- keep private JobHunter rendering/publication behind an optional artifact gateway
- make MCP document roots explicit and remove implicit CWD/Hermes-profile authority
- preserve local editable documents, snapshots, publication, downloads, and restart behavior
- harden SQLite migrations, path traversal/race handling, atomic paired publication, and DOCX/PDF validation
- document the source-first Phase 4 boundary truthfully

## Verification

- Node 26.5.0 (`.node-version`)
- `pnpm check`
  - desktop: 368 passed
  - Python: 527 passed, 2 skipped, 2 strict xfailed
- `pnpm contracts:check`
- `git diff --cached --check`
- strict `--runxfail`: exactly the two existing operator-default/private-path blockers remain red
- real source smoke on a fresh profile: one synthetic job + starter document, save revision 2, snapshot, publish DOCX/PDF, checksum-verified downloads
- restart smoke: one job, one document, two artifacts, revision 2 and published revision 2 persisted
- independent read-only review of the exact staged diff: APPROVED

## Known deferred boundary

This proves the source-first local runtime. Public installed-app provisioning and installed UI acceptance remain deferred; this PR does not claim that a clean public packaged binary is ready.

## Safety

- no history rewrite
- no repository visibility change
- no production deployment or public release
- no private JobHunter dependency in the public default composition


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local storage for imported DOCX files and published DOCX/PDF pairs.
  * Added editable resume support for the synthetic demo, including reset and cleanup behavior.
  * Added selectable local or gateway artifact providers.
  * Improved document downloads, persistence across restarts, and publication replay.

* **Bug Fixes**
  * Strengthened artifact validation, integrity checks, path safety, and failure handling.
  * Improved MCP document-root security and containment checks.

* **Documentation**
  * Updated architecture, privacy, troubleshooting, and Documents capability guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->