### PR TITLE
test: prove clean-clone release path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,41 @@ jobs:
         run: pnpm contracts:check
       - name: Prove stale generated contracts are rejected
         run: pnpm contracts:test-drift
+
+  clean-clone-linux:
+    name: Clean clone (Linux source subset)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 26.5.0
+          cache: pnpm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@v8.3.2
+        with:
+          version: "0.11.18"
+          enable-cache: true
+      - run: pnpm public:smoke-clean-clone
+
+  clean-clone-macos:
+    name: Clean clone (macOS complete path)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 26.5.0
+          cache: pnpm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@v8.3.2
+        with:
+          version: "0.11.18"
+          enable-cache: true
+      - run: pnpm public:smoke-clean-clone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 26.5.0
-          cache: pnpm
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -61,7 +60,6 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 26.5.0
-          cache: pnpm
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dev": "pnpm --filter @jobos/desktop dev",
     "license:check": "uv run python scripts/verify_license_inventory.py",
     "public:check": "uv run python scripts/public-release/verify-public-tree.py && uv run python scripts/public-release/verify-fixture-manifest.py",
+    "public:smoke-clean-clone": "python scripts/public-release/smoke-clean-clone.py --source . --ref HEAD",
     "lint": "pnpm --filter @jobos/contracts lint && pnpm --filter @jobos/desktop lint && uv run ruff check services scripts",
     "test": "pnpm --filter @jobos/desktop test && uv run pytest",
     "typecheck": "pnpm contracts:generate && pnpm --filter @jobos/contracts build && pnpm --filter @jobos/contracts typecheck && pnpm --filter @jobos/desktop typecheck"

--- a/scripts/public-release/export-editable-document.mjs
+++ b/scripts/public-release/export-editable-document.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto'
+import { open, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+
+import { app } from 'electron'
+
+function argument(name) {
+  const index = process.argv.indexOf(name)
+  const value = index >= 0 ? process.argv[index + 1] : undefined
+  if (!value || !path.isAbsolute(value)) throw new Error(`${name} requires an absolute path`)
+  return value
+}
+
+function settings(value) {
+  return {
+    pageSize: value.page_size,
+    orientation: value.orientation,
+    marginsInches: value.margins_inches,
+    defaultFontFamily: value.default_font_family,
+    defaultFontSizePt: value.default_font_size_pt,
+    header: {
+      left: value.header.left,
+      center: value.header.center,
+      right: value.header.right,
+      firstPageDifferent: value.header.first_page_different
+    },
+    footer: {
+      left: value.footer.left,
+      center: value.footer.center,
+      right: value.footer.right,
+      firstPageDifferent: value.footer.first_page_different
+    },
+    showPageNumbers: value.show_page_numbers
+  }
+}
+
+function canonicalDocument(value) {
+  return {
+    schemaVersion: value.schema_version,
+    documentId: value.document_id,
+    jobId: value.job_id,
+    documentKey: value.document_key,
+    documentLabel: value.document_label,
+    revision: value.revision,
+    content: value.content,
+    settings: settings(value.settings),
+    comments: value.comments.map(comment => ({
+      commentId: comment.comment_id,
+      blockId: comment.block_id,
+      author: comment.author,
+      body: comment.body,
+      createdAt: comment.created_at,
+      resolvedAt: comment.resolved_at
+    })),
+    sourceArtifactId: value.source_artifact_id,
+    sourceFilename: value.source_filename,
+    sourceSha256: value.source_sha256,
+    publishedRevision: value.published_revision,
+    importReport: {
+      sourceFilename: value.import_report.source_filename,
+      importedAt: value.import_report.imported_at,
+      issues: value.import_report.issues
+    },
+    createdAt: value.created_at,
+    updatedAt: value.updated_at
+  }
+}
+
+async function writeExclusive(target, bytes) {
+  const handle = await open(target, 'wx', 0o600)
+  try {
+    await handle.writeFile(bytes)
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+const input = argument('--input')
+const docxPath = argument('--docx')
+const pdfPath = argument('--pdf')
+const resultPath = argument('--result')
+if (path.extname(docxPath).toLowerCase() !== '.docx' || path.extname(pdfPath).toLowerCase() !== '.pdf') {
+  throw new Error('output paths must use .docx and .pdf extensions')
+}
+if (path.extname(resultPath).toLowerCase() !== '.json') throw new Error('result path must use a .json extension')
+
+async function exportDocuments() {
+  const [{ exportEditableDocumentDocx }, { exportEditableDocumentPdf }] = await Promise.all([
+    import('../../apps/desktop/dist/main/document-export/documentDocx.js'),
+    import('../../apps/desktop/dist/main/document-export/pdfExporter.js')
+  ])
+  const document = canonicalDocument(JSON.parse(await readFile(input, 'utf8')))
+  const docx = await exportEditableDocumentDocx(document)
+  const pdf = await exportEditableDocumentPdf(document)
+  await writeExclusive(docxPath, docx)
+  await writeExclusive(pdfPath, pdf)
+  const result = JSON.stringify({
+    docx: { filename: path.basename(docxPath), sha256: createHash('sha256').update(docx).digest('hex') },
+    pdf: { filename: path.basename(pdfPath), sha256: createHash('sha256').update(pdf).digest('hex') }
+  })
+  await writeExclusive(resultPath, Buffer.from(`${result}\n`, 'utf8'))
+}
+
+async function run() {
+  const keepAlive = setInterval(() => {}, 1_000)
+  try {
+    await exportDocuments()
+    app.exit(0)
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : 'Document export failed'}\n`)
+    app.exit(1)
+  } finally {
+    clearInterval(keepAlive)
+  }
+}
+
+app.on('window-all-closed', event => event.preventDefault())
+
+if (app.isReady()) void run()
+else app.once('ready', () => { void run() })

--- a/scripts/public-release/smoke-clean-clone.py
+++ b/scripts/public-release/smoke-clean-clone.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Prove the public JobOS source path from an exact, detached Git revision."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+NODE_VERSION = "v26.5.0"
+REDACTIONS = (
+    (
+        re.compile(
+            r"(?i)([\"']?authorization[\"']?\s*[:=]\s*)"
+            r"(?:\"(?:\\[\s\S]|[^\"\\])*\"|'(?:\\[\s\S]|[^'\\])*'|"
+            r"\"(?:\\[\s\S]|[^\"\\])*\Z|'(?:\\[\s\S]|[^'\\])*\Z|"
+            r"[^\r\n]*(?:\r?\n[ \t]+[^\r\n]*)*)"
+        ),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(
+            r"(?i)([\"']?(?:jobos[_-])?(?:device|mcp)[_-]?token[\"']?\s*[:=]\s*[\"']?)([^\"'\s,;}\]]+)"
+        ),
+        r"\1[REDACTED]",
+    ),
+    (re.compile(r"/(?:Users|home)/[^/\s]+"), "/home/[REDACTED]"),
+)
+
+
+def redacted(value: str) -> str:
+    for pattern, replacement in REDACTIONS:
+        value = pattern.sub(replacement, value)
+    return value
+
+
+def base_environment(home: Path) -> dict[str, str]:
+    platform_keys = (
+        "USER",
+        "LOGNAME",
+        "__CF_USER_TEXT_ENCODING",
+        "SECURITYSESSIONID",
+    ) if sys.platform == "darwin" else ()
+    allowed = {
+        key: os.environ[key]
+        for key in ("PATH", "SHELL", "LANG", "LC_ALL", "TMPDIR", "SYSTEMROOT", *platform_keys)
+        if os.environ.get(key)
+    }
+    allowed.update(
+        {
+            "HOME": str(home),
+            "XDG_DATA_HOME": str(home / ".local/share"),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "CI": "1",
+        }
+    )
+    return allowed
+
+
+def run(
+    arguments: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    timeout: float,
+    log: Path,
+) -> None:
+    started = time.monotonic()
+    process = subprocess.Popen(
+            arguments,
+            cwd=cwd,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            errors="replace",
+            start_new_session=True,
+        )
+    try:
+        output, _ = process.communicate(timeout=max(1, timeout))
+    except subprocess.TimeoutExpired as error:
+        os.killpg(process.pid, signal.SIGTERM)
+        try:
+            output, _ = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            output = ""
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        if process.poll() is None:
+            killed_output, _ = process.communicate(timeout=5)
+            output += killed_output
+        log.write_text(redacted(output) + "\ncommand timed out\n", encoding="utf-8")
+        raise RuntimeError(f"command timed out after {timeout:.0f}s: {arguments[0]}") from error
+    log.write_text(redacted(output), encoding="utf-8")
+    if process.returncode:
+        raise RuntimeError(
+            f"command failed ({process.returncode}, {time.monotonic() - started:.1f}s): "
+            f"{arguments[0]}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=Path.cwd())
+    parser.add_argument("--ref", default="HEAD")
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--keep-on-failure", action="store_true")
+    args = parser.parse_args()
+    if args.timeout < 60:
+        parser.error("--timeout must be at least 60 seconds")
+    if sys.platform not in {"darwin", "linux"}:
+        parser.error("the clean-clone proof supports macOS and the Linux source subset only")
+
+    source = args.source.expanduser().resolve(strict=True)
+    root = Path(tempfile.mkdtemp(prefix="jobos-clean-clone-"))
+    clone = root / "checkout"
+    logs = root / "logs"
+    home = root / "home"
+    logs.mkdir(mode=0o700)
+    home.mkdir(mode=0o700)
+    environment = base_environment(home)
+    deadline = time.monotonic() + args.timeout
+
+    def remaining(limit: int) -> float:
+        value = deadline - time.monotonic()
+        if value <= 0:
+            raise RuntimeError("overall clean-clone timeout expired")
+        return min(value, limit)
+
+    try:
+        resolved = subprocess.run(
+            ["git", "-C", str(source), "rev-parse", "--verify", f"{args.ref}^{{commit}}"],
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=True,
+        ).stdout.strip()
+        if not re.fullmatch(r"[0-9a-f]{40}", resolved):
+            raise RuntimeError("ref did not resolve to a full Git commit")
+        run(
+            ["git", "clone", "--no-local", "--no-checkout", str(source), str(clone)],
+            cwd=root,
+            environment=environment,
+            timeout=remaining(120),
+            log=logs / "clone.log",
+        )
+        run(
+            ["git", "checkout", "--detach", resolved],
+            cwd=clone,
+            environment=environment,
+            timeout=remaining(30),
+            log=logs / "checkout.log",
+        )
+        actual = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=clone,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        ).stdout.strip()
+        if actual != resolved:
+            raise RuntimeError("fresh checkout does not match the requested exact revision")
+        status = subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=all"],
+            cwd=clone,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        ).stdout
+        if status:
+            raise RuntimeError("fresh checkout contains unexpected changes")
+        node = subprocess.run(
+            ["node", "--version"],
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        ).stdout.strip()
+        if node != NODE_VERSION:
+            raise RuntimeError(f"Node {NODE_VERSION} is required; found {node}")
+
+        run(
+            ["pnpm", "install", "--frozen-lockfile"],
+            cwd=clone,
+            environment=environment,
+            timeout=remaining(300),
+            log=logs / "pnpm-install.log",
+        )
+        run(
+            ["uv", "sync", "--all-packages", "--frozen"],
+            cwd=clone,
+            environment=environment,
+            timeout=remaining(300),
+            log=logs / "uv-sync.log",
+        )
+        if sys.platform == "darwin":
+            run(
+                ["pnpm", "build"],
+                cwd=clone,
+                environment=environment,
+                timeout=remaining(180),
+                log=logs / "desktop-build.log",
+            )
+        runtime_environment = {
+            **environment,
+            "JOBOS_CLEAN_CLONE": "1",
+            "JOBOS_CLEAN_CLONE_PLATFORM": "complete" if sys.platform == "darwin" else "source",
+        }
+        run(
+            [
+                "uv",
+                "run",
+                "--frozen",
+                "--no-sync",
+                "pytest",
+                "-p",
+                "no:cacheprovider",
+                "tests/public-release/test_clean_clone.py",
+            ],
+            cwd=clone,
+            environment=runtime_environment,
+            timeout=remaining(120),
+            log=logs / "golden-path.log",
+        )
+        result = {"status": "passed", "commit": resolved, "platform": sys.platform}
+        (logs / "result.json").write_text(
+            json.dumps(result, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except (OSError, RuntimeError, subprocess.SubprocessError) as error:
+        failure = {"status": "failed", "error": redacted(str(error)), "platform": sys.platform}
+        (logs / "result.json").write_text(
+            json.dumps(failure, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        if args.keep_on_failure:
+            print(f"clean-clone proof failed; retained redacted logs at {logs}", file=sys.stderr)
+        else:
+            print("clean-clone proof failed; sanitized diagnostics follow", file=sys.stderr)
+        for log in sorted(logs.glob("*.log")):
+            tail = log.read_text(encoding="utf-8", errors="replace").splitlines()[-200:]
+            if tail:
+                print(f"[{log.name}]", file=sys.stderr)
+                print(redacted("\n".join(tail)), file=sys.stderr)
+        if not args.keep_on_failure:
+            shutil.rmtree(root)
+        return 1
+    else:
+        print(json.dumps(result, sort_keys=True))
+        shutil.rmtree(root)
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -2316,7 +2316,7 @@ def create_app(
                 idempotency_key=command.idempotency_key,
                 request_hash=request_hash,
                 mutation=apply_document_operations,
-                label="Applied JobHunter document edits",
+                label="Applied MCP document edits",
             )
         except EditableDocumentConflict as error:
             raise editable_conflict(error) from error

--- a/services/mcp/jobos_mcp/jobs.py
+++ b/services/mcp/jobos_mcp/jobs.py
@@ -262,7 +262,7 @@ class JobOsMcpClient:
             f"/v1/jobs/{self._segment(job_id, 'job ID')}/description",
             json={
                 "description_text": description_text,
-                "source": "jobhunter_agent",
+                "source": "mcp_agent",
                 "provenance": source_note,
                 "origin": "mcp",
                 "idempotency_key": self._key(idempotency_key),

--- a/services/mcp/tests/test_jobs_tools.py
+++ b/services/mcp/tests/test_jobs_tools.py
@@ -279,7 +279,7 @@ async def test_job_tools_use_only_the_authenticated_jobos_http_contract():
     }
     assert json.loads(requests[6].content) == {
         "description_text": "Full canonical listing text.",
-        "source": "jobhunter_agent",
+        "source": "mcp_agent",
         "provenance": "Supplied by the user",
         "origin": "mcp",
         "idempotency_key": "description-1",

--- a/tests/public-release/fixtures/clean-clone-golden.json
+++ b/tests/public-release/fixtures/clean-clone-golden.json
@@ -1,0 +1,6 @@
+{
+  "description": "Synthetic listing text updated by the public clean-clone golden path.",
+  "documentText": "Dear Northstar Hiring Team, this synthetic letter proves local document persistence.",
+  "snapshotLabel": "Clean-clone synthetic checkpoint",
+  "workspaceQuery": "synthetic northstar"
+}

--- a/tests/public-release/test_clean_clone.py
+++ b/tests/public-release/test_clean_clone.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import xml.etree.ElementTree as ElementTree
+import zipfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+support_path = Path(__file__).parents[1] / "public_release_support.py"
+support_spec = importlib.util.spec_from_file_location("jobos_public_release_support", support_path)
+assert support_spec is not None and support_spec.loader is not None
+support = importlib.util.module_from_spec(support_spec)
+support_spec.loader.exec_module(support)
+ApiProcess = support.ApiProcess
+redact = support.redact
+run_json = support.run_json
+clean_runtime = support.clean_runtime
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("JOBOS_CLEAN_CLONE") != "1",
+    reason="run through scripts/public-release/smoke-clean-clone.py",
+)
+
+EXPECTED_HEALTH = {
+    "status": "ready",
+    "service": "jobos-api",
+    "transport": "local-loopback",
+    "agent": "not-configured",
+    "artifact_storage": "available",
+    "artifact_gateway": "not-configured",
+}
+
+
+def fixture() -> dict[str, str]:
+    path = Path(__file__).parent / "fixtures/clean-clone-golden.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert all(isinstance(item, str) for item in value.values())
+    return value
+
+
+def assert_response(response, status: int = 200) -> dict[str, Any]:
+    assert response.status_code == status, (response.status_code, response.text[:500])
+    value = response.json()
+    assert isinstance(value, dict)
+    return value
+
+
+def mcp_value(result) -> dict[str, Any]:
+    assert result.isError is False, str(result.content)[:500]
+    assert isinstance(result.structuredContent, dict)
+    return result.structuredContent
+
+
+async def call(session: ClientSession, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    with anyio.fail_after(10):
+        return mcp_value(await session.call_tool(name, arguments))
+
+
+async def assert_optional_error(
+    session: ClientSession, name: str, arguments: dict[str, Any], code: str
+) -> None:
+    with anyio.fail_after(10):
+        result = await session.call_tool(name, arguments)
+    assert result.isError is True
+    text = " ".join(str(item) for item in result.content)
+    assert code in text
+    assert "retryable=true" in text
+    assert "correlation_id=" in text
+
+
+@asynccontextmanager
+async def mcp_session(
+    root: Path,
+    environment: dict[str, str],
+    *,
+    base_url: str,
+    device_token: str,
+    mcp_token: str,
+    label: str,
+):
+    mcp_environment = {
+        **environment,
+        "JOBOS_API_BASE_URL": base_url,
+        "JOBOS_DEVICE_TOKEN": device_token,
+        "JOBOS_MCP_TOKEN": mcp_token,
+    }
+    error_path = root / "logs" / f"mcp-{label}.stderr.log"
+    try:
+        with error_path.open("w", encoding="utf-8") as errors:
+            parameters = StdioServerParameters(
+                command="uv",
+                args=["run", "--frozen", "--no-sync", "jobos-mcp"],
+                env=mcp_environment,
+            )
+            async with (
+                stdio_client(parameters, errlog=errors) as (reader, writer),
+                ClientSession(reader, writer) as session,
+            ):
+                with anyio.fail_after(10):
+                    await session.initialize()
+                    tools = await session.list_tools()
+                assert {tool.name for tool in tools.tools} >= {
+                    "job_list",
+                    "job_inspect",
+                    "job_select",
+                    "job_update_status",
+                    "job_update_description",
+                    "workspace_inspect",
+                    "workspace_update",
+                    "document_draft_get",
+                    "document_draft_snapshot",
+                    "document_refresh",
+                    "document_render",
+                    "browser_tabs_inspect",
+                }
+                yield session
+    finally:
+        if error_path.exists():
+            error_path.write_text(redact(error_path.read_text(encoding="utf-8")), encoding="utf-8")
+
+
+def read_credentials(config: dict[str, Any], profile: Path) -> tuple[str, str]:
+    store = config["credentialStore"]
+    assert store["provider"] == "file"
+    path = Path(store["path"])
+    target = path if path.is_absolute() else profile / path
+    metadata = target.lstat()
+    assert stat.S_IMODE(metadata.st_mode) == 0o600
+    assert not target.is_symlink()
+    value = json.loads(target.read_text(encoding="utf-8"))
+    return value["deviceToken"], value["mcpToken"]
+
+
+def insert_synthetic_text(content: dict[str, Any], text: str) -> None:
+    for section in content["content"]:
+        if section["attrs"]["semanticRole"] == "cover_letter_body":
+            paragraph = section["content"][0]
+            paragraph["content"] = [{"type": "text", "text": text}]
+            return
+    raise AssertionError("blank cover letter did not contain an editable body")
+
+
+def text_fragments(value: Any) -> list[str]:
+    if isinstance(value, dict):
+        own = [value["text"]] if isinstance(value.get("text"), str) and value["text"] else []
+        return own + text_fragments(value.get("content"))
+    if isinstance(value, list):
+        return [fragment for item in value for fragment in text_fragments(item)]
+    return []
+
+
+def export_pair(
+    root: Path, environment: dict[str, str], document: dict[str, Any]
+) -> tuple[Path, Path, dict[str, Any]]:
+    input_path = root / "synthetic-document.json"
+    docx_path = root / "synthetic-cover-letter.docx"
+    pdf_path = root / "synthetic-cover-letter.pdf"
+    result_path = root / "synthetic-export-result.json"
+    input_path.write_text(json.dumps(document, sort_keys=True), encoding="utf-8")
+    electron = Path.cwd() / "apps/desktop/node_modules/.bin/electron"
+    assert electron.is_file(), "desktop Electron binary was not installed"
+    result = subprocess.run(
+        [
+            str(electron),
+            "scripts/public-release/export-editable-document.mjs",
+            "--input",
+            str(input_path.resolve()),
+            "--docx",
+            str(docx_path.resolve()),
+            "--pdf",
+            str(pdf_path.resolve()),
+            "--result",
+            str(result_path.resolve()),
+        ],
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    (root / "logs/document-export.log").write_text(redact(result.stderr), encoding="utf-8")
+    assert result.returncode == 0, "production document export failed; see redacted harness log"
+    output = json.loads(result_path.read_text(encoding="utf-8"))
+    with zipfile.ZipFile(docx_path) as archive:
+        assert "word/document.xml" in archive.namelist()
+        assert archive.testzip() is None
+        document_xml = ElementTree.fromstring(archive.read("word/document.xml"))
+        exported_text = "".join(document_xml.itertext())
+        expected_fragments = text_fragments(document["content"])
+        assert expected_fragments
+        assert all(fragment in exported_text for fragment in expected_fragments)
+    assert pdf_path.read_bytes().startswith(b"%PDF-")
+    for path, key in ((docx_path, "docx"), (pdf_path, "pdf")):
+        assert 0 < path.stat().st_size <= 20_000_000
+        assert hashlib.sha256(path.read_bytes()).hexdigest() == output[key]["sha256"]
+        assert output[key]["filename"] == path.name
+    return docx_path, pdf_path, output
+
+
+@pytest.mark.anyio
+async def test_clean_home_golden_path(clean_runtime) -> None:
+    root, environment = clean_runtime
+    profile = Path(environment["JOBOS_DATA_DIR"])
+    config_path = Path(environment["JOBOS_CONFIG_PATH"])
+    values = fixture()
+    assert not profile.exists()
+    assert not config_path.exists()
+    assert not any(key.startswith(("HERMES_", "TAILSCALE_", "JOBHUNTER_")) for key in environment)
+    probe = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--frozen",
+            "--no-sync",
+            "python",
+            "-c",
+            "import importlib.util; assert importlib.util.find_spec('job_hunter') is None",
+        ],
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert probe.returncode == 0
+
+    initialization = run_json(
+        [
+            "uv",
+            "run",
+            "--frozen",
+            "--no-sync",
+            "jobos-init",
+            "--data-dir",
+            str(profile),
+            "--config-path",
+            str(config_path),
+        ],
+        environment=environment,
+    )
+    assert initialization == {
+        "status": "ready",
+        "created": True,
+        "demoSeeded": True,
+        "credentialProvider": "file",
+    }
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    assert config["mode"] == "local-service"
+    assert config["jobProvider"] == "sqlite"
+    assert config["artifactProvider"] == "local"
+    assert config["agentProvider"] == "offline"
+    device_token, mcp_token = read_credentials(config, profile)
+
+    api = ApiProcess(root, environment, device_token)
+    document: dict[str, Any]
+    workspace_revision: int
+    exported: tuple[Path, Path, dict[str, Any]] | None = None
+    artifact_bytes: dict[str, bytes] = {}
+    try:
+        api.start("first")
+        with api.client() as client:
+            health = assert_response(client.get("/v1/health"))
+            assert {key: health[key] for key in EXPECTED_HEALTH} == EXPECTED_HEALTH
+            assert assert_response(client.get("/v1/version"))["contract"] == "jobos-api-v1"
+            session_state = assert_response(client.get("/v1/device-session"))
+            assert session_state["desktop"] == "disconnected"
+            assert session_state["transport"] == "local-loopback"
+
+        async with mcp_session(
+            root,
+            environment,
+            base_url=api.base_url,
+            device_token=device_token,
+            mcp_token=mcp_token,
+            label="first",
+        ) as mcp:
+            jobs = (await call(mcp, "job_list", {"idempotency_key": "clean-list-1"}))["jobs"]
+            assert len(jobs) == 1
+            demo = jobs[0]
+            assert demo["synthetic_demo"] is True
+            assert demo["dataset_version"] == "jobos-demo-v1"
+            job_id = demo["job_id"]
+            inspected = await call(
+                mcp, "job_inspect", {"job_id": job_id, "idempotency_key": "clean-inspect-1"}
+            )
+            assert inspected["job_id"] == job_id
+            selected = await call(
+                mcp, "job_select", {"job_id": job_id, "idempotency_key": "clean-select-1"}
+            )
+            assert selected["event_id"]
+            updated_status = await call(
+                mcp,
+                "job_update_status",
+                {
+                    "job_id": job_id,
+                    "target_status": "reviewed",
+                    "reason": "Synthetic review",
+                    "idempotency_key": "clean-status-1",
+                },
+            )
+            assert updated_status["job"]["status"] == "reviewed"
+            updated_description = await call(
+                mcp,
+                "job_update_description",
+                {
+                    "job_id": job_id,
+                    "description_text": values["description"],
+                    "source_note": "Synthetic clean-clone fixture",
+                    "idempotency_key": "clean-description-1",
+                },
+            )
+            assert updated_description["job"]["description"] == values["description"]
+            workspace = await call(
+                mcp, "workspace_inspect", {"idempotency_key": "clean-workspace-read-1"}
+            )
+            for response_only in ("repaired_presets", "repaired_browser", "browser_repair_reasons"):
+                workspace.pop(response_only, None)
+            workspace["browse_query"] = values["workspaceQuery"]
+            persisted_workspace = await call(
+                mcp,
+                "workspace_update",
+                {"snapshot": workspace, "idempotency_key": "clean-workspace-write-1"},
+            )
+            workspace_revision = persisted_workspace["revision"]
+
+            with api.client() as client:
+                history = assert_response(client.get(f"/v1/jobs/{job_id}/history"))["events"]
+                assert {event["event_type"] for event in history} >= {
+                    "lead_state_changed",
+                    "job_description_updated",
+                }
+                document = assert_response(
+                    client.post(
+                        f"/v1/jobs/{job_id}/editable-documents",
+                        json={
+                            "mode": "blank",
+                            "document_key": "cover_letter",
+                            "idempotency_key": "clean-document-create-1",
+                        },
+                    ),
+                    201,
+                )
+                insert_synthetic_text(document["content"], values["documentText"])
+                document = assert_response(
+                    client.put(
+                        f"/v1/editable-documents/{document['document_id']}",
+                        json={
+                            "base_revision": document["revision"],
+                            "content": document["content"],
+                            "settings": document["settings"],
+                            "comments": document["comments"],
+                            "idempotency_key": "clean-document-save-1",
+                        },
+                    )
+                )
+            draft = await call(
+                mcp,
+                "document_draft_get",
+                {
+                    "job_id": job_id,
+                    "document_key": "cover_letter",
+                    "idempotency_key": "clean-document-read-1",
+                },
+            )
+            assert any(block["text"] == values["documentText"] for block in draft["outline"])
+            snapshot = await call(
+                mcp,
+                "document_draft_snapshot",
+                {
+                    "job_id": job_id,
+                    "document_id": document["document_id"],
+                    "label": values["snapshotLabel"],
+                    "idempotency_key": "clean-document-snapshot-1",
+                },
+            )
+            assert snapshot["document_revision"] == document["revision"]
+
+            if os.environ["JOBOS_CLEAN_CLONE_PLATFORM"] == "complete":
+                exported = export_pair(root, environment, document)
+                docx_path, pdf_path, checksums = exported
+                docx_bytes, pdf_bytes = docx_path.read_bytes(), pdf_path.read_bytes()
+                with api.client() as client:
+                    published = assert_response(
+                        client.post(
+                            f"/v1/editable-documents/{document['document_id']}/publish",
+                            json={
+                                "expected_revision": document["revision"],
+                                "docx_filename": docx_path.name,
+                                "docx_base64": base64.b64encode(docx_bytes).decode("ascii"),
+                                "docx_sha256": checksums["docx"]["sha256"],
+                                "pdf_filename": pdf_path.name,
+                                "pdf_base64": base64.b64encode(pdf_bytes).decode("ascii"),
+                                "pdf_sha256": checksums["pdf"]["sha256"],
+                                "idempotency_key": "clean-document-publish-1",
+                            },
+                        )
+                    )
+                    assert published["published_revision"] == document["revision"]
+                    artifacts = assert_response(client.get(f"/v1/jobs/{job_id}/artifacts"))[
+                        "artifacts"
+                    ]
+                    assert len(artifacts) == 2
+                    expected_by_type = {
+                        (
+                            "application/vnd.openxmlformats-officedocument."
+                            "wordprocessingml.document"
+                        ): docx_bytes,
+                        "application/pdf": pdf_bytes,
+                    }
+                    for artifact in artifacts:
+                        downloaded = client.get(f"/v1/artifacts/{artifact['artifact_id']}/download")
+                        assert downloaded.status_code == 200
+                        expected = expected_by_type[artifact["media_type"]]
+                        assert downloaded.content == expected
+                        artifact_bytes[artifact["artifact_id"]] = expected
+
+            await assert_optional_error(
+                mcp,
+                "browser_tabs_inspect",
+                {"timeout_ms": 500},
+                "desktop_unavailable",
+            )
+            await assert_optional_error(
+                mcp,
+                "document_refresh",
+                {"job_id": job_id, "idempotency_key": "clean-refresh-1"},
+                "artifact_provider_unavailable",
+            )
+            await assert_optional_error(
+                mcp,
+                "document_render",
+                {
+                    "job_id": job_id,
+                    "source_id": "synthetic-source",
+                    "idempotency_key": "clean-render-1",
+                },
+                "renderer_unavailable",
+            )
+        with api.client() as client:
+            health = assert_response(client.get("/v1/health"))
+            assert {key: health[key] for key in EXPECTED_HEALTH} == EXPECTED_HEALTH
+    finally:
+        api.stop()
+
+    repeated = run_json(
+        [
+            "uv",
+            "run",
+            "--frozen",
+            "--no-sync",
+            "jobos-init",
+            "--data-dir",
+            str(profile),
+            "--config-path",
+            str(config_path),
+        ],
+        environment=environment,
+    )
+    assert repeated == {
+        "status": "ready",
+        "created": False,
+        "demoSeeded": False,
+        "credentialProvider": "file",
+    }
+
+    try:
+        api.start("restart")
+        async with mcp_session(
+            root,
+            environment,
+            base_url=api.base_url,
+            device_token=device_token,
+            mcp_token=mcp_token,
+            label="restart",
+        ) as mcp:
+            jobs = (await call(mcp, "job_list", {"idempotency_key": "clean-list-2"}))["jobs"]
+            assert len(jobs) == 1
+            assert jobs[0]["job_id"] == job_id
+            assert jobs[0]["status"] == "reviewed"
+            inspected = await call(
+                mcp, "job_inspect", {"job_id": job_id, "idempotency_key": "clean-inspect-2"}
+            )
+            assert inspected["description"] == values["description"]
+            workspace = await call(
+                mcp, "workspace_inspect", {"idempotency_key": "clean-workspace-read-2"}
+            )
+            assert workspace["revision"] == workspace_revision
+            assert workspace["browse_query"] == values["workspaceQuery"]
+            with api.client() as client:
+                saved = assert_response(
+                    client.get(f"/v1/editable-documents/{document['document_id']}")
+                )
+                assert saved["revision"] == document["revision"]
+                snapshots = assert_response(
+                    client.get(f"/v1/editable-documents/{document['document_id']}/snapshots")
+                )["snapshots"]
+                assert any(item["label"] == values["snapshotLabel"] for item in snapshots)
+                artifacts = assert_response(client.get(f"/v1/jobs/{job_id}/artifacts"))["artifacts"]
+                assert len(artifacts) == (2 if exported else 0)
+                for artifact in artifacts:
+                    downloaded = client.get(f"/v1/artifacts/{artifact['artifact_id']}/download")
+                    assert downloaded.content == artifact_bytes[artifact["artifact_id"]]
+                removed = client.request(
+                    "DELETE",
+                    f"/v1/jobs/{job_id}/demo",
+                    json={"origin": "user", "idempotency_key": "clean-remove-demo-1"},
+                )
+                assert removed.status_code == 200
+                assert assert_response(client.get("/v1/jobs"))["jobs"] == []
+                assert_response(
+                    client.get(f"/v1/editable-documents/{document['document_id']}"), 404
+                )
+    finally:
+        api.stop()
+
+    after_delete = run_json(
+        [
+            "uv",
+            "run",
+            "--frozen",
+            "--no-sync",
+            "jobos-init",
+            "--data-dir",
+            str(profile),
+            "--config-path",
+            str(config_path),
+        ],
+        environment=environment,
+    )
+    assert after_delete["created"] is False
+    assert after_delete["demoSeeded"] is False
+    try:
+        api.start("after-delete")
+        with api.client() as client:
+            assert assert_response(client.get("/v1/jobs"))["jobs"] == []
+            documents = assert_response(client.get(f"/v1/jobs/{job_id}/editable-documents"), 404)
+            assert documents["detail"] == "Job not found"
+    finally:
+        api.stop()

--- a/tests/public-release/test_smoke_clean_clone.py
+++ b/tests/public-release/test_smoke_clean_clone.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import time
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ROOT = Path(__file__).parents[2]
+SMOKE = load_module("jobos_smoke_clean_clone", ROOT / "scripts/public-release/smoke-clean-clone.py")
+SUPPORT = load_module("jobos_public_release_support_unit", ROOT / "tests/public_release_support.py")
+
+
+@pytest.mark.parametrize(
+    ("value", "secret_fragments"),
+    [
+        ("JOBOS_MCP_TOKEN=sensitive-value-123", ("sensitive-value-123",)),
+        ("JOBOS_DEVICE_TOKEN='sensitive-value-123'", ("sensitive-value-123",)),
+        ('"mcp_token": "sensitive-value-123"', ("sensitive-value-123",)),
+        ('"deviceToken": "sensitive-value-123"', ("sensitive-value-123",)),
+        ("Authorization: Bearer sensitive-value-123", ("sensitive-value-123",)),
+        ('"Authorization": "Bearer sensitive-value-123"', ("sensitive-value-123",)),
+        ("authorization=\"sensitive-value-123\"", ("sensitive-value-123",)),
+        ("Authorization: Basic basic-credential-456", ("basic-credential-456",)),
+        ("Authorization: Token token-credential-789", ("token-credential-789",)),
+        (
+            "Authorization: AWS4-HMAC-SHA256 Credential=aws-credential, "
+            "SignedHeaders=host, Signature=aws-signature",
+            ("aws-credential", "aws-signature"),
+        ),
+        (
+            '"Authorization": "Digest username=\\"Mufasa\\", '
+            'realm=\\"testrealm\\", response=\\"digest-response\\""',
+            ("Mufasa", "testrealm", "digest-response"),
+        ),
+        (
+            "Authorization: Digest username=Mufasa,\n response=folded-response",
+            ("Mufasa", "folded-response"),
+        ),
+        (
+            '"Authorization": "Digest username=Mufasa,\nresponse=malformed-response',
+            ("Mufasa", "malformed-response"),
+        ),
+        (
+            '"Authorization": "Digest username=Mufasa,\\\nresponse=escaped-lf-response',
+            ("Mufasa", "escaped-lf-response"),
+        ),
+        (
+            '"Authorization": "Digest username=Mufasa,\\\r\nresponse=escaped-crlf-response',
+            ("Mufasa", "escaped-crlf-response"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("redactor", [SMOKE.redacted, SUPPORT.redact])
+def test_release_log_redaction_covers_token_and_authorization_formats(
+    value, secret_fragments, redactor
+):
+    result = redactor(value)
+    for secret_fragment in secret_fragments:
+        assert secret_fragment not in result
+    assert "[REDACTED]" in result
+
+
+def test_run_terminates_the_entire_process_group_on_timeout(tmp_path: Path):
+    child_pid_path = tmp_path / "child.pid"
+    script = (
+        "import pathlib, subprocess, sys, time; "
+        "child=subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
+        "pathlib.Path(sys.argv[1]).write_text(str(child.pid)); "
+        "time.sleep(60)"
+    )
+    with pytest.raises(RuntimeError, match="command timed out"):
+        SMOKE.run(
+            [sys.executable, "-c", script, str(child_pid_path)],
+            cwd=tmp_path,
+            environment=dict(os.environ),
+            timeout=0.1,
+            log=tmp_path / "timeout.log",
+        )
+    child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail("descendant process survived the timeout cleanup")
+
+
+def test_run_kills_sigterm_resistant_descendant_after_parent_exits(tmp_path: Path):
+    child_pid_path = tmp_path / "resistant-child.pid"
+    child_ready_path = tmp_path / "resistant-child.ready"
+    child_script = (
+        "import pathlib, signal, sys, time; "
+        "assert signal.getsignal(signal.SIGTERM) == signal.SIG_IGN; "
+        "pathlib.Path(sys.argv[1]).write_text('ready'); "
+        "time.sleep(60)"
+    )
+    parent_script = (
+        "import pathlib, signal, subprocess, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "child=subprocess.Popen([sys.executable, '-c', sys.argv[2], sys.argv[3]], "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL); "
+        "ready=pathlib.Path(sys.argv[3]); "
+        "deadline=time.monotonic()+5; "
+        "exec(\"while not ready.exists() and time.monotonic() < deadline:\\n time.sleep(0.01)\"); "
+        "assert ready.exists(); "
+        "signal.signal(signal.SIGTERM, signal.SIG_DFL); "
+        "pathlib.Path(sys.argv[1]).write_text(str(child.pid)); "
+        "time.sleep(60)"
+    )
+    with pytest.raises(RuntimeError, match="command timed out"):
+        SMOKE.run(
+            [
+                sys.executable,
+                "-c",
+                parent_script,
+                str(child_pid_path),
+                child_script,
+                str(child_ready_path),
+            ],
+            cwd=tmp_path,
+            environment=dict(os.environ),
+            timeout=2,
+            log=tmp_path / "resistant-timeout.log",
+        )
+    assert child_ready_path.read_text(encoding="utf-8") == "ready"
+    child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail("SIGTERM-resistant descendant survived timeout cleanup")
+
+
+@pytest.mark.parametrize("keep_on_failure", [False, True])
+def test_failure_artifacts_are_retained_only_when_requested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, keep_on_failure: bool
+):
+    temporary_root = tmp_path / ("retained" if keep_on_failure else "removed")
+
+    def make_temporary_root(prefix: str) -> str:
+        assert prefix == "jobos-clean-clone-"
+        temporary_root.mkdir(mode=0o700)
+        return str(temporary_root)
+
+    monkeypatch.setattr(SMOKE.tempfile, "mkdtemp", make_temporary_root)
+    arguments = [
+        "smoke-clean-clone.py",
+        "--source",
+        str(ROOT),
+        "--ref",
+        "refs/heads/definitely-missing-clean-clone-ref",
+    ]
+    if keep_on_failure:
+        arguments.append("--keep-on-failure")
+    monkeypatch.setattr(sys, "argv", arguments)
+
+    assert SMOKE.main() == 1
+    assert temporary_root.exists() is keep_on_failure

--- a/tests/public_release_support.py
+++ b/tests/public_release_support.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+REDACTIONS = (
+    (
+        re.compile(
+            r"(?i)([\"']?authorization[\"']?\s*[:=]\s*)"
+            r"(?:\"(?:\\[\s\S]|[^\"\\])*\"|'(?:\\[\s\S]|[^'\\])*'|"
+            r"\"(?:\\[\s\S]|[^\"\\])*\Z|'(?:\\[\s\S]|[^'\\])*\Z|"
+            r"[^\r\n]*(?:\r?\n[ \t]+[^\r\n]*)*)"
+        ),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(
+            r"(?i)([\"']?(?:jobos[_-])?(?:device|mcp)[_-]?token[\"']?\s*[:=]\s*[\"']?)([^\"'\s,;}\]]+)"
+        ),
+        r"\1[REDACTED]",
+    ),
+    (re.compile(r"/(?:Users|home)/[^/\s]+"), "/home/[REDACTED]"),
+)
+
+
+def redact(value: str) -> str:
+    for pattern, replacement in REDACTIONS:
+        value = pattern.sub(replacement, value)
+    return value
+
+
+def isolated_environment(root: Path) -> dict[str, str]:
+    platform_keys = (
+        "USER",
+        "LOGNAME",
+        "__CF_USER_TEXT_ENCODING",
+        "SECURITYSESSIONID",
+    ) if sys.platform == "darwin" else ()
+    allowed = {
+        key: os.environ[key]
+        for key in ("PATH", "SHELL", "LANG", "LC_ALL", "SYSTEMROOT", *platform_keys)
+        if os.environ.get(key)
+    }
+    directories = {
+        "HOME": root / "home",
+        "TMPDIR": root / "tmp",
+        "XDG_DATA_HOME": root / "xdg/data",
+        "XDG_CONFIG_HOME": root / "xdg/config",
+        "XDG_CACHE_HOME": root / "xdg/cache",
+        "XDG_RUNTIME_DIR": root / "xdg/runtime",
+    }
+    for directory in directories.values():
+        directory.mkdir(parents=True, mode=0o700)
+    allowed.update({key: str(value) for key, value in directories.items()})
+    allowed.update(
+        {
+            "JOBOS_DATA_DIR": str(root / "profile"),
+            "JOBOS_CONFIG_PATH": str(root / "profile/config.json"),
+            "JOBOS_KEYCHAIN_HELPER_PATH": str(root / "absent/jobos-keychain"),
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    return allowed
+
+
+def run_json(
+    arguments: list[str], *, environment: dict[str, str], timeout: int = 15
+) -> dict[str, Any]:
+    result = subprocess.run(
+        arguments,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode:
+        detail = redact(result.stderr).strip().splitlines()[-20:]
+        raise AssertionError(
+            f"{arguments[0]} failed with exit code {result.returncode}: {' | '.join(detail)}"
+        )
+    value = json.loads(result.stdout)
+    assert isinstance(value, dict)
+    return value
+
+
+class ApiProcess:
+    def __init__(self, root: Path, environment: dict[str, str], token: str) -> None:
+        self.root = root
+        self.environment = environment
+        self.token = token
+        self.process: subprocess.Popen[str] | None = None
+        self.base_url = ""
+        self._log = None
+
+    def start(self, label: str) -> None:
+        self._label = label
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(128)
+        listener.set_inheritable(True)
+        port = listener.getsockname()[1]
+        self.base_url = f"http://127.0.0.1:{port}"
+        self._log = (self.root / "logs" / f"api-{label}.log").open("w", encoding="utf-8")
+        self.process = subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "--frozen",
+                "--no-sync",
+                "uvicorn",
+                "jobos_api.main:app",
+                "--fd",
+                str(listener.fileno()),
+                "--no-access-log",
+                "--log-level",
+                "warning",
+            ],
+            env=self.environment,
+            stdin=subprocess.DEVNULL,
+            stdout=self._log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            pass_fds=(listener.fileno(),),
+        )
+        listener.close()
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                raise AssertionError("JobOS API exited before readiness")
+            try:
+                response = httpx.get(f"{self.base_url}/v1/health", timeout=1)
+                if response.status_code == 200:
+                    return
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.1)
+        raise AssertionError("JobOS API did not become ready within 15 seconds")
+
+    def client(self) -> httpx.Client:
+        return httpx.Client(
+            base_url=self.base_url,
+            headers={"Authorization": f"Bearer {self.token}"},
+            timeout=10,
+        )
+
+    def stop(self) -> None:
+        if self.process is not None and self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=5)
+        if self._log is not None:
+            self._log.close()
+            path = self.root / "logs" / f"api-{self._label}.log"
+            path.write_text(redact(path.read_text(encoding="utf-8")), encoding="utf-8")
+        self.process = None
+
+
+@pytest.fixture
+def clean_runtime(tmp_path: Path):
+    root = tmp_path / "runtime"
+    root.mkdir(mode=0o700)
+    (root / "logs").mkdir(mode=0o700)
+    environment = isolated_environment(root)
+    yield root, environment


### PR DESCRIPTION
## Summary
- add an exact-revision clean-clone release harness
- prove isolated API/MCP lifecycle, restart persistence, deletion without reseeding, and local artifact persistence
- produce and validate synthetic DOCX/PDF exports through the production path
- enforce the source subset in Linux CI and complete export proof on macOS

## Verification
- pnpm check
- pnpm contracts:check
- pnpm contracts:test-drift
- 34 focused privacy/process regression tests
- complete macOS golden path
- pnpm public:smoke-clean-clone against committed revision c8f3ca389a1bab37aa63de2323ff3805b6e340f6
- independent exact-byte approval for staged diff be78d6bdb612b5cb3d4b9dacef5fbaedcd2ba7e5a70361d3fc0e0d432edcdd88

No deployment, publication, updater transmission, or history rewrite is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added public-release workflows for exporting editable documents to DOCX and PDF, including checksum metadata and clear failure reporting.
  - Added a clean-clone validation path covering setup, configuration, document editing, persistence, downloads, and optional publishing.

- **Bug Fixes**
  - Clarified document-edit audit activity as originating from MCP operations.

- **Tests**
  - Expanded automated validation across Linux and macOS, including security checks, export integrity, restart persistence, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->