### PR TITLE
Fix updater smoke path canonicalization

### DIFF
--- a/apps/desktop/scripts/create-macbook-update.mjs
+++ b/apps/desktop/scripts/create-macbook-update.mjs
@@ -8,6 +8,7 @@ import {
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   readFileSync,
   readdirSync,
   readlinkSync,
@@ -552,8 +553,9 @@ function treeDigest(root) {
 }
 
 function runSmokeTests(updaterPath, verifyRoot) {
-  const testRoot = path.join(verifyRoot, 'updater-smoke')
-  mkdirSync(testRoot)
+  const testRootPath = path.join(verifyRoot, 'updater-smoke')
+  mkdirSync(testRootPath)
+  const testRoot = realpathSync(testRootPath)
   const sentinels = [path.join(testRoot, 'external-config.json'), path.join(testRoot, 'external-state.sqlite')]
   writeFileSync(sentinels[0], '{"synthetic":"config"}\n')
   writeFileSync(sentinels[1], randomBytes(257))


### PR DESCRIPTION
## Summary
- canonicalize the private updater smoke root before deriving transaction fixtures
- prevent macOS `/var` versus `/private/var` aliases from invalidating recovery proof

## Verification
- full `pnpm check`
- contracts check and drift proof
- public/media checks
- updater tests: 10 passed
- independent exact-byte review approved