### PR TITLE
Strip private build paths from Swift helper

### DIFF
--- a/apps/desktop/scripts/build-docx-atomic-replace.mjs
+++ b/apps/desktop/scripts/build-docx-atomic-replace.mjs
@@ -1,11 +1,12 @@
 import { execFileSync } from 'node:child_process'
-import { mkdirSync } from 'node:fs'
+import { mkdirSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
 const desktopRoot = path.resolve(scriptDirectory, '..')
-const source = path.join(desktopRoot, 'native', 'JobOSDocxAtomicReplace.swift')
+const source = path.join('native', 'JobOSDocxAtomicReplace.swift')
 const outputDirectory = path.join(desktopRoot, 'build')
 const output = path.join(outputDirectory, 'jobos-docx-atomic-replace')
 
@@ -17,6 +18,26 @@ if (process.platform !== 'darwin') {
 mkdirSync(outputDirectory, { recursive: true })
 execFileSync(
   '/usr/bin/xcrun',
-  ['swiftc', source, '-framework', 'CryptoKit', '-o', output],
-  { stdio: 'inherit' }
+  [
+    'swiftc',
+    source,
+    '-framework',
+    'CryptoKit',
+    '-debug-prefix-map',
+    `${desktopRoot}=/jobos/apps/desktop`,
+    '-file-prefix-map',
+    `${desktopRoot}=/jobos/apps/desktop`,
+    '-file-compilation-dir',
+    '/jobos',
+    '-o',
+    output
+  ],
+  { cwd: desktopRoot, stdio: 'inherit' }
 )
+
+const helperBytes = readFileSync(output)
+for (const privatePath of [desktopRoot, homedir()]) {
+  if (privatePath && helperBytes.includes(Buffer.from(privatePath))) {
+    throw new Error(`DOCX atomic-replace helper contains a private build path`)
+  }
+}


### PR DESCRIPTION
## Summary
- compile the DOCX atomic-replace helper from a relative source path
- remap compiler paths to synthetic public locations
- fail packaging if the generated helper contains the build root or home path

## Verification
- full pnpm check
- contracts/public/media checks
- helper rebuilt under multiple roots with byte-identical output
- generated binary privacy scan passed
- independent exact-byte review approved