### PR TITLE
Fix panel drag reordering over native browser

### DIFF
--- a/apps/desktop/src/renderer/App.test.tsx
+++ b/apps/desktop/src/renderer/App.test.tsx
@@ -1233,20 +1233,91 @@ test('pointer resizing tracks movement and every panel has a recovery affordance
   }
 })
 
-test('drag reordering shows an insertion preview before changing presentation only', () => {
+test('drag reordering shows an insertion preview before changing presentation only', async () => {
   Object.defineProperty(window, 'jobos', { configurable: true, value: undefined })
+  const rect = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    const panel = this.getAttribute('data-testid')
+    const x = panel === 'panel-jobs' ? 0 : panel === 'panel-center' ? 100 : panel === 'panel-agent' ? 200 : 0
+    return DOMRect.fromRect({ x, y: 0, width: 100, height: 500 })
+  })
   render(<App />)
   const source = screen.getByRole('button', { name: 'Reorder Agent chat' })
   const target = screen.getByTestId('panel-jobs')
-  const transfer = { getData: vi.fn().mockReturnValue('agent'), setData: vi.fn(), effectAllowed: '' }
 
-  fireEvent.dragStart(source, { dataTransfer: transfer })
-  fireEvent.dragOver(target, { dataTransfer: transfer })
+  fireEvent.pointerDown(source, { button: 0, clientX: 250, pointerId: 1 })
+  await act(async () => undefined)
+  fireEvent.pointerMove(window, { clientX: 50, pointerId: 1 })
   expect(target.classList.contains('insertion-target')).toBe(true)
-  fireEvent.drop(target, { dataTransfer: transfer })
+  fireEvent.pointerUp(window, { clientX: 50, pointerId: 1 })
 
   expect(panelDomOrder()).toEqual(['agent', 'jobs', 'center'])
   expect(target.classList.contains('insertion-target')).toBe(false)
+  rect.mockRestore()
+})
+
+test('panel reordering detaches the native browser so the center panel can receive the drop', async () => {
+  const tab = {
+    tabId: 'listing', url: 'https://jobs.example.com/7', title: 'Listing', faviconUrl: null, associatedJobId: null,
+    loading: false, canGoBack: false, canGoForward: false, error: null, crashed: false, blockedUrl: null
+  }
+  const browserState = { tabs: [tab], activeTabId: tab.tabId, download: null, notice: null }
+  const detachResolvers: Array<() => void> = []
+  const setBounds = vi.fn().mockImplementation(bounds => bounds.visible
+    ? Promise.resolve()
+    : new Promise<void>(resolve => detachResolvers.push(resolve)))
+  const rect = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    const panel = this.getAttribute('data-testid')
+    if (panel) {
+      const x = panel === 'panel-jobs' ? 0 : panel === 'panel-center' ? 100 : 200
+      return DOMRect.fromRect({ x, y: 0, width: 100, height: 500 })
+    }
+    return DOMRect.fromRect({ x: 100, y: 120, width: 800, height: 500 })
+  })
+  Object.defineProperty(window, 'jobos', { configurable: true, value: {
+    connectivity: { get: vi.fn().mockResolvedValue({ state: 'connected', checkedAt: '', message: 'Private API authenticated' }) },
+    workspace: {
+      get: vi.fn().mockResolvedValue({
+        ...restoredWorkspace(3), selectedPreset: 'research', activeCenterSurface: 'browser',
+        browserTabs: [{ tabId: tab.tabId, url: tab.url, title: tab.title, faviconUrl: null, associatedJobId: null }],
+        activeBrowserTabId: tab.tabId, repairedBrowser: false
+      }),
+      save: vi.fn().mockImplementation(snapshot => Promise.resolve({ ...snapshot, revision: snapshot.revision + 1 }))
+    },
+    browser: {
+      restore: vi.fn().mockResolvedValue(browserState), getState: vi.fn(), subscribe: vi.fn().mockReturnValue(() => undefined), setBounds,
+      create: vi.fn(), select: vi.fn(), close: vi.fn(), reorder: vi.fn(), navigate: vi.fn(), back: vi.fn(), forward: vi.fn(),
+      reload: vi.fn(), stop: vi.fn(), associate: vi.fn(), copyBlockedUrl: vi.fn()
+    }
+  } })
+
+  render(<App />)
+  await screen.findByRole('tab', { name: 'Select Listing' })
+  await waitFor(() => expect(setBounds).toHaveBeenCalledWith(expect.objectContaining({ visible: true })))
+  setBounds.mockClear()
+  detachResolvers.length = 0
+  const source = screen.getByRole('button', { name: 'Reorder Agent chat' })
+  const target = screen.getByTestId('panel-center')
+
+  fireEvent.pointerDown(source, { button: 0, clientX: 250, pointerId: 1 })
+  await waitFor(() => expect(setBounds).toHaveBeenCalledWith(expect.objectContaining({ visible: false })))
+  fireEvent.pointerMove(window, { clientX: 150, pointerId: 1 })
+  expect(target.classList.contains('insertion-target')).toBe(false)
+  expect(panelDomOrder()).toEqual(['jobs', 'center', 'agent'])
+  await act(async () => detachResolvers.shift()?.())
+  await waitFor(() => expect(target.classList.contains('insertion-target')).toBe(true))
+  fireEvent.pointerUp(window, { clientX: 150, pointerId: 1 })
+
+  expect(panelDomOrder()).toEqual(['jobs', 'agent', 'center'])
+  await waitFor(() => expect(setBounds).toHaveBeenCalledWith(expect.objectContaining({ visible: true })))
+
+  setBounds.mockClear()
+  detachResolvers.length = 0
+  fireEvent.pointerDown(source, { button: 0, clientX: 150, pointerId: 2 })
+  await waitFor(() => expect(setBounds).toHaveBeenCalledWith(expect.objectContaining({ visible: false })))
+  fireEvent.pointerUp(window, { clientX: 150, pointerId: 2 })
+  await act(async () => detachResolvers.shift()?.())
+  await waitFor(() => expect(setBounds).toHaveBeenCalledWith(expect.objectContaining({ visible: true })))
+  rect.mockRestore()
 })
 
 test('a delayed Browse action survives hydration and Reset Layout leaves Browse state intact', async () => {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -49,9 +49,11 @@ function WorkbenchApp() {
   const [documentMutationGeneration, setDocumentMutationGeneration] = useState(0)
   const [documentPreviewMode, setDocumentPreviewMode] = useState<'pdf' | 'docx'>('pdf')
   const [editingDocument, setEditingDocument] = useState<DocxOpenResult | null>(null)
+  const [panelReorderActive, setPanelReorderActive] = useState(false)
   const nextJobListingRequestId = useRef(0)
   const latestNavigatorSelection = useRef(0)
   const browseTransitionGeneration = useRef(0)
+  const panelReorderGeneration = useRef(0)
   const navigatorSelectionQueue = useRef<Promise<unknown>>(Promise.resolve())
   const prepareClose = useRef<() => Promise<boolean>>(async () => true)
   const activePreset = layoutState.workspace.selectedPreset
@@ -59,6 +61,28 @@ function WorkbenchApp() {
   const activeLayout = layoutState.workspace.layouts[activePreset]
   const browseVisible = activeTopLevelWorkspace === 'browse' && browseDetachState === 'ready'
   const browserTransitionPending = browseDetachState === 'preparing'
+  const nativeBrowserVisible = layoutState.hydrated && activeTopLevelWorkspace !== 'browse' && !browserTransitionPending && !activeLayout.collapsed.includes('center') && !settingsOpen && !settingsPreparing
+
+  const changePanelReorderInteraction = useCallback(async (active: boolean) => {
+    if (!active) {
+      panelReorderGeneration.current += 1
+      setPanelReorderActive(false)
+      return true
+    }
+    const generation = panelReorderGeneration.current + 1
+    panelReorderGeneration.current = generation
+    setPanelReorderActive(true)
+    if (nativeBrowserVisible && window.jobos?.browser) {
+      try {
+        await window.jobos.browser.setBounds({ x: 0, y: 0, width: 0, height: 0, visible: false })
+      } catch {
+        if (generation === panelReorderGeneration.current) setPanelReorderActive(false)
+        return false
+      }
+    }
+    if (generation !== panelReorderGeneration.current) return false
+    return true
+  }, [nativeBrowserVisible])
 
   useEffect(() => window.jobos?.lifecycle?.subscribePrepareClose(
     () => prepareClose.current()
@@ -240,7 +264,7 @@ function WorkbenchApp() {
           }}
           browserRepaired={Boolean(layoutState.workspace.repairedBrowser)}
           browserRepairReasons={layoutState.workspace.browserRepairReasons ?? []}
-          browserVisible={layoutState.hydrated && activeTopLevelWorkspace !== 'browse' && !browserTransitionPending && !activeLayout.collapsed.includes('center') && !settingsOpen && !settingsPreparing}
+          browserVisible={nativeBrowserVisible && !panelReorderActive}
           agentConversationId={agentSessions.activeId}
           documentMutationGeneration={documentMutationGeneration}
           documentPreviewMode={documentPreviewMode}
@@ -278,6 +302,7 @@ function WorkbenchApp() {
         />}
         onCollapse={layoutState.collapse}
         onMove={layoutState.move}
+        onReorderInteractionChange={changePanelReorderInteraction}
         onResize={layoutState.resize}
         workspace={layoutState.workspace}
       />

--- a/apps/desktop/src/renderer/components/WorkbenchLayout.test.tsx
+++ b/apps/desktop/src/renderer/components/WorkbenchLayout.test.tsx
@@ -1,0 +1,140 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+import { canonicalWorkspace } from '../workspaceLayout'
+import { WorkbenchLayout } from './WorkbenchLayout'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  cleanup()
+})
+
+function mockPanelBounds() {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    const panel = this.getAttribute('data-testid')
+    const x = panel === 'panel-jobs' ? 0 : panel === 'panel-center' ? 100 : panel === 'panel-agent' ? 200 : 0
+    return DOMRect.fromRect({ x, y: 100, width: 100, height: 400 })
+  })
+}
+
+function layout(onMove = vi.fn(), onReorderInteractionChange = vi.fn()) {
+  return (
+    <WorkbenchLayout
+      agent={<div />}
+      center={<div />}
+      jobs={<div />}
+      onCollapse={vi.fn()}
+      onMove={onMove}
+      onReorderInteractionChange={onReorderInteractionChange}
+      onResize={vi.fn()}
+      workspace={canonicalWorkspace()}
+    />
+  )
+}
+
+test('unmounting during a reorder releases the native-surface interaction state', () => {
+  const onReorderInteractionChange = vi.fn()
+  const view = render(layout(vi.fn(), onReorderInteractionChange))
+
+  fireEvent.pointerDown(screen.getByRole('button', { name: 'Reorder Agent chat' }), {
+    clientX: 250,
+    clientY: 150,
+    pointerId: 1
+  })
+  expect(onReorderInteractionChange).toHaveBeenLastCalledWith(true)
+
+  view.unmount()
+  expect(onReorderInteractionChange).toHaveBeenLastCalledWith(false)
+})
+
+test('releasing outside the panels cancels the reorder', async () => {
+  mockPanelBounds()
+  const onMove = vi.fn()
+  render(layout(onMove))
+
+  fireEvent.pointerDown(screen.getByRole('button', { name: 'Reorder Agent chat' }), {
+    button: 0,
+    clientX: 250,
+    clientY: 150,
+    pointerId: 1
+  })
+  await act(async () => undefined)
+  fireEvent.pointerMove(window, { clientX: 150, clientY: 50, pointerId: 1 })
+  expect(screen.getByTestId('panel-center').classList.contains('insertion-target')).toBe(false)
+  fireEvent.pointerUp(window, { clientX: 150, clientY: 50, pointerId: 1 })
+
+  expect(onMove).not.toHaveBeenCalled()
+})
+
+test('changing the interaction callback mid-gesture clears the insertion target', async () => {
+  mockPanelBounds()
+  const firstInteraction = vi.fn()
+  const view = render(layout(vi.fn(), firstInteraction))
+
+  fireEvent.pointerDown(screen.getByRole('button', { name: 'Reorder Agent chat' }), {
+    button: 0,
+    clientX: 250,
+    clientY: 150,
+    pointerId: 1
+  })
+  await act(async () => undefined)
+  fireEvent.pointerMove(window, { clientX: 150, clientY: 150, pointerId: 1 })
+  expect(screen.getByTestId('panel-center').classList.contains('insertion-target')).toBe(true)
+
+  view.rerender(layout(vi.fn(), vi.fn()))
+
+  expect(screen.getByTestId('panel-center').classList.contains('insertion-target')).toBe(false)
+  expect(firstInteraction).toHaveBeenLastCalledWith(false)
+})
+
+test('Escape cancels an active pointer reorder', async () => {
+  mockPanelBounds()
+  const onMove = vi.fn()
+  const onReorderInteractionChange = vi.fn()
+  render(layout(onMove, onReorderInteractionChange))
+
+  fireEvent.pointerDown(screen.getByRole('button', { name: 'Reorder Agent chat' }), {
+    button: 0,
+    clientX: 250,
+    clientY: 150,
+    pointerId: 1
+  })
+  await act(async () => undefined)
+  fireEvent.pointerMove(window, { clientX: 150, clientY: 150, pointerId: 1 })
+  expect(screen.getByTestId('panel-center').classList.contains('insertion-target')).toBe(true)
+
+  fireEvent.keyDown(window, { key: 'Escape' })
+  fireEvent.pointerUp(window, { clientX: 150, clientY: 150, pointerId: 1 })
+
+  expect(screen.getByTestId('panel-center').classList.contains('insertion-target')).toBe(false)
+  expect(onMove).not.toHaveBeenCalled()
+  expect(onReorderInteractionChange).toHaveBeenLastCalledWith(false)
+})
+
+test('a stale approval cannot affect a newer gesture that reuses the pointer id', async () => {
+  mockPanelBounds()
+  const onMove = vi.fn()
+  let resolveFirst!: (approved: boolean) => void
+  let firstStart = true
+  const onReorderInteractionChange = vi.fn((active: boolean) => {
+    if (!active) return true
+    if (!firstStart) return true
+    firstStart = false
+    return new Promise<boolean>(resolve => { resolveFirst = resolve })
+  })
+  render(layout(onMove, onReorderInteractionChange))
+  const control = screen.getByRole('button', { name: 'Reorder Agent chat' })
+
+  fireEvent.pointerDown(control, { button: 0, clientX: 250, clientY: 150, pointerId: 1 })
+  fireEvent.pointerUp(window, { clientX: 250, clientY: 150, pointerId: 1 })
+  fireEvent.pointerDown(control, { button: 0, clientX: 250, clientY: 150, pointerId: 1 })
+  await act(async () => undefined)
+  fireEvent.pointerMove(window, { clientX: 150, clientY: 150, pointerId: 1 })
+  expect(screen.getByTestId('panel-center').classList.contains('insertion-target')).toBe(true)
+
+  await act(async () => resolveFirst(false))
+  expect(screen.getByTestId('panel-center').classList.contains('insertion-target')).toBe(true)
+  fireEvent.pointerUp(window, { clientX: 150, clientY: 150, pointerId: 1 })
+
+  expect(onMove).toHaveBeenCalledWith('agent', 1)
+})

--- a/apps/desktop/src/renderer/components/WorkbenchLayout.tsx
+++ b/apps/desktop/src/renderer/components/WorkbenchLayout.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, ArrowRight, GripVertical, PanelLeftClose } from 'lucide-react'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { PanelId, WorkspaceSnapshot } from '../workspaceLayout'
 import { panelNames } from '../workspaceLayout'
@@ -7,6 +7,7 @@ import { panelNames } from '../workspaceLayout'
 interface WorkbenchLayoutProps {
   workspace: WorkspaceSnapshot
   onCollapse: (panel: PanelId, collapsed: boolean) => void
+  onReorderInteractionChange?: (active: boolean) => boolean | void | Promise<boolean | void>
   onMove: (panel: PanelId, targetIndex: number) => void
   onResize: (before: PanelId, after: PanelId, delta: number) => void
   jobs: React.ReactNode
@@ -17,10 +18,116 @@ interface WorkbenchLayoutProps {
 export function WorkbenchLayout(props: WorkbenchLayoutProps) {
   const [insertionTarget, setInsertionTarget] = useState<PanelId | null>(null)
   const collapseControls = useRef<Partial<Record<PanelId, HTMLButtonElement | null>>>({})
+  const panelElements = useRef<Partial<Record<PanelId, HTMLElement | null>>>({})
   const recoveryControls = useRef<Partial<Record<PanelId, HTMLButtonElement | null>>>({})
+  const reorderPointer = useRef<{
+    pointerId: number
+    source: PanelId
+    target: PanelId | null
+    clientX: number
+    clientY: number
+    ready: boolean
+  } | null>(null)
+  const reorderReleaseCleanup = useRef<(() => void) | null>(null)
   const layout = props.workspace.layouts[props.workspace.selectedPreset]
   const content: Record<PanelId, React.ReactNode> = { jobs: props.jobs, center: props.center, agent: props.agent }
   const visibleOrder = layout.order.filter(panel => !layout.collapsed.includes(panel))
+
+  useEffect(() => () => {
+    reorderPointer.current = null
+    reorderReleaseCleanup.current?.()
+    reorderReleaseCleanup.current = null
+    setInsertionTarget(null)
+    void props.onReorderInteractionChange?.(false)
+  }, [props.onReorderInteractionChange])
+
+  const targetAt = (clientX: number, clientY: number) => visibleOrder.find(panelId => {
+    const rect = panelElements.current[panelId]?.getBoundingClientRect()
+    return Boolean(
+      rect
+      && clientX >= rect.left
+      && clientX <= rect.right
+      && clientY >= rect.top
+      && clientY <= rect.bottom
+    )
+  }) ?? null
+
+  const updateReorderTarget = (clientX: number, clientY: number) => {
+    const gesture = reorderPointer.current
+    if (!gesture) return
+    gesture.clientX = clientX
+    gesture.clientY = clientY
+    if (!gesture.ready) return
+    gesture.target = targetAt(clientX, clientY)
+    setInsertionTarget(gesture.target)
+  }
+
+  const finishReorderInteraction = (commit: boolean) => {
+    const gesture = reorderPointer.current
+    reorderPointer.current = null
+    reorderReleaseCleanup.current?.()
+    reorderReleaseCleanup.current = null
+    setInsertionTarget(null)
+    if (commit && gesture?.ready && gesture.target && gesture.target !== gesture.source) {
+      props.onMove(gesture.source, layout.order.indexOf(gesture.target))
+    }
+    void props.onReorderInteractionChange?.(false)
+  }
+
+  const prepareReorderInteraction = (event: React.PointerEvent<HTMLButtonElement>, source: PanelId) => {
+    if (event.button !== 0) return
+    event.preventDefault()
+    reorderReleaseCleanup.current?.()
+    const pointerId = event.pointerId
+    const gesture = {
+      pointerId,
+      source,
+      target: null,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      ready: false
+    }
+    reorderPointer.current = gesture
+    event.currentTarget.setPointerCapture?.(pointerId)
+    const move = (pointerEvent: PointerEvent) => {
+      if (pointerEvent.pointerId === pointerId) updateReorderTarget(pointerEvent.clientX, pointerEvent.clientY)
+    }
+    const release = (pointerEvent: PointerEvent) => {
+      if (pointerEvent.pointerId !== pointerId) return
+      updateReorderTarget(pointerEvent.clientX, pointerEvent.clientY)
+      finishReorderInteraction(true)
+    }
+    const cancel = (pointerEvent: PointerEvent) => {
+      if (pointerEvent.pointerId === pointerId) finishReorderInteraction(false)
+    }
+    const cancelWithKeyboard = (keyboardEvent: KeyboardEvent) => {
+      if (keyboardEvent.key === 'Escape' && reorderPointer.current === gesture) {
+        keyboardEvent.preventDefault()
+        finishReorderInteraction(false)
+      }
+    }
+    window.addEventListener('pointermove', move)
+    window.addEventListener('pointerup', release)
+    window.addEventListener('pointercancel', cancel)
+    window.addEventListener('keydown', cancelWithKeyboard)
+    reorderReleaseCleanup.current = () => {
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', release)
+      window.removeEventListener('pointercancel', cancel)
+      window.removeEventListener('keydown', cancelWithKeyboard)
+    }
+    void Promise.resolve(props.onReorderInteractionChange?.(true)).then(approved => {
+      if (reorderPointer.current !== gesture) return
+      if (approved === false) {
+        finishReorderInteraction(false)
+        return
+      }
+      gesture.ready = true
+      updateReorderTarget(gesture.clientX, gesture.clientY)
+    }).catch(() => {
+      if (reorderPointer.current === gesture) finishReorderInteraction(false)
+    })
+  }
 
   const panel = (panelId: PanelId) => {
     const index = layout.order.indexOf(panelId)
@@ -33,13 +140,7 @@ export function WorkbenchLayout(props: WorkbenchLayoutProps) {
         hidden={layout.collapsed.includes(panelId)}
         id={`workbench-panel-${panelId}`}
         key={panelId}
-        onDragOver={event => { event.preventDefault(); setInsertionTarget(panelId) }}
-        onDrop={event => {
-          event.preventDefault()
-          const source = event.dataTransfer.getData('application/x-jobos-panel') as PanelId
-          if (source && source !== panelId) props.onMove(source, index)
-          setInsertionTarget(null)
-        }}
+        ref={element => { panelElements.current[panelId] = element }}
         style={{ flexBasis: `${layout.widths[panelId]}px` }}
       >
         {previous ? (
@@ -60,11 +161,7 @@ export function WorkbenchLayout(props: WorkbenchLayoutProps) {
               <button
                 aria-label={`Reorder ${panelNames[panelId]}`}
                 className="panel-control drag-control"
-                draggable
-                onDragStart={event => {
-                  event.dataTransfer.effectAllowed = 'move'
-                  event.dataTransfer.setData('application/x-jobos-panel', panelId)
-                }}
+                onPointerDown={event => prepareReorderInteraction(event, panelId)}
                 title={`Drag to reorder ${panelNames[panelId]}`}
                 type="button"
               ><GripVertical aria-hidden="true" size={14} /></button>
@@ -116,9 +213,7 @@ export function WorkbenchLayout(props: WorkbenchLayoutProps) {
           ))}
         </nav>
       ) : null}
-      <div className="workbench" onDragLeave={event => {
-        if (!event.currentTarget.contains(event.relatedTarget as Node)) setInsertionTarget(null)
-      }}>
+      <div className="workbench">
         {layout.order.map(panel)}
       </div>
     </div>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -270,7 +270,7 @@ button:focus-visible {
 .panel-control { width: 22px; height: 22px; display: grid; place-items: center; padding: 0; border: 0; border-radius: 3px; color: var(--muted); background: transparent; cursor: pointer; }
 .panel-control:hover:not(:disabled) { color: var(--text); background: var(--surface-hover); }
 .panel-control:disabled { opacity: var(--disabled-opacity); cursor: default; }
-.drag-control { cursor: grab; }
+.drag-control { cursor: grab; touch-action: none; }
 
 .panel-resize-handle {
   position: absolute;


### PR DESCRIPTION
## What changed
- replace HTML drag-and-drop with pointer-based panel reordering
- temporarily detach the native browser surface while arranging panels
- handle cancellation, stale async approvals, outside drops, and Escape
- add renderer and native-surface regression coverage

## Verification
- `pnpm check`
- `pnpm contracts:check`
- Codex medium review: clean