### PR TITLE
Wire the visible panel grip to drag reordering

### DIFF
--- a/apps/desktop/src/renderer/App.test.tsx
+++ b/apps/desktop/src/renderer/App.test.tsx
@@ -1241,7 +1241,7 @@ test('drag reordering shows an insertion preview before changing presentation on
     return DOMRect.fromRect({ x, y: 0, width: 100, height: 500 })
   })
   render(<App />)
-  const source = screen.getByRole('button', { name: 'Reorder Agent chat' })
+  const source = screen.getByTitle('Drag to reorder Agent chat; click for move controls')
   const target = screen.getByTestId('panel-jobs')
 
   fireEvent.pointerDown(source, { button: 0, clientX: 250, pointerId: 1 })
@@ -1295,7 +1295,7 @@ test('panel reordering detaches the native browser so the center panel can recei
   await waitFor(() => expect(setBounds).toHaveBeenCalledWith(expect.objectContaining({ visible: true })))
   setBounds.mockClear()
   detachResolvers.length = 0
-  const source = screen.getByRole('button', { name: 'Reorder Agent chat' })
+  const source = screen.getByTitle('Drag to reorder Agent chat; click for move controls')
   const target = screen.getByTestId('panel-center')
 
   fireEvent.pointerDown(source, { button: 0, clientX: 250, pointerId: 1 })

--- a/apps/desktop/src/renderer/components/WorkbenchLayout.test.tsx
+++ b/apps/desktop/src/renderer/components/WorkbenchLayout.test.tsx
@@ -32,11 +32,70 @@ function layout(onMove = vi.fn(), onReorderInteractionChange = vi.fn()) {
   )
 }
 
+test('the visible arrange grip directly reorders a panel', async () => {
+  mockPanelBounds()
+  const onMove = vi.fn()
+  const view = render(layout(onMove))
+  const visibleGrip = view.container.querySelector('summary[aria-label="Arrange Agent chat"]')
+
+  expect(visibleGrip).not.toBeNull()
+  expect(visibleGrip?.tagName).toBe('SUMMARY')
+  fireEvent.pointerDown(visibleGrip as HTMLElement, {
+    button: 0,
+    clientX: 250,
+    clientY: 150,
+    pointerId: 1
+  })
+  await act(async () => undefined)
+  fireEvent.pointerMove(window, { clientX: 150, clientY: 150, pointerId: 1 })
+  fireEvent.pointerUp(window, { clientX: 150, clientY: 150, pointerId: 1 })
+
+  expect(onMove).toHaveBeenCalledWith('agent', 1)
+})
+
+test('clicking the visible arrange grip still opens its move controls', () => {
+  const view = render(layout())
+  const visibleGrip = view.container.querySelector('summary[aria-label="Arrange Agent chat"]')
+  const menu = visibleGrip?.closest('details')
+
+  expect(menu?.open).toBe(false)
+  fireEvent.pointerDown(visibleGrip as HTMLElement, {
+    button: 0,
+    clientX: 250,
+    clientY: 150,
+    pointerId: 1
+  })
+  fireEvent.pointerUp(window, { clientX: 250, clientY: 150, pointerId: 1 })
+  fireEvent.click(visibleGrip as HTMLElement)
+
+  expect(menu?.open).toBe(true)
+})
+
+test('a canceled drag does not swallow the next arrange click', async () => {
+  mockPanelBounds()
+  const view = render(layout())
+  const visibleGrip = view.container.querySelector('summary[aria-label="Arrange Agent chat"]')
+  const menu = visibleGrip?.closest('details')
+
+  fireEvent.pointerDown(visibleGrip as HTMLElement, {
+    button: 0,
+    clientX: 250,
+    clientY: 150,
+    pointerId: 1
+  })
+  await act(async () => undefined)
+  fireEvent.pointerMove(window, { clientX: 150, clientY: 150, pointerId: 1 })
+  fireEvent.pointerCancel(window, { clientX: 150, clientY: 150, pointerId: 1 })
+  fireEvent.click(visibleGrip as HTMLElement)
+
+  expect(menu?.open).toBe(true)
+})
+
 test('unmounting during a reorder releases the native-surface interaction state', () => {
   const onReorderInteractionChange = vi.fn()
   const view = render(layout(vi.fn(), onReorderInteractionChange))
 
-  fireEvent.pointerDown(screen.getByRole('button', { name: 'Reorder Agent chat' }), {
+  fireEvent.pointerDown(screen.getByTitle('Drag to reorder Agent chat; click for move controls'), {
     clientX: 250,
     clientY: 150,
     pointerId: 1
@@ -52,7 +111,7 @@ test('releasing outside the panels cancels the reorder', async () => {
   const onMove = vi.fn()
   render(layout(onMove))
 
-  fireEvent.pointerDown(screen.getByRole('button', { name: 'Reorder Agent chat' }), {
+  fireEvent.pointerDown(screen.getByTitle('Drag to reorder Agent chat; click for move controls'), {
     button: 0,
     clientX: 250,
     clientY: 150,
@@ -71,7 +130,7 @@ test('changing the interaction callback mid-gesture clears the insertion target'
   const firstInteraction = vi.fn()
   const view = render(layout(vi.fn(), firstInteraction))
 
-  fireEvent.pointerDown(screen.getByRole('button', { name: 'Reorder Agent chat' }), {
+  fireEvent.pointerDown(screen.getByTitle('Drag to reorder Agent chat; click for move controls'), {
     button: 0,
     clientX: 250,
     clientY: 150,
@@ -93,7 +152,7 @@ test('Escape cancels an active pointer reorder', async () => {
   const onReorderInteractionChange = vi.fn()
   render(layout(onMove, onReorderInteractionChange))
 
-  fireEvent.pointerDown(screen.getByRole('button', { name: 'Reorder Agent chat' }), {
+  fireEvent.pointerDown(screen.getByTitle('Drag to reorder Agent chat; click for move controls'), {
     button: 0,
     clientX: 250,
     clientY: 150,
@@ -123,7 +182,7 @@ test('a stale approval cannot affect a newer gesture that reuses the pointer id'
     return new Promise<boolean>(resolve => { resolveFirst = resolve })
   })
   render(layout(onMove, onReorderInteractionChange))
-  const control = screen.getByRole('button', { name: 'Reorder Agent chat' })
+  const control = screen.getByTitle('Drag to reorder Agent chat; click for move controls')
 
   fireEvent.pointerDown(control, { button: 0, clientX: 250, clientY: 150, pointerId: 1 })
   fireEvent.pointerUp(window, { clientX: 250, clientY: 150, pointerId: 1 })

--- a/apps/desktop/src/renderer/components/WorkbenchLayout.tsx
+++ b/apps/desktop/src/renderer/components/WorkbenchLayout.tsx
@@ -24,11 +24,16 @@ export function WorkbenchLayout(props: WorkbenchLayoutProps) {
     pointerId: number
     source: PanelId
     target: PanelId | null
+    startX: number
+    startY: number
     clientX: number
     clientY: number
+    moved: boolean
     ready: boolean
+    suppressClickAfterDrag: boolean
   } | null>(null)
   const reorderReleaseCleanup = useRef<(() => void) | null>(null)
+  const suppressedArrangeClick = useRef<PanelId | null>(null)
   const layout = props.workspace.layouts[props.workspace.selectedPreset]
   const content: Record<PanelId, React.ReactNode> = { jobs: props.jobs, center: props.center, agent: props.agent }
   const visibleOrder = layout.order.filter(panel => !layout.collapsed.includes(panel))
@@ -57,7 +62,10 @@ export function WorkbenchLayout(props: WorkbenchLayoutProps) {
     if (!gesture) return
     gesture.clientX = clientX
     gesture.clientY = clientY
-    if (!gesture.ready) return
+    if (!gesture.moved) {
+      gesture.moved = Math.hypot(clientX - gesture.startX, clientY - gesture.startY) >= 4
+    }
+    if (!gesture.ready || !gesture.moved) return
     gesture.target = targetAt(clientX, clientY)
     setInsertionTarget(gesture.target)
   }
@@ -68,23 +76,32 @@ export function WorkbenchLayout(props: WorkbenchLayoutProps) {
     reorderReleaseCleanup.current?.()
     reorderReleaseCleanup.current = null
     setInsertionTarget(null)
-    if (commit && gesture?.ready && gesture.target && gesture.target !== gesture.source) {
+    if (commit && gesture?.moved && gesture.suppressClickAfterDrag) suppressedArrangeClick.current = gesture.source
+    if (commit && gesture?.ready && gesture.moved && gesture.target && gesture.target !== gesture.source) {
       props.onMove(gesture.source, layout.order.indexOf(gesture.target))
     }
     void props.onReorderInteractionChange?.(false)
   }
 
-  const prepareReorderInteraction = (event: React.PointerEvent<HTMLButtonElement>, source: PanelId) => {
+  const prepareReorderInteraction = (
+    event: React.PointerEvent<HTMLElement>,
+    source: PanelId,
+    options: { preserveClick?: boolean } = {}
+  ) => {
     if (event.button !== 0) return
-    event.preventDefault()
+    if (!options.preserveClick) event.preventDefault()
     reorderReleaseCleanup.current?.()
     const pointerId = event.pointerId
     const gesture = {
       pointerId,
       source,
       target: null,
+      startX: event.clientX,
+      startY: event.clientY,
       clientX: event.clientX,
       clientY: event.clientY,
+      moved: false,
+      suppressClickAfterDrag: Boolean(options.preserveClick),
       ready: false
     }
     reorderPointer.current = gesture
@@ -149,7 +166,17 @@ export function WorkbenchLayout(props: WorkbenchLayoutProps) {
         <div aria-label={`${panelNames[panelId]} layout controls`} className="panel-layout-controls">
           <span className="sr-only">{panelNames[panelId]}</span>
           <details className="panel-arrange-menu">
-            <summary aria-label={`Arrange ${panelNames[panelId]}`} className="panel-control" title={`Arrange ${panelNames[panelId]}`}><GripVertical aria-hidden="true" size={14} /></summary>
+            <summary
+              aria-label={`Arrange ${panelNames[panelId]}`}
+              className="panel-control drag-control"
+              onClick={event => {
+                if (suppressedArrangeClick.current !== panelId) return
+                event.preventDefault()
+                suppressedArrangeClick.current = null
+              }}
+              onPointerDown={event => prepareReorderInteraction(event, panelId, { preserveClick: true })}
+              title={`Drag to reorder ${panelNames[panelId]}; click for move controls`}
+            ><GripVertical aria-hidden="true" size={14} /></summary>
             <span className="panel-arrange-actions" role="toolbar" aria-label={`Arrange ${panelNames[panelId]}`}>
               <button
                 aria-label={`Move ${panelNames[panelId]} left`}
@@ -158,13 +185,7 @@ export function WorkbenchLayout(props: WorkbenchLayoutProps) {
                 onClick={() => props.onMove(panelId, index - 1)}
                 type="button"
               ><ArrowLeft aria-hidden="true" size={13} /></button>
-              <button
-                aria-label={`Reorder ${panelNames[panelId]}`}
-                className="panel-control drag-control"
-                onPointerDown={event => prepareReorderInteraction(event, panelId)}
-                title={`Drag to reorder ${panelNames[panelId]}`}
-                type="button"
-              ><GripVertical aria-hidden="true" size={14} /></button>
+
               <button
                 aria-label={`Move ${panelNames[panelId]} right`}
                 className="panel-control"


### PR DESCRIPTION
## Root cause
The visible grip was a `<summary>` menu opener, while the drag handler and tests targeted a second grip hidden inside the closed menu. The shipped UI therefore never entered the reorder path when dragging the visible control.

## Fix
- wire pointer reordering directly to the visible arrange grip
- preserve click-to-open arrow controls with a movement threshold
- suppress only the synthetic post-drag click
- cover the exact visible element, cancellation, and native-browser detachment

## Verification
- 55/55 focused tests
- 439/439 full desktop tests with one worker
- 10/10 updater tests
- lint + typecheck + contract drift
- Codex medium review: clean