### PR TITLE
Fix asynchronous agent continuation delivery

### DIFF
--- a/services/api/jobos_api/conversation_store.py
+++ b/services/api/jobos_api/conversation_store.py
@@ -2,6 +2,7 @@
 # ruff: noqa: E501
 
 import json
+import re
 import secrets
 import sqlite3
 from hashlib import sha256
@@ -272,6 +273,70 @@ class ConversationStore:
         return {**result, "created": True}
 
     create_conversation_turn = create_turn
+
+    def record_agent_continuation(
+        self,
+        *,
+        turn_id: str,
+        status: str,
+        event_type: str,
+        summary: str,
+        detail: dict[str, object],
+        source_event_id: str | None = None,
+    ) -> bool:
+        """Atomically append one terminal assistant-only continuation."""
+        if not re.fullmatch(r"turn_[A-Za-z0-9_-]{8,200}", turn_id):
+            raise ValueError("Invalid continuation turn id")
+        if status not in {"completed", "failed", "interrupted"}:
+            raise ValueError("Continuation must be terminal")
+        safe_detail = _conversation_detail(event_type, detail)
+        message_id = f"msg_{secrets.token_urlsafe(16)}"
+        context = {"agent_continuation": True}
+        with connect_sqlite(self._path) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_active(connection)
+            if connection.execute(
+                "SELECT 1 FROM conversation_turns WHERE turn_id = ? AND conversation_id = ?",
+                (turn_id, self.conversation_id),
+            ).fetchone():
+                connection.rollback()
+                return False
+            connection.execute(
+                "INSERT INTO conversation_turns(turn_id, conversation_id, message_id, source_turn_id, text, context_json, status) VALUES (?, ?, ?, NULL, '', ?, ?)",
+                (
+                    turn_id,
+                    self.conversation_id,
+                    message_id,
+                    json.dumps(context, separators=(",", ":"), sort_keys=True),
+                    status,
+                ),
+            )
+            connection.execute(
+                "INSERT INTO conversation_events(conversation_id, turn_id, event_type, state, summary, detail_json) VALUES (?, ?, 'turn', 'working', 'Agent completed background work', ?)",
+                (
+                    self.conversation_id,
+                    turn_id,
+                    json.dumps(
+                        {"context": context, "source_turn_id": None},
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                ),
+            )
+            connection.execute(
+                "INSERT INTO conversation_events(conversation_id, turn_id, event_type, state, summary, detail_json, source_event_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    self.conversation_id,
+                    turn_id,
+                    event_type[:50],
+                    status,
+                    sanitize_summary(summary),
+                    json.dumps(safe_detail, separators=(",", ":"), sort_keys=True),
+                    source_event_id[:256] if source_event_id else None,
+                ),
+            )
+            connection.commit()
+        return True
 
     def append_event(
         self,

--- a/services/api/jobos_api/conversations.py
+++ b/services/api/jobos_api/conversations.py
@@ -260,6 +260,9 @@ class ConversationService:
             return None
         if source["status"] not in {"failed", "interrupted"}:
             raise ValueError("Only failed or interrupted turns can be retried")
+        source_context = source.get("context")
+        if isinstance(source_context, dict) and source_context.get("agent_continuation") is True:
+            raise ValueError("Background continuation turns cannot be retried directly")
         created = self.store.create_conversation_turn(
             text=str(source["text"]),
             context=source["context"],
@@ -436,6 +439,19 @@ class ConversationService:
                 continue
             turn_id = event.turn_id
             if turn_id and self.store.turn_record(turn_id) is None:
+                if (
+                    event.detail.get("agent_continuation") is True
+                    and event.state in {"completed", "failed", "interrupted"}
+                    and event.event_type in {"assistant_message", "error"}
+                ):
+                    self.store.record_agent_continuation(
+                        turn_id=turn_id,
+                        status=event.state,
+                        event_type=event.event_type,
+                        summary=event.summary,
+                        detail={**event.detail, "activity_id": event.activity_id},
+                        source_event_id=event.source_event_id,
+                    )
                 continue
             is_terminal = bool(
                 turn_id

--- a/services/api/jobos_api/hermes_adapter.py
+++ b/services/api/jobos_api/hermes_adapter.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import ipaddress
 import json
 import re
@@ -152,6 +153,7 @@ class HermesWebSocketGateway:
         self._session_isolation_event = asyncio.Event()
         self._attaching_session = False
         self._pending_session_info: dict[str, tuple[bool, GatewayEvent | None]] = {}
+        self._pending_continuation_frames: list[dict[str, object]] = []
         self._activity = ActivityNormalizer()
         self._closed = False
         self._start_lock = asyncio.Lock()
@@ -298,6 +300,8 @@ class HermesWebSocketGateway:
                 self._record_session_verification(True)
             pending = self._pending_session_info.get(live)
             self._pending_session_info.clear()
+            pending_continuations = self._pending_continuation_frames
+            self._pending_continuation_frames = []
             self._attaching_session = False
             if pending is not None:
                 verified, reconciliation = pending
@@ -305,10 +309,15 @@ class HermesWebSocketGateway:
                 if self._session_isolation_state == "verified" and reconciliation is not None:
                     self._apply_reconciled_stored_session(reconciliation)
                     await self._events.put(reconciliation)
+            for pending_frame in pending_continuations:
+                event = self.normalize_frame(pending_frame)
+                if event is not None:
+                    await self._events.put(event)
             return self._stored_session_id, live
         except Exception:
             self._attaching_session = False
             self._pending_session_info.clear()
+            self._pending_continuation_frames = []
             raise
 
     def _begin_session_attachment(self) -> None:
@@ -318,6 +327,7 @@ class HermesWebSocketGateway:
         self._session_isolation_event = asyncio.Event()
         self._attaching_session = True
         self._pending_session_info.clear()
+        self._pending_continuation_frames = []
 
     def _reset_live_session(self) -> None:
         if self._session_isolation_state == "unverified":
@@ -328,6 +338,7 @@ class HermesWebSocketGateway:
         self._session_isolation_event = asyncio.Event()
         self._attaching_session = False
         self._pending_session_info.clear()
+        self._pending_continuation_frames = []
 
     def _record_session_verification(self, verified: bool) -> None:
         if self._session_isolation_state in {"failed", "verified"}:
@@ -588,6 +599,13 @@ class HermesWebSocketGateway:
         session_id = frame.get("session_id")
         if frame_type == "session.info":
             return self._normalize_session_info(frame, session_id)
+        if (
+            self._live_session_id is None
+            and self._attaching_session
+            and frame.get("display_kind") == "async_delegation_complete"
+        ):
+            self._pending_continuation_frames.append(dict(raw_frame))
+            return None
         if self._live_session_id is None or session_id != self._live_session_id:
             return None
         supported_types = {
@@ -613,6 +631,46 @@ class HermesWebSocketGateway:
         }
         if frame_type not in supported_types:
             return None
+        continuation_id = frame.get("continuation_id")
+        if frame.get("display_kind") == "async_delegation_complete":
+            if not isinstance(continuation_id, str) or not re.fullmatch(
+                r"[A-Za-z0-9_-]{8,200}", continuation_id
+            ):
+                return None
+            if frame_type not in {"message.complete", "error"}:
+                return None
+            continuation_digest = hashlib.sha256(continuation_id.encode()).hexdigest()[:32]
+            turn_id = f"turn_cont_{continuation_digest}"
+            source_event_id = f"async_delegation:{continuation_digest}:terminal"
+            safe_detail = redact_detail(frame)
+            safe_detail["agent_continuation"] = True
+            if frame_type == "error":
+                return GatewayEvent(
+                    event_type="error",
+                    state="failed",
+                    summary=safe_error_summary(safe_detail.get("message") or "Hermes error"),
+                    detail={**safe_detail, "actionable": True},
+                    turn_id=turn_id,
+                    source_event_id=source_event_id,
+                )
+            safe_text = sanitize_assistant_text(
+                str(frame.get("text") or frame.get("delta") or "")
+            )
+            safe_detail["text"] = safe_text
+            status = str(frame.get("status", ""))
+            return GatewayEvent(
+                event_type="assistant_message",
+                state={
+                    "complete": "completed",
+                    "completed": "completed",
+                    "interrupted": "interrupted",
+                    "error": "failed",
+                }.get(status, "completed"),
+                summary=safe_text[:1000],
+                detail=safe_detail,
+                turn_id=turn_id,
+                source_event_id=source_event_id,
+            )
         if frame_type != "session.info" and self._active_turn_id is None:
             # A resumed Hermes session can keep emitting after JobOS restarts, but
             # without an active JobOS turn those events have no safe transcript

--- a/services/api/tests/test_hermes_adapter.py
+++ b/services/api/tests/test_hermes_adapter.py
@@ -4,7 +4,7 @@ from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from jobos_api.agent_gateway import AgentContext, GatewayEvent
-from jobos_api.conversations import ConversationService, SendMessageRequest
+from jobos_api.conversations import ConversationService, RetryTurnRequest, SendMessageRequest
 from jobos_api.hermes_adapter import HermesWebSocketGateway, _prompt_with_context
 from jobos_api.state_store import JobOsStateStore
 
@@ -448,6 +448,111 @@ def test_two_serialized_service_prompts_reuse_one_verified_live_attachment(tmp_p
         assert "raw-runtime-secret" not in serialized
         assert "raw-tool-metadata" not in serialized
         assert TOKEN not in repr(gateway)
+
+    asyncio.run(scenario())
+
+
+def test_service_records_late_continuation_without_disturbing_active_user_turn(tmp_path):
+    async def scenario():
+        socket = FakeWebSocket(
+            lambda request: [
+                result(
+                    request,
+                    {
+                        "stored_session_id": "stored-1",
+                        "session_id": "live-1",
+                        "info": {"profile_name": "job-hunter", "cwd": str(tmp_path)},
+                    },
+                )
+            ]
+        )
+        gateway = HermesWebSocketGateway(
+            url="ws://127.0.0.1:9119/api/ws",
+            token=TOKEN,
+            cwd=tmp_path,
+            request_timeout=1,
+            connector=FakeConnector(socket),
+        )
+        store = JobOsStateStore(tmp_path / "jobos.db")
+        store.initialize()
+        await gateway.start()
+        await gateway.create_or_resume_conversation(None)
+        service = ConversationService(store, gateway)
+        await service.start()
+        active = store.create_conversation_turn(
+            text="A newer follow-up",
+            context={"selected_job_id": None, "workspace": {}},
+            idempotency_key="active-during-late-continuation",
+            actor_id="device-a",
+        )
+        gateway._active_turn_id = str(active["turn_id"])
+        snapshot = store.conversation_snapshot()
+        gateway_active_turn_id = None
+        try:
+            socket.incoming.put_nowait(
+                json.dumps(
+                    event(
+                        "message.start",
+                        "live-1",
+                        {
+                            "display_kind": "async_delegation_complete",
+                            "continuation_id": "delegation-service-1234",
+                        },
+                    )
+                )
+            )
+            socket.incoming.put_nowait(
+                json.dumps(
+                    event(
+                        "message.complete",
+                        "live-1",
+                        {
+                            "status": "complete",
+                            "text": "Background work finished",
+                            "display_kind": "async_delegation_complete",
+                            "continuation_id": "delegation-service-1234",
+                        },
+                    )
+                )
+            )
+            for _ in range(50):
+                snapshot = store.conversation_snapshot()
+                entries = snapshot["entries"]
+                assert isinstance(entries, list)
+                if any(
+                    isinstance(entry, dict)
+                    and entry["type"] == "assistant_message"
+                    and entry["summary"] == "Background work finished"
+                    for entry in entries
+                ):
+                    break
+                await asyncio.sleep(0.01)
+            gateway_active_turn_id = gateway._active_turn_id
+        finally:
+            await service.close()
+
+        entries = snapshot["entries"]
+        assert isinstance(entries, list)
+        typed_entries = [entry for entry in entries if isinstance(entry, dict)]
+        continuation = [
+            entry
+            for entry in typed_entries
+            if entry["type"] == "turn"
+            and entry["context"].get("agent_continuation") is True
+        ]
+        assert len(continuation) == 1
+        continuation_id = continuation[0]["turn_id"]
+        assert any(
+            entry["turn_id"] == continuation_id
+            and entry["type"] == "assistant_message"
+            and entry["state"] == "completed"
+            for entry in typed_entries
+        )
+        assert sum(entry["type"] == "user_message" for entry in typed_entries) == 1
+        active_turn = snapshot["active_turn"]
+        assert isinstance(active_turn, dict)
+        assert active_turn["turn_id"] == active["turn_id"]
+        assert gateway_active_turn_id == active["turn_id"]
 
     asyncio.run(scenario())
 
@@ -907,6 +1012,115 @@ def test_turn_events_without_an_active_jobos_turn_are_dropped(tmp_path):
     assert orphan_delta is None
     assert orphan_tool is None
     assert orphan_status is None
+
+
+def test_async_delegation_completion_stays_separate_from_a_new_user_turn(tmp_path):
+    gateway = HermesWebSocketGateway(url="ws://127.0.0.1:9119/api/ws", token=TOKEN, cwd=tmp_path)
+    gateway._live_session_id = "live-1"
+    gateway._active_turn_id = "turn-new-user"
+
+    assert gateway.normalize_frame(
+        event(
+            "message.start",
+            "live-1",
+            {
+                "display_kind": "async_delegation_complete",
+                "continuation_id": "delegation-unit-1234",
+            },
+        )
+    ) is None
+    assert gateway.normalize_frame(
+        event(
+            "message.delta",
+            "live-1",
+            {
+                "text": "Background",
+                "display_kind": "async_delegation_complete",
+                "continuation_id": "delegation-unit-1234",
+            },
+        )
+    ) is None
+    user_completion = gateway.normalize_frame(
+        event(
+            "message.complete",
+            "live-1",
+            {"status": "complete", "text": "New user turn done"},
+        )
+    )
+    continuation = gateway.normalize_frame(
+        event(
+            "message.complete",
+            "live-1",
+            {
+                "status": "complete",
+                "text": "Background done",
+                "display_kind": "async_delegation_complete",
+                "continuation_id": "delegation-unit-1234",
+            },
+        )
+    )
+
+    assert continuation is not None
+    assert continuation.turn_id is not None
+    assert continuation.turn_id != "turn-new-user"
+    assert continuation.detail["agent_continuation"] is True
+    assert continuation.source_event_id is not None
+    assert continuation.summary == "Background done"
+    assert user_completion is not None
+    assert user_completion.turn_id == "turn-new-user"
+    assert user_completion.summary == "New user turn done"
+
+
+def test_async_delegation_completion_is_buffered_during_session_attachment(tmp_path):
+    gateway = HermesWebSocketGateway(url="ws://127.0.0.1:9119/api/ws", token=TOKEN, cwd=tmp_path)
+    gateway._begin_session_attachment()
+    frame = event(
+        "message.complete",
+        "live-after-resume",
+        {
+            "status": "complete",
+            "text": "Recovered background result",
+            "display_kind": "async_delegation_complete",
+            "continuation_id": "delegation-resume-1234",
+        },
+    )
+
+    assert gateway.normalize_frame(frame) is None
+    assert gateway._pending_continuation_frames == [frame]
+
+    gateway._live_session_id = "live-after-resume"
+    gateway._attaching_session = False
+    recovered = gateway.normalize_frame(gateway._pending_continuation_frames.pop())
+
+    assert recovered is not None
+    assert recovered.summary == "Recovered background result"
+    assert recovered.detail["agent_continuation"] is True
+
+
+def test_failed_agent_continuation_cannot_retry_as_an_empty_user_turn(tmp_path):
+    async def scenario():
+        store = JobOsStateStore(tmp_path / "jobos.db")
+        store.initialize()
+        conversation = store.conversation_store(store.first_active_conversation_id())
+        conversation.record_agent_continuation(
+            turn_id="turn_failed_continuation_1234",
+            status="failed",
+            event_type="error",
+            summary="Background continuation failed",
+            detail={"agent_continuation": True, "message": "failed"},
+        )
+        gateway = HermesWebSocketGateway(
+            url="ws://127.0.0.1:9119/api/ws", token=TOKEN, cwd=tmp_path
+        )
+        service = ConversationService(store, gateway)
+        with pytest.raises(ValueError, match="cannot be retried"):
+            await service.retry(
+                "turn_failed_continuation_1234",
+                RetryTurnRequest(idempotency_key="retry-background-continuation"),
+                actor_id="device-a",
+            )
+
+    asyncio.run(scenario())
 
 
 def test_real_status_and_error_fields_are_read_from_payload(tmp_path):

--- a/services/api/tests/test_state_store.py
+++ b/services/api/tests/test_state_store.py
@@ -795,6 +795,48 @@ def test_conversation_events_restore_in_monotonic_order_from_fresh_store(tmp_pat
     assert restored["entries"][1]["context"]["selected_job_id"] is None
 
 
+def test_terminal_agent_continuation_does_not_replace_active_user_turn(tmp_path):
+    store = JobOsStateStore(tmp_path / "jobos.db")
+    store.initialize()
+    active = store.create_conversation_turn(
+        text="A newer follow-up",
+        context={"selected_job_id": None, "workspace": {}},
+        idempotency_key="active-user-before-continuation",
+        actor_id="device-a",
+    )
+    conversation = store.conversation_store(store.first_active_conversation_id())
+
+    assert conversation.record_agent_continuation(
+        turn_id="turn_agent_continuation_1234",
+        status="completed",
+        event_type="assistant_message",
+        summary="Background work finished",
+        detail={
+            "type": "message.complete",
+            "text": "Background work finished",
+            "agent_continuation": True,
+        },
+    )
+    snapshot = conversation.conversation_snapshot()
+
+    entries = snapshot["entries"]
+    assert isinstance(entries, list)
+    continuation_entries = [
+        entry
+        for entry in entries
+        if isinstance(entry, dict)
+        and entry["turn_id"] == "turn_agent_continuation_1234"
+    ]
+    assert [entry["type"] for entry in continuation_entries] == [
+        "turn",
+        "assistant_message",
+    ]
+    assert not any(entry["type"] == "user_message" for entry in continuation_entries)
+    active_turn = snapshot["active_turn"]
+    assert isinstance(active_turn, dict)
+    assert active_turn["turn_id"] == active["turn_id"]
+
+
 def test_completed_assistant_text_uses_transcript_bound_while_summary_stays_concise(tmp_path):
     database = tmp_path / "jobos.db"
     store = JobOsStateStore(database)


### PR DESCRIPTION
## What changed
- preserve autonomous Hermes subagent completions as assistant-only JobOS turns
- correlate and deduplicate replayed completions by stable continuation identity
- isolate late completions from newer active user turns
- buffer replayed completions during session attachment
- prevent retrying synthetic failed continuations as blank user prompts

## Verification
- full API test suite passed
- Ruff passed
- full Hermes gateway suite: 586 passed
- independent Codex review: PASS