### PR TITLE
fix: release agent chat upward scrolling

### DIFF
--- a/apps/desktop/src/renderer/components/AgentPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.test.tsx
@@ -112,6 +112,40 @@ test('two session panel DOM nodes restore their distinct real scroll positions a
   expect(secondScrollTop).toBe(900)
 })
 
+test('a small upward scroll detaches from live bottom-following immediately', async () => {
+  const initialAnswer = event(1, {
+    type: 'assistant_message', state: 'completed', summary: 'Initial answer',
+    detail: { type: 'message.complete', text: 'Initial answer' }
+  })
+  const { emit } = install([summary(1)], [snapshot(1, [initialAnswer])])
+  render(<Harness />)
+  const panel = await screen.findByRole('tabpanel')
+  let scrollHeight = 1_000
+  let scrollTop = 0
+  Object.defineProperties(panel, {
+    clientHeight: { configurable: true, get: () => 300 },
+    scrollHeight: { configurable: true, get: () => scrollHeight },
+    scrollTop: { configurable: true, get: () => scrollTop, set: value => { scrollTop = Number(value) } }
+  })
+
+  act(() => emit({
+    kind: 'event', conversationId: 'conv_1', recoveryState: 'ready',
+    event: event(2, { type: 'assistant_message', state: 'completed', summary: 'Followed answer', detail: { type: 'message.complete', text: 'Followed answer' } })
+  }))
+  expect(scrollTop).toBe(1_000)
+
+  scrollTop = 950
+  fireEvent.scroll(panel)
+  expect(screen.getByRole('button', { name: 'Jump to latest' })).not.toBeNull()
+
+  scrollHeight = 1_200
+  act(() => emit({
+    kind: 'event', conversationId: 'conv_1', recoveryState: 'ready',
+    event: event(3, { type: 'assistant_message', state: 'completed', summary: 'Newest answer', detail: { type: 'message.complete', text: 'Newest answer' } })
+  }))
+  expect(scrollTop).toBe(950)
+})
+
 test('close stays disabled across the pending send response gap', async () => {
   const response = deferred<{ turnId: string; status: string }>()
   const { agent } = install([summary(1), summary(2)])

--- a/apps/desktop/src/renderer/components/AgentPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.test.tsx
@@ -112,12 +112,12 @@ test('two session panel DOM nodes restore their distinct real scroll positions a
   expect(secondScrollTop).toBe(900)
 })
 
-test('a small upward scroll detaches from live bottom-following immediately', async () => {
+test('a small upward scroll stays detached across session switching and streamed updates', async () => {
   const initialAnswer = event(1, {
     type: 'assistant_message', state: 'completed', summary: 'Initial answer',
     detail: { type: 'message.complete', text: 'Initial answer' }
   })
-  const { emit } = install([summary(1)], [snapshot(1, [initialAnswer])])
+  const { emit } = install([summary(1), summary(2)], [snapshot(1, [initialAnswer]), snapshot(2)])
   render(<Harness />)
   const panel = await screen.findByRole('tabpanel')
   let scrollHeight = 1_000
@@ -125,16 +125,25 @@ test('a small upward scroll detaches from live bottom-following immediately', as
   Object.defineProperties(panel, {
     clientHeight: { configurable: true, get: () => 300 },
     scrollHeight: { configurable: true, get: () => scrollHeight },
-    scrollTop: { configurable: true, get: () => scrollTop, set: value => { scrollTop = Number(value) } }
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: value => { scrollTop = Math.min(Number(value), scrollHeight - 300) }
+    }
   })
 
   act(() => emit({
     kind: 'event', conversationId: 'conv_1', recoveryState: 'ready',
     event: event(2, { type: 'assistant_message', state: 'completed', summary: 'Followed answer', detail: { type: 'message.complete', text: 'Followed answer' } })
   }))
-  expect(scrollTop).toBe(1_000)
+  expect(scrollTop).toBe(700)
 
-  scrollTop = 950
+  scrollTop = 650
+  fireEvent.scroll(panel)
+  expect(screen.getByRole('button', { name: 'Jump to latest' })).not.toBeNull()
+
+  fireEvent.click(screen.getByRole('tab', { name: 'Session 2, Idle' }))
+  fireEvent.click(screen.getByRole('tab', { name: 'Session 1, Idle' }))
   fireEvent.scroll(panel)
   expect(screen.getByRole('button', { name: 'Jump to latest' })).not.toBeNull()
 
@@ -143,7 +152,7 @@ test('a small upward scroll detaches from live bottom-following immediately', as
     kind: 'event', conversationId: 'conv_1', recoveryState: 'ready',
     event: event(3, { type: 'assistant_message', state: 'completed', summary: 'Newest answer', detail: { type: 'message.complete', text: 'Newest answer' } })
   }))
-  expect(scrollTop).toBe(950)
+  expect(scrollTop).toBe(650)
 })
 
 test('close stays disabled across the pending send response gap', async () => {

--- a/apps/desktop/src/renderer/components/AgentPanel.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.tsx
@@ -38,6 +38,7 @@ export function AgentPanel({ contextLabel, apiState = 'connected', onArtifactRen
   }
   const activeId = sessions.activeId
   const panelRefs = useRef(new Map<string, HTMLDivElement>())
+  const lastScrollTops = useRef(new Map<string, number>())
   const pinnedToBottom = useRef(true)
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true)
   const observedEventIds = useRef(new Map<string, number>())
@@ -74,6 +75,7 @@ export function AgentPanel({ contextLabel, apiState = 'connected', onArtifactRen
     const transcript = activeId ? panelRefs.current.get(activeId) : undefined
     if (!transcript) return
     transcript.scrollTop = transcript.scrollHeight
+    if (activeId) lastScrollTops.current.set(activeId, transcript.scrollTop)
     pinnedToBottom.current = true
     setIsPinnedToBottom(true)
     if (focusTranscript && activeId) sessions.saveScroll(activeId, transcript.scrollTop, true)
@@ -91,15 +93,19 @@ export function AgentPanel({ contextLabel, apiState = 'connected', onArtifactRen
     pinnedToBottom.current = saved?.pinnedToBottom ?? true
     setIsPinnedToBottom(pinnedToBottom.current)
     transcript.scrollTop = pinnedToBottom.current ? transcript.scrollHeight : (saved?.scrollTop ?? 0)
+    lastScrollTops.current.set(activeId, transcript.scrollTop)
   }, [activeId, sessions.saveScroll])
 
   const handleScroll = () => {
     const transcript = activeId ? panelRefs.current.get(activeId) : undefined
-    if (!transcript) return
-    const pinned = transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight <= 64
+    if (!transcript || !activeId) return
+    const previousScrollTop = lastScrollTops.current.get(activeId) ?? transcript.scrollTop
+    const movedUp = transcript.scrollTop < previousScrollTop
+    const pinned = !movedUp && transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight <= 64
+    lastScrollTops.current.set(activeId, transcript.scrollTop)
     pinnedToBottom.current = pinned
     setIsPinnedToBottom(pinned)
-    if (activeId) sessions.saveScroll(activeId, transcript.scrollTop, pinned)
+    sessions.saveScroll(activeId, transcript.scrollTop, pinned)
   }
 
   const handleTurnLayoutChange = useCallback(() => {

--- a/apps/desktop/src/renderer/components/AgentPanel.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.tsx
@@ -101,7 +101,8 @@ export function AgentPanel({ contextLabel, apiState = 'connected', onArtifactRen
     if (!transcript || !activeId) return
     const previousScrollTop = lastScrollTops.current.get(activeId) ?? transcript.scrollTop
     const movedUp = transcript.scrollTop < previousScrollTop
-    const pinned = !movedUp && transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight <= 64
+    const distanceFromBottom = transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight
+    const pinned = !movedUp && (pinnedToBottom.current ? distanceFromBottom <= 64 : distanceFromBottom <= 1)
     lastScrollTops.current.set(activeId, transcript.scrollTop)
     pinnedToBottom.current = pinned
     setIsPinnedToBottom(pinned)


### PR DESCRIPTION
## Problem
Small upward scrolls near the bottom of Agent Chat stayed inside the 64px auto-follow threshold, so streamed updates snapped the transcript back to the bottom. Only a large scroll escaped.

## Fix
- Track the previous scroll position per agent session.
- Treat any upward movement as an immediate detach from bottom-following.
- Preserve normal auto-follow, Jump to latest, and per-session scroll restoration.

## Verification
- New regression test failed on the old behavior and passes with the fix.
- `pnpm check`
- 440 desktop tests passed.
- 655 API/MCP tests passed (4 skipped).
- 10 updater tests passed.
- Production build, lint, typecheck, public-tree, fixture, and license checks passed.