### PR TITLE
feat: show elapsed agent turn time

### DIFF
--- a/apps/desktop/src/renderer/components/AgentPanel.regression.test.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.regression.test.tsx
@@ -148,7 +148,9 @@ test('shows stopping rather than completed activity state while cancellation is 
   expect(group.classList.contains('stopping')).toBe(true)
   expect(group.querySelector('.activity-group-state .lucide-pause')).not.toBeNull()
   expect(group.querySelector('.activity-group-state .lucide-check')).toBeNull()
-  expect(screen.getByLabelText('Agent turn status').textContent).toBe('Stopping agent…')
+  const turnStatus = screen.getByLabelText('Agent turn status')
+  expect(turnStatus.querySelector('span')?.textContent).toBe('Stopping agent…')
+  expect(screen.getByLabelText('Elapsed agent time')).not.toBeNull()
 })
 
 test('drops ownerless activity and never marks an inactive unfinished group complete', async () => {
@@ -208,7 +210,9 @@ test('keeps a waiting turn open without showing working activity state', async (
   expect(group.classList.contains('waiting')).toBe(true)
   expect(group.classList.contains('working')).toBe(false)
   expect(group.querySelector('.activity-group-state .spin')).toBeNull()
-  expect(screen.getByLabelText('Agent turn status').textContent).toBe('Agent waiting for you')
+  const turnStatus = screen.getByLabelText('Agent turn status')
+  expect(turnStatus.querySelector('span')?.textContent).toBe('Agent waiting for you')
+  expect(screen.getByLabelText('Elapsed agent time')).not.toBeNull()
 })
 
 test('collapses untouched activity once when the turn completes', async () => {

--- a/apps/desktop/src/renderer/components/AgentPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.test.tsx
@@ -5,7 +5,7 @@ import type { AgentConversationSnapshot, AgentSessionStreamUpdate, AgentSessionS
 import { useAgentSessions } from '../hooks/useAgentSessions'
 import { AgentPanel } from './AgentPanel'
 
-afterEach(() => { cleanup(); window.localStorage.clear() })
+afterEach(() => { cleanup(); window.localStorage.clear(); vi.restoreAllMocks() })
 
 const summary = (position: number, activeTurn: AgentSessionSummary['activeTurn'] = null): AgentSessionSummary => ({
   conversationId: `conv_${position}`, position, title: `Session ${position}`, createdAt: '2026-08-16T10:00:00Z',
@@ -45,6 +45,23 @@ function deferred<T>() {
   let resolve!: (value: T) => void
   const promise = new Promise<T>(next => { resolve = next })
   return { promise, resolve }
+}
+
+function installClock(isoTime: string) {
+  let now = Date.parse(isoTime)
+  let tick: () => void = () => undefined
+  vi.spyOn(Date, 'now').mockImplementation(() => now)
+  vi.spyOn(window, 'setInterval').mockImplementation(callback => {
+    tick = callback as () => void
+    return 1 as unknown as ReturnType<typeof window.setInterval>
+  })
+  vi.spyOn(window, 'clearInterval').mockImplementation(() => undefined)
+  return {
+    advance(milliseconds: number) {
+      now += milliseconds
+      act(() => tick())
+    }
+  }
 }
 
 test('renders accessible tabs and creates a fresh additive session without a reset modal', async () => {
@@ -153,6 +170,50 @@ test('a small upward scroll stays detached across session switching and streamed
     event: event(3, { type: 'assistant_message', state: 'completed', summary: 'Newest answer', detail: { type: 'message.complete', text: 'Newest answer' } })
   }))
   expect(scrollTop).toBe(650)
+})
+
+test('a new agent turn timer starts at zero and counts upward', async () => {
+  const clock = installClock('2026-08-16T10:00:00Z')
+  install()
+  await act(async () => { render(<Harness />); await Promise.resolve() })
+  const composer = screen.getByRole('textbox', { name: 'Message the agent' })
+  fireEvent.change(composer, { target: { value: 'Start the work' } })
+  await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Send message' })); await Promise.resolve() })
+
+  expect(screen.getByLabelText('Elapsed agent time').textContent).toBe('0:00')
+  clock.advance(1_000)
+  expect(screen.getByLabelText('Elapsed agent time').textContent).toBe('0:01')
+})
+
+test('each active session shows its own elapsed timer until that turn completes', async () => {
+  const clock = installClock('2026-08-16T10:01:05Z')
+  const firstTurn = { turnId: 'turn-1', status: 'running' as const, cancelRequested: false }
+  const secondTurn = { turnId: 'turn-2', status: 'running' as const, cancelRequested: false }
+  // SQLite CURRENT_TIMESTAMP is UTC without a timezone suffix. The renderer
+  // must not accidentally interpret these persisted values as local time.
+  const firstStart = event(1, { type: 'turn', state: 'working', occurredAt: '2026-08-16 10:00:00' })
+  const secondStart = event(2, { turnId: 'turn-2', type: 'turn', state: 'working', occurredAt: '2026-08-16 10:01:00' })
+  const { emit } = install(
+    [summary(1, firstTurn), summary(2, secondTurn)],
+    [snapshot(1, [firstStart], firstTurn), snapshot(2, [secondStart], secondTurn)]
+  )
+
+  await act(async () => { render(<Harness />); await Promise.resolve() })
+  expect(screen.getByLabelText('Elapsed agent time').textContent).toBe('1:05')
+
+  fireEvent.click(screen.getByRole('tab', { name: 'Session 2, Working' }))
+  expect(screen.getByLabelText('Elapsed agent time').textContent).toBe('0:05')
+  clock.advance(2_000)
+  expect(screen.getByLabelText('Elapsed agent time').textContent).toBe('0:07')
+
+  act(() => emit({
+    kind: 'event', conversationId: 'conv_2', recoveryState: 'ready',
+    event: event(3, {
+      turnId: 'turn-2', type: 'assistant_message', state: 'completed', occurredAt: '2026-08-16T10:01:07Z',
+      summary: 'Done', detail: { type: 'message.complete', text: 'Done' }
+    })
+  }))
+  expect(screen.queryByLabelText('Elapsed agent time')).toBeNull()
 })
 
 test('close stays disabled across the pending send response gap', async () => {

--- a/apps/desktop/src/renderer/components/AgentPanel.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.tsx
@@ -9,6 +9,34 @@ import { ActivityRow } from './ActivityRow'
 import { AssistantMarkdown } from './AssistantMarkdown'
 import { AgentSessionTabs } from './AgentSessionTabs'
 
+function formatElapsedTime(elapsedMilliseconds: number): string {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMilliseconds / 1_000))
+  const seconds = totalSeconds % 60
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  const minutes = totalMinutes % 60
+  const hours = Math.floor(totalMinutes / 60)
+  return hours > 0
+    ? `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+    : `${minutes}:${String(seconds).padStart(2, '0')}`
+}
+
+function parseEventTimestamp(value: string): number {
+  const sqliteUtc = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(value)
+  return Date.parse(sqliteUtc ? `${value.replace(' ', 'T')}Z` : value)
+}
+
+function AgentElapsedTime({ startedAt }: { startedAt: number }) {
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    setNow(Date.now())
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000)
+    return () => window.clearInterval(timer)
+  }, [startedAt])
+
+  return <time aria-label="Elapsed agent time">{formatElapsedTime(now - startedAt)}</time>
+}
+
 interface AgentPanelProps {
   contextLabel: string
   apiState?: ConnectivityState
@@ -42,6 +70,7 @@ export function AgentPanel({ contextLabel, apiState = 'connected', onArtifactRen
   const pinnedToBottom = useRef(true)
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true)
   const observedEventIds = useRef(new Map<string, number>())
+  const activeTurnStarts = useRef(new Map<string, { turnId: string; startedAt: number }>())
   const canSend = Boolean(
     conversation.draft.trim()
     && !conversation.activeTurn
@@ -116,6 +145,19 @@ export function AgentPanel({ contextLabel, apiState = 'connected', onArtifactRen
   const activePresentation = conversation.activeTurn
     ? conversation.items.find(item => item.kind === 'agent-turn' && item.turnId === conversation.activeTurn?.turnId)
     : undefined
+  let activeTurnStartedAt: number | null = null
+  if (activeId && conversation.activeTurn) {
+    const eventStart = conversation.entries
+      .filter(entry => entry.turnId === conversation.activeTurn?.turnId)
+      .map(entry => parseEventTimestamp(entry.occurredAt))
+      .filter(Number.isFinite)
+      .reduce<number | null>((earliest, timestamp) => earliest === null ? timestamp : Math.min(earliest, timestamp), null)
+    const remembered = activeTurnStarts.current.get(activeId)
+    activeTurnStartedAt = remembered?.turnId === conversation.activeTurn.turnId
+      ? Math.min(remembered.startedAt, eventStart ?? remembered.startedAt)
+      : (eventStart ?? Date.now())
+    activeTurnStarts.current.set(activeId, { turnId: conversation.activeTurn.turnId, startedAt: activeTurnStartedAt })
+  }
   const activeActionCount = activePresentation?.kind === 'agent-turn' ? activePresentation.activities.length : 0
   const latestTurn = [...conversation.items].reverse().find(item => item.kind === 'agent-turn')
   const activeStatus = conversation.activeTurn?.cancelRequested
@@ -252,7 +294,8 @@ export function AgentPanel({ contextLabel, apiState = 'connected', onArtifactRen
       {conversation.activeTurn && (
         <div aria-label="Agent turn status" className="agent-turn-status">
           {conversation.activeTurn.status === 'running' && !conversation.activeTurn.cancelRequested && <LoaderCircle aria-hidden="true" className="spin" size={13} />}
-          {activeStatus}
+          <span>{activeStatus}</span>
+          {activeTurnStartedAt !== null && <><span aria-hidden="true">·</span><AgentElapsedTime startedAt={activeTurnStartedAt} /></>}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- show an elapsed timer while an Agent Chat turn is active
- preserve independent timing across agent sessions and restored turns
- parse persisted SQLite UTC timestamps correctly

## Verification
- `pnpm check`
- AgentPanel focused tests: 41 passed
- AgentPanel timer/session test file: 5 consecutive passing runs
- independent exact-byte review: PASS