### PR TITLE
Fix installed MCP/API release skew

### DIFF
--- a/scripts/macos/jobos_mcp_runtime.py
+++ b/scripts/macos/jobos_mcp_runtime.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class McpRuntimeLaunch:
+    executable: Path
+    arguments: tuple[str, ...]
+    environment: dict[str, str]
+
+
+def _absolute_existing_path(
+    value: object,
+    label: str,
+    *,
+    directory: bool = False,
+    preserve_symlink: bool = False,
+) -> Path:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"JobOS {label} is unavailable")
+    path = Path(value)
+    if not path.is_absolute():
+        raise RuntimeError(f"JobOS {label} must be absolute")
+    if preserve_symlink:
+        if not path.exists():
+            raise RuntimeError(f"JobOS {label} is unavailable")
+    else:
+        try:
+            path = path.resolve(strict=True)
+        except OSError as error:
+            raise RuntimeError(f"JobOS {label} is unavailable") from error
+    if directory and not path.is_dir():
+        raise RuntimeError(f"JobOS {label} must be a directory")
+    if not directory and not path.is_file():
+        raise RuntimeError(f"JobOS {label} must be a file")
+    return path
+
+
+def _required_secret(credentials: Mapping[str, Any], field: str) -> str:
+    value = credentials.get(field)
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"JobOS {field.replace('_', ' ')} is unavailable")
+    return value
+
+
+def _release_path(
+    jobos_root: Path,
+    relative_path: str,
+    label: str,
+    *,
+    directory: bool = False,
+) -> Path:
+    expected_path = jobos_root / relative_path
+    resolved_path = _absolute_existing_path(
+        str(expected_path), label, directory=directory
+    )
+    if resolved_path != expected_path:
+        raise RuntimeError(f"JobOS {label} must stay inside the runtime release")
+    return resolved_path
+
+
+def build_mcp_runtime_launch(
+    runtime: Mapping[str, Any],
+    credentials: Mapping[str, Any],
+    *,
+    base_environment: Mapping[str, str] | None = None,
+) -> McpRuntimeLaunch:
+    jobos_root = _absolute_existing_path(runtime.get("jobos_root"), "runtime root", directory=True)
+    python_path = _absolute_existing_path(
+        runtime.get("python_path"), "Python executable", preserve_symlink=True
+    )
+    mcp_source = _release_path(
+        jobos_root, "services/mcp", "release MCP source", directory=True
+    )
+    mcp_package = _release_path(
+        jobos_root,
+        "services/mcp/jobos_mcp",
+        "release MCP package",
+        directory=True,
+    )
+    _release_path(
+        jobos_root,
+        "services/mcp/jobos_mcp/__init__.py",
+        "release MCP package marker",
+    )
+    _release_path(
+        jobos_root,
+        "services/mcp/jobos_mcp/__main__.py",
+        "release MCP entry point",
+    )
+    _release_path(
+        jobos_root,
+        "services/mcp/jobos_mcp/server.py",
+        "release MCP server",
+    )
+    _release_path(
+        jobos_root,
+        "services/mcp/jobos_mcp/jobs.py",
+        "release MCP client",
+    )
+    if any(path.is_symlink() for path in mcp_package.rglob("*")):
+        raise RuntimeError("JobOS release MCP package cannot contain symbolic links")
+
+    host = runtime.get("host")
+    port = runtime.get("port")
+    valid_port = isinstance(port, int) and not isinstance(port, bool) and 1 <= port <= 65535
+    if host != "127.0.0.1" or not valid_port:
+        raise RuntimeError("JobOS MCP requires a loopback API runtime")
+
+    environment = dict(os.environ if base_environment is None else base_environment)
+    environment.update(
+        {
+            "PYTHONPATH": str(mcp_source),
+            "PYTHONUNBUFFERED": "1",
+            "JOBOS_API_BASE_URL": f"http://127.0.0.1:{port}",
+            "JOBOS_DEVICE_TOKEN": _required_secret(credentials, "device_token"),
+            "JOBOS_MCP_TOKEN": _required_secret(credentials, "mcp_token"),
+            "JOBOS_RUNTIME_ROOT": str(jobos_root),
+        }
+    )
+    arguments = (str(python_path), "-P", "-m", "jobos_mcp")
+    return McpRuntimeLaunch(
+        executable=python_path,
+        arguments=arguments,
+        environment=environment,
+    )
+
+
+def main(arguments: list[str] | None = None) -> None:
+    values = list(sys.argv[1:] if arguments is None else arguments)
+    if len(values) != 2:
+        raise RuntimeError("Usage: jobos_mcp_runtime.py <runtime.json> <credentials.json>")
+
+    runtime_path = _absolute_existing_path(values[0], "runtime configuration")
+    credentials_path = _absolute_existing_path(values[1], "credentials file")
+    runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+    credentials = json.loads(credentials_path.read_text(encoding="utf-8"))
+    if not isinstance(runtime, dict) or not isinstance(credentials, dict):
+        raise RuntimeError("JobOS MCP runtime files must contain JSON objects")
+
+    launch = build_mcp_runtime_launch(runtime, credentials)
+    os.execve(str(launch.executable), list(launch.arguments), launch.environment)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mcp/jobos_mcp/__main__.py
+++ b/services/mcp/jobos_mcp/__main__.py
@@ -1,0 +1,4 @@
+from .server import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/public-release/test_mcp_runtime_launcher.py
+++ b/tests/public-release/test_mcp_runtime_launcher.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+LAUNCHER_PATH = REPOSITORY_ROOT / "scripts/macos/jobos_mcp_runtime.py"
+
+
+def load_launcher() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("jobos_mcp_runtime_tested", LAUNCHER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+jobos_mcp_runtime = load_launcher()
+
+
+def runtime_files(tmp_path: Path) -> tuple[dict[str, object], dict[str, object]]:
+    release = tmp_path / "releases/release-new"
+    mcp_package = release / "services/mcp/jobos_mcp"
+    mcp_package.mkdir(parents=True)
+    (mcp_package / "__init__.py").write_text("", encoding="utf-8")
+    (mcp_package / "__main__.py").write_text("", encoding="utf-8")
+    (mcp_package / "server.py").write_text("", encoding="utf-8")
+    (mcp_package / "jobs.py").write_text("", encoding="utf-8")
+    python_path = tmp_path / "shared-venv/bin/python"
+    python_path.parent.mkdir(parents=True)
+    python_path.write_text("python", encoding="utf-8")
+    runtime: dict[str, object] = {
+        "jobos_root": str(release),
+        "python_path": str(python_path),
+        "host": "127.0.0.1",
+        "port": 8766,
+    }
+    credentials: dict[str, object] = {
+        "device_token": "device-secret-value",
+        "mcp_token": "mcp-secret-value",
+    }
+    return runtime, credentials
+
+
+def test_mcp_runtime_launch_pins_imports_to_the_api_release(tmp_path):
+    runtime, credentials = runtime_files(tmp_path)
+    mutable_checkout = tmp_path / "mutable-checkout/services/mcp"
+    mutable_checkout.mkdir(parents=True)
+
+    launch = jobos_mcp_runtime.build_mcp_runtime_launch(
+        runtime,
+        credentials,
+        base_environment={"PYTHONPATH": str(mutable_checkout), "PATH": "/usr/bin:/bin"},
+    )
+
+    release = Path(str(runtime["jobos_root"]))
+    assert launch.arguments == (
+        str(runtime["python_path"]),
+        "-P",
+        "-m",
+        "jobos_mcp",
+    )
+    assert launch.environment["PYTHONPATH"] == str(release / "services/mcp")
+    assert launch.environment["JOBOS_RUNTIME_ROOT"] == str(release)
+    assert launch.environment["JOBOS_API_BASE_URL"] == "http://127.0.0.1:8766"
+    assert mutable_checkout.as_posix() not in launch.environment["PYTHONPATH"]
+
+
+def test_mcp_runtime_rejects_missing_release_source_and_non_loopback_api(tmp_path):
+    runtime, credentials = runtime_files(tmp_path)
+    release = Path(str(runtime["jobos_root"]))
+    mcp_package = release / "services/mcp/jobos_mcp"
+    (mcp_package / "__init__.py").unlink()
+    (mcp_package / "__main__.py").unlink()
+    (mcp_package / "server.py").unlink()
+    (mcp_package / "jobs.py").unlink()
+    mcp_package.rmdir()
+
+    with pytest.raises(RuntimeError, match="release MCP package"):
+        jobos_mcp_runtime.build_mcp_runtime_launch(runtime, credentials)
+
+    mcp_package.mkdir()
+    with pytest.raises(RuntimeError, match="release MCP package marker"):
+        jobos_mcp_runtime.build_mcp_runtime_launch(runtime, credentials)
+
+    (mcp_package / "__init__.py").write_text("", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="release MCP entry point"):
+        jobos_mcp_runtime.build_mcp_runtime_launch(runtime, credentials)
+
+    (mcp_package / "__main__.py").write_text("", encoding="utf-8")
+    (mcp_package / "server.py").write_text("", encoding="utf-8")
+    (mcp_package / "jobs.py").write_text("", encoding="utf-8")
+    runtime["host"] = "0.0.0.0"
+    with pytest.raises(RuntimeError, match="loopback"):
+        jobos_mcp_runtime.build_mcp_runtime_launch(runtime, credentials)
+
+
+def test_mcp_runtime_rejects_release_package_symlinks(tmp_path):
+    runtime, credentials = runtime_files(tmp_path)
+    release = Path(str(runtime["jobos_root"]))
+    mcp_package = release / "services/mcp/jobos_mcp"
+    external_package = tmp_path / "mutable/jobos_mcp"
+    external_package.mkdir(parents=True)
+    (external_package / "__init__.py").write_text("", encoding="utf-8")
+    (external_package / "__main__.py").write_text("", encoding="utf-8")
+    (external_package / "server.py").write_text("", encoding="utf-8")
+    (external_package / "jobs.py").write_text("", encoding="utf-8")
+
+    (mcp_package / "__init__.py").unlink()
+    (mcp_package / "__main__.py").unlink()
+    (mcp_package / "server.py").unlink()
+    (mcp_package / "jobs.py").unlink()
+    mcp_package.rmdir()
+    mcp_package.symlink_to(external_package, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="must stay inside the runtime release"):
+        jobos_mcp_runtime.build_mcp_runtime_launch(runtime, credentials)
+
+    mcp_package.unlink()
+    mcp_package.mkdir()
+    for name in ("__init__.py", "__main__.py", "jobs.py"):
+        (mcp_package / name).write_text("", encoding="utf-8")
+    (mcp_package / "server.py").symlink_to(external_package / "server.py")
+
+    with pytest.raises(RuntimeError, match="must stay inside the runtime release"):
+        jobos_mcp_runtime.build_mcp_runtime_launch(runtime, credentials)
+
+
+def test_mcp_runtime_main_executes_the_release_module(tmp_path, monkeypatch):
+    runtime, credentials = runtime_files(tmp_path)
+    runtime_path = tmp_path / "runtime.json"
+    credentials_path = tmp_path / "credentials.json"
+    runtime_path.write_text(json.dumps(runtime), encoding="utf-8")
+    credentials_path.write_text(json.dumps(credentials), encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def capture_execve(executable, arguments, environment):
+        captured.update(
+            executable=executable,
+            arguments=arguments,
+            environment=environment,
+        )
+
+    monkeypatch.setattr(jobos_mcp_runtime.os, "execve", capture_execve)
+    jobos_mcp_runtime.main([str(runtime_path), str(credentials_path)])
+
+    assert captured["executable"] == str(runtime["python_path"])
+    assert captured["arguments"] == [
+        str(runtime["python_path"]),
+        "-P",
+        "-m",
+        "jobos_mcp",
+    ]
+    environment = captured["environment"]
+    assert isinstance(environment, dict)
+    assert environment["PYTHONPATH"] == str(Path(str(runtime["jobos_root"])) / "services/mcp")
+
+
+@pytest.mark.anyio
+async def test_release_pinned_process_exposes_correlated_browser_snapshot(tmp_path):
+    stale_cwd = tmp_path / "stale"
+    stale_source = stale_cwd / "jobos_mcp"
+    stale_source.mkdir(parents=True)
+    (stale_source / "__init__.py").write_text("", encoding="utf-8")
+    (stale_source / "__main__.py").write_text(
+        "raise RuntimeError('mutable MCP checkout was imported')\n", encoding="utf-8"
+    )
+    runtime = {
+        "jobos_root": str(REPOSITORY_ROOT),
+        "python_path": sys.executable,
+        "host": "127.0.0.1",
+        "port": 8766,
+    }
+    credentials = {
+        "device_token": "test-device-token",
+        "mcp_token": "test-mcp-token",
+    }
+    launch = jobos_mcp_runtime.build_mcp_runtime_launch(
+        runtime,
+        credentials,
+        base_environment={"PYTHONPATH": str(stale_cwd)},
+    )
+    parameters = StdioServerParameters(
+        command=str(launch.executable),
+        args=list(launch.arguments[1:]),
+        env=launch.environment,
+        cwd=stale_cwd,
+    )
+
+    async with (
+        stdio_client(parameters) as (reader, writer),
+        ClientSession(reader, writer) as session,
+    ):
+        await session.initialize()
+        tools = await session.list_tools()
+
+    snapshot = next(tool for tool in tools.tools if tool.name == "browser_snapshot")
+    schema = snapshot.model_dump(by_alias=True)["inputSchema"]
+    assert "conversation_id" in schema["required"]
+    assert schema["properties"]["conversation_id"]["pattern"] == (
+        "^conv_[A-Za-z0-9_-]{1,128}$"
+    )


### PR DESCRIPTION
## What changed
- launch JobOS MCP from the same immutable runtime release as the API
- fail closed against cwd, PYTHONPATH, incomplete-package, and symlink source escapes
- add real stdio regression coverage for the correlated browser_snapshot contract

## Verification
- focused MCP/browser suite passed (58 tests)
- full Python suite passed (660 passed, 4 skipped)
- desktop suite passed (446 tests) and updater suite passed (10 tests)
- lint, typecheck, public checks, contracts drift check, and production build passed
- independent exact-byte review passed with no security or logic findings

Note: repeated monolithic check runs exposed an unrelated pre-existing async AgentPanel/App test-order flake; the affected suites passed immediately in isolation and the complete desktop suite also passed on a clean rerun.