### PR TITLE
Fix refresh of superseded local document artifacts

### DIFF
--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -2793,8 +2793,14 @@ def create_app(
             return JobArtifactsResponse.model_validate(replay)
         try:
             raw_artifacts = artifacts.list_job_artifacts(job_id)
-            verified = verify_facade_artifacts(raw_artifacts, trusted_artifact_roots)
-            state_store.register_document_artifacts(job_id, verified)
+            verified = verify_facade_artifacts(
+                raw_artifacts, trusted_artifact_roots, expected_job_id=job_id
+            )
+            state_store.register_document_artifacts(
+                job_id,
+                verified.artifacts,
+                invalidated_registry_keys=verified.superseded_registry_keys,
+            )
         except (ArtifactStorageError, OSError) as error:
             raise HTTPException(
                 status_code=503, detail=LOCAL_ARTIFACT_STORAGE_UNAVAILABLE

--- a/services/api/jobos_api/documents.py
+++ b/services/api/jobos_api/documents.py
@@ -71,6 +71,12 @@ class VerifiedArtifact:
         return sha256(material.encode("utf-8")).hexdigest()
 
 
+@dataclass(frozen=True)
+class VerifiedArtifactBatch:
+    artifacts: list[VerifiedArtifact]
+    superseded_registry_keys: frozenset[str]
+
+
 class ArtifactRecord(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -360,13 +366,117 @@ def verify_source_artifact(raw: dict[str, Any], roots: tuple[Path, ...]) -> Veri
 
 
 def verify_facade_artifacts(
-    raw_artifacts: list[dict[str, Any]], roots: tuple[Path, ...]
-) -> list[VerifiedArtifact]:
-    verified = [verify_source_artifact(raw, roots) for raw in raw_artifacts]
+    raw_artifacts: list[dict[str, Any]],
+    roots: tuple[Path, ...],
+    *,
+    expected_job_id: str,
+) -> VerifiedArtifactBatch:
+    metadata = [_validated_artifact_metadata(raw, expected_job_id) for raw in raw_artifacts]
+    current_artifacts, superseded = _discard_superseded_mutable_path_rows(raw_artifacts, metadata)
+    verified = [verify_source_artifact(raw, roots) for raw in current_artifacts]
     sequences = [artifact.render_sequence for artifact in verified]
     if len(sequences) != len(set(sequences)):
         raise ArtifactTrustError("Facade artifact render sequences must be unique")
-    return verified
+    return VerifiedArtifactBatch(
+        artifacts=verified,
+        superseded_registry_keys=frozenset(artifact.registry_key for artifact in superseded),
+    )
+
+
+def _validated_artifact_metadata(
+    raw: dict[str, Any], expected_job_id: str
+) -> VerifiedArtifact:
+    required = ("job_id", "source_revision", "artifact_revision", "media_type", "render_status")
+    if any(not isinstance(raw.get(key), str) or not raw[key] for key in required):
+        raise ArtifactTrustError("Artifact metadata is incomplete")
+    if raw["job_id"] != expected_job_id:
+        raise ArtifactTrustError("Artifact job association does not match the requested job")
+    status = raw["render_status"]
+    if status not in {"succeeded", "failed", "rendering"}:
+        raise ArtifactTrustError("Artifact render status is invalid")
+    media_type = raw["media_type"]
+    if media_type not in ALLOWED_MEDIA_TYPES:
+        raise ArtifactTrustError("Artifact media type is not allowlisted")
+    document_key = raw.get("document_key", "resume")
+    document_label = raw.get("document_label", "Resume")
+    if document_key not in DOCUMENT_KEYS:
+        raise ArtifactTrustError("Artifact document key is invalid")
+    if not isinstance(document_label, str) or not 1 <= len(document_label.strip()) <= 80:
+        raise ArtifactTrustError("Artifact document label is invalid")
+    render_sequence = raw.get("render_sequence")
+    if (
+        not isinstance(render_sequence, int)
+        or isinstance(render_sequence, bool)
+        or render_sequence < 0
+    ):
+        raise ArtifactTrustError("Artifact render sequence is missing or invalid")
+    supplied_path = raw.get("path")
+    supplied_hash = raw.get("sha256")
+    if status == "succeeded" and (
+        not isinstance(supplied_path, (str, Path))
+        or not isinstance(supplied_hash, str)
+        or re.fullmatch(r"[0-9a-f]{64}", supplied_hash) is None
+    ):
+        raise ArtifactTrustError("Successful artifact metadata is incomplete")
+    successful_path = supplied_path if isinstance(supplied_path, (str, Path)) else None
+    successful_hash = supplied_hash if isinstance(supplied_hash, str) else ""
+    successful_filename = Path(successful_path).name if successful_path is not None else None
+    return VerifiedArtifact(
+        job_id=raw["job_id"],
+        document_key=document_key,
+        document_label=document_label.strip(),
+        source_revision=raw["source_revision"],
+        artifact_revision=raw["artifact_revision"],
+        media_type=media_type,
+        sha256=successful_hash if status == "succeeded" else "",
+        render_status=status,
+        render_sequence=render_sequence,
+        canonical_path=str(successful_path) if successful_path is not None else None,
+        filename=successful_filename,
+        failure_message=(
+            str(raw.get("failure_message"))[:500] if raw.get("failure_message") else None
+        ),
+    )
+
+
+def _discard_superseded_mutable_path_rows(
+    raw_artifacts: list[dict[str, Any]],
+    metadata: list[VerifiedArtifact],
+) -> tuple[list[dict[str, Any]], list[VerifiedArtifact]]:
+    """Ignore stale revisions when a provider reused one output path.
+
+    A trusted producer should publish immutable artifact paths. Older private
+    providers instead appended new checksum metadata while reusing the same
+    PDF/DOCX paths, so the historical rows can no longer pass integrity checks.
+    Keep only the highest-sequence row for a path when its checksums conflict;
+    identical immutable revisions and non-success rows retain their history.
+    """
+    conflicting_paths: set[str] = set()
+    rows_by_path: dict[str, list[tuple[int, str]]] = {}
+    for raw, artifact in zip(raw_artifacts, metadata, strict=True):
+        path = raw.get("path")
+        if artifact.render_status != "succeeded":
+            continue
+        path_key = str(path)
+        rows_by_path.setdefault(path_key, []).append(
+            (artifact.render_sequence, artifact.sha256)
+        )
+
+    newest_sequence_by_path: dict[str, int] = {}
+    for path, rows in rows_by_path.items():
+        if len({digest for _, digest in rows}) > 1:
+            conflicting_paths.add(path)
+            newest_sequence_by_path[path] = max(sequence for sequence, _ in rows)
+
+    kept: list[dict[str, Any]] = []
+    superseded: list[VerifiedArtifact] = []
+    for raw, artifact in zip(raw_artifacts, metadata, strict=True):
+        path = str(raw.get("path"))
+        if path in conflicting_paths and artifact.render_sequence != newest_sequence_by_path[path]:
+            superseded.append(artifact)
+        else:
+            kept.append(raw)
+    return kept, superseded
 
 
 def artifact_record(

--- a/services/api/jobos_api/state_store.py
+++ b/services/api/jobos_api/state_store.py
@@ -2209,6 +2209,7 @@ class JobOsStateStore:
         *,
         editable_document_id: str | None = None,
         editable_document_revision: int | None = None,
+        invalidated_registry_keys: frozenset[str] = frozenset(),
         connection: sqlite3.Connection | None = None,
     ) -> tuple[str | None, str | None]:
         if (editable_document_id is None) != (editable_document_revision is None):
@@ -2216,6 +2217,20 @@ class JobOsStateStore:
         if any(artifact.job_id != job_id for artifact in artifacts):
             raise ValueError("Artifact job association does not match the requested job")
         with self._editable_write_connection(connection) as connection:
+            for registry_key in invalidated_registry_keys:
+                connection.execute(
+                    """
+                    UPDATE job_document_state
+                    SET approved_artifact_id = NULL,
+                        approved_at = NULL,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE job_id = ? AND approved_artifact_id = (
+                        SELECT artifact_id FROM document_artifacts
+                        WHERE job_id = ? AND registry_key = ?
+                    )
+                    """,
+                    (job_id, job_id, registry_key),
+                )
             state = connection.execute(
                 "SELECT current_artifact_id, last_successful_artifact_id "
                 "FROM job_document_state WHERE job_id = ?",

--- a/services/api/tests/test_jobs_contract.py
+++ b/services/api/tests/test_jobs_contract.py
@@ -1779,6 +1779,123 @@ def test_failed_or_cross_job_artifact_cannot_be_approved(tmp_path):
     assert cross_job.status_code == 409
 
 
+def test_refresh_uses_latest_checksum_when_provider_reuses_an_artifact_path(tmp_path):
+    facade = FakeJobHunterFacade()
+    facade.jobs = facade.jobs[:1]
+    pdf = tmp_path / "resume.pdf"
+    pdf.write_bytes(build_minimal_pdf("(FAKE) pre-fix resume"))
+    stale = artifact_metadata(pdf, source="source-old", revision="render-old", sequence=1)
+    pdf.write_bytes(build_minimal_pdf("(FAKE) corrected resume"))
+    corrected = artifact_metadata(
+        pdf, source="source-corrected", revision="render-corrected", sequence=2
+    )
+    facade.artifacts["job-0"] = [stale, corrected]
+
+    with make_client(tmp_path, facade) as client:
+        response = client.post(
+            "/v1/jobs/job-0/artifacts/refresh", headers=auth_headers()
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["artifacts"]) == 1
+    assert body["artifacts"][0]["artifact_revision"] == "render-corrected"
+    assert body["artifacts"][0]["source_revision"] == "source-corrected"
+    assert body["artifacts"][0]["is_current"] is True
+
+
+def test_refresh_clears_approval_for_superseded_mutable_path_bytes(tmp_path):
+    facade = FakeJobHunterFacade()
+    facade.jobs = facade.jobs[:1]
+    pdf = tmp_path / "resume.pdf"
+    pdf.write_bytes(build_minimal_pdf("(FAKE) approved pre-fix resume"))
+    stale = artifact_metadata(pdf, source="source-old", revision="render-old", sequence=1)
+    facade.artifacts["job-0"] = [stale]
+
+    with make_client(tmp_path, facade) as client:
+        initial = client.post(
+            "/v1/jobs/job-0/artifacts/refresh", headers=auth_headers()
+        ).json()
+        approved_id = initial["last_successful_artifact_id"]
+        approved = client.post(
+            f"/v1/jobs/job-0/artifacts/{approved_id}/approve",
+            headers=auth_headers(),
+            json={"origin": "user", "idempotency_key": "approve-pre-fix-resume"},
+        )
+        pdf.write_bytes(build_minimal_pdf("(FAKE) corrected resume"))
+        facade.artifacts["job-0"].append(
+            artifact_metadata(
+                pdf,
+                source="source-corrected",
+                revision="render-corrected",
+                sequence=2,
+            )
+        )
+        refreshed = client.post(
+            "/v1/jobs/job-0/artifacts/refresh", headers=auth_headers()
+        )
+
+    assert approved.status_code == 200
+    assert refreshed.status_code == 200
+    body = refreshed.json()
+    assert body["approved_artifact_id"] is None
+    old = next(item for item in body["artifacts"] if item["artifact_id"] == approved_id)
+    corrected = next(
+        item for item in body["artifacts"] if item["artifact_revision"] == "render-corrected"
+    )
+    assert old["is_approved"] is False
+    assert corrected["is_current"] is True
+
+
+@pytest.mark.parametrize("hidden_damage", ["malformed", "cross-job"])
+def test_refresh_does_not_hide_invalid_metadata_behind_path_supersession(
+    tmp_path, hidden_damage
+):
+    facade = FakeJobHunterFacade()
+    facade.jobs = facade.jobs[:1]
+    pdf = tmp_path / "resume.pdf"
+    pdf.write_bytes(build_minimal_pdf("(FAKE) pre-fix resume"))
+    stale = artifact_metadata(pdf, source="source-old", revision="render-old", sequence=1)
+    if hidden_damage == "malformed":
+        stale["render_sequence"] = -1
+    else:
+        stale["job_id"] = "job-other"
+    pdf.write_bytes(build_minimal_pdf("(FAKE) corrected resume"))
+    corrected = artifact_metadata(
+        pdf, source="source-corrected", revision="render-corrected", sequence=2
+    )
+    facade.artifacts["job-0"] = [stale, corrected]
+
+    with make_client(tmp_path, facade) as client:
+        response = client.post(
+            "/v1/jobs/job-0/artifacts/refresh", headers=auth_headers()
+        )
+        listed = client.get("/v1/jobs/job-0/artifacts", headers=auth_headers())
+
+    assert response.status_code == 422
+    assert listed.json()["artifacts"] == []
+
+
+def test_refresh_still_rejects_a_lone_artifact_with_stale_checksum(tmp_path):
+    facade = FakeJobHunterFacade()
+    facade.jobs = facade.jobs[:1]
+    pdf = tmp_path / "resume.pdf"
+    pdf.write_bytes(build_minimal_pdf("(FAKE) registered resume"))
+    stale = artifact_metadata(pdf)
+    pdf.write_bytes(build_minimal_pdf("(FAKE) unregistered replacement"))
+    facade.artifacts["job-0"] = [stale]
+
+    with make_client(tmp_path, facade) as client:
+        response = client.post(
+            "/v1/jobs/job-0/artifacts/refresh", headers=auth_headers()
+        )
+
+    assert (response.status_code, response.json()["detail"]) == (
+        503,
+        "Local artifact storage is unavailable",
+    )
+
+
 def test_failed_render_stays_in_audit_without_injecting_chat_activity(tmp_path):
     class FailedRenderFacade(FakeJobHunterFacade):
         def render_resume(self, job_id, source_id, output_options):


### PR DESCRIPTION
## Summary
- reconcile stale historical rows when a legacy provider reused mutable PDF/DOCX paths
- verify every row\u2019s metadata and job association before supersession handling
- atomically clear approval when its exact registered bytes have been superseded
- retain fail-closed behavior for lone stale, malformed, and cross-job artifacts

## Root cause
Legacy publication rows reused the same output path across renders. Once corrected bytes replaced the old file, refresh validated all historical rows as a batch; the old checksum mismatch raised storage-unavailable and prevented valid newer rows from importing.

## Verification
- `pnpm check` passed
- desktop: 446 tests passed
- API: 665 passed, 4 skipped
- focused/full artifact contract tests passed
- real six-row artifact set reconciled against a disposable copy of JobOS state
- independent exact-byte review approved with both prior findings resolved

## Companion producer fix
The private Job Hunter publisher now writes immutable content-addressed snapshots, merged separately in cobibean/job-hunter-agent-workspace#2.