### PR TITLE
Fix external apply links in the JobOS browser

### DIFF
--- a/apps/desktop/src/main/browser.test.ts
+++ b/apps/desktop/src/main/browser.test.ts
@@ -5,7 +5,7 @@ import { expect, test } from 'vitest'
 import { EventEmitter } from 'node:events'
 import { readFileSync } from 'node:fs'
 
-import type { BrowserWindow, Dialog, Session, WebContents, WebContentsView } from 'electron'
+import type { BrowserWindow, BrowserWindowConstructorOptions, Dialog, Session, WebContents, WebContentsView, WebContentsViewConstructorOptions } from 'electron'
 import { vi } from 'vitest'
 
 import { BrowserManager, DEFAULT_BROWSER_URL, isOrdinaryWebUrl, normalizeBrowserInput, remoteBrowserPreferences, safeBlockedExternalUrl } from './browser.js'
@@ -76,6 +76,102 @@ test('desktop title persistence matches the shared conservative redaction fixtur
   for (const fixture of browserTitlePolicyFixtures) {
     expect(sanitizeBrowserTitleForPersistence(fixture.title), fixture.title).toBe(fixture.expected)
   }
+})
+
+test('new-window handoff preserves Chromium request context instead of replaying only the URL', async () => {
+  const views: WebContentsView[] = []
+  const createView = vi.fn((options?: WebContentsViewConstructorOptions) => {
+    const events = new EventEmitter()
+    let url = ''
+    const contents = options?.webContents ?? Object.assign(events, {
+      navigationHistory: { canGoBack: () => false, canGoForward: () => false, goBack: vi.fn(), goForward: vi.fn() },
+      loadURL: vi.fn(async (next: string) => { url = next }),
+      getURL: () => url,
+      setWindowOpenHandler: vi.fn(),
+      isDestroyed: () => false,
+      close: vi.fn(),
+      reload: vi.fn(),
+      stop: vi.fn()
+    })
+    const view = { webContents: contents, setBounds: vi.fn() } as unknown as WebContentsView
+    views.push(view)
+    return view
+  })
+  const manager = new BrowserManager({
+    window: {
+      contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+      webContents: { send: vi.fn() },
+      isDestroyed: () => false
+    } as unknown as BrowserWindow,
+    browserSession: Object.assign(new EventEmitter(), {
+      setPermissionCheckHandler: vi.fn(), setPermissionRequestHandler: vi.fn()
+    }) as unknown as Session,
+    createView,
+    dialog: { showSaveDialog: vi.fn() } as unknown as Pick<Dialog, 'showSaveDialog'>,
+    clipboard: { writeText: vi.fn() },
+    downloadsPath: '/tmp'
+  })
+
+  await manager.restore({
+    tabs: [{ tabId: 'linkedin', url: 'https://www.linkedin.com/jobs/view/123', title: 'LinkedIn job', faviconUrl: null, associatedJobId: 'job-123' }],
+    activeTabId: 'linkedin'
+  })
+  const opener = views[0]
+  const openHandler = (opener?.webContents.setWindowOpenHandler as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]
+  if (!openHandler) throw new Error('Window-open policy was not installed')
+
+  const response = openHandler({
+    url: 'https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fjobs.example.com%2Fapply',
+    frameName: '_blank',
+    features: '',
+    disposition: 'foreground-tab',
+    referrer: { url: 'https://www.linkedin.com/jobs/view/123', policy: 'strict-origin-when-cross-origin' }
+  })
+
+  expect(response.action).toBe('allow')
+  expect(response.outlivesOpener).toBe(true)
+  expect(response.createWindow).toBeTypeOf('function')
+  const pendingPopupContents = {
+    navigationHistory: { canGoBack: () => false, canGoForward: () => false, goBack: vi.fn(), goForward: vi.fn() },
+    loadURL: vi.fn(), getURL: () => '', setWindowOpenHandler: vi.fn(), isDestroyed: () => false,
+    close: vi.fn(), reload: vi.fn(), stop: vi.fn(), on: vi.fn()
+  } as unknown as WebContents
+  const childContents = response.createWindow?.({
+    webContents: pendingPopupContents,
+    webPreferences: { partition: 'persist:jobos-browser-v1' }
+  } as BrowserWindowConstructorOptions)
+  expect(childContents).toBe(pendingPopupContents)
+  expect(createView).toHaveBeenLastCalledWith({
+    webContents: pendingPopupContents,
+    webPreferences: expect.objectContaining({ partition: 'persist:jobos-browser-v1' })
+  })
+  expect(views[1]?.webContents.loadURL).not.toHaveBeenCalled()
+  expect(manager.getState().tabs.at(-1)).toMatchObject({
+    url: 'https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fjobs.example.com%2Fapply',
+    associatedJobId: 'job-123'
+  })
+
+  const postData = [{ bytes: Buffer.from('applicationId=123') }]
+  const backgroundResponse = openHandler({
+    url: 'https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fjobs.example.com%2Fapply-later',
+    frameName: '_blank',
+    features: '',
+    disposition: 'background-tab',
+    referrer: { url: 'https://www.linkedin.com/jobs/view/123', policy: 'strict-origin-when-cross-origin' },
+    postBody: { contentType: 'application/x-www-form-urlencoded', data: postData }
+  })
+  expect(backgroundResponse.outlivesOpener).toBe(true)
+  backgroundResponse.createWindow?.({
+    webPreferences: { partition: 'persist:jobos-browser-v1' }
+  } as BrowserWindowConstructorOptions)
+  expect(views[2]?.webContents.loadURL).toHaveBeenCalledWith(
+    'https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fjobs.example.com%2Fapply-later',
+    {
+      httpReferrer: { url: 'https://www.linkedin.com/jobs/view/123', policy: 'strict-origin-when-cross-origin' },
+      extraHeaders: 'Content-Type: application/x-www-form-urlencoded',
+      postData
+    }
+  )
 })
 
 test('new tab commands do not complete before the initial page load settles', async () => {

--- a/apps/desktop/src/main/browser.ts
+++ b/apps/desktop/src/main/browser.ts
@@ -6,9 +6,11 @@ import type {
   Clipboard,
   Dialog,
   DownloadItem,
+  LoadURLOptions,
   Session,
   WebContents,
   WebContentsView,
+  WebContentsViewConstructorOptions,
   WebPreferences
 } from 'electron'
 
@@ -102,7 +104,7 @@ interface SemanticTarget {
 interface BrowserManagerOptions {
   window: BrowserWindow
   browserSession: Session
-  createView: () => WebContentsView
+  createView: (options?: WebContentsViewConstructorOptions) => WebContentsView
   dialog: Pick<Dialog, 'showSaveDialog'>
   downloadsPath: string
   clipboard: Pick<Clipboard, 'writeText'>
@@ -111,7 +113,7 @@ interface BrowserManagerOptions {
 export class BrowserManager {
   readonly #window: BrowserWindow
   readonly #session: Session
-  readonly #createView: () => WebContentsView
+  readonly #createView: (options?: WebContentsViewConstructorOptions) => WebContentsView
   readonly #dialog: Pick<Dialog, 'showSaveDialog'>
   readonly #downloadsPath: string
   readonly #clipboard: Pick<Clipboard, 'writeText'>
@@ -522,6 +524,11 @@ export class BrowserManager {
 
   #createTab(restored: BrowserTabMetadata): Promise<void> {
     const view = this.#createView()
+    this.#registerTab(restored, view)
+    return view.webContents.loadURL(restored.url).then(() => undefined, () => undefined)
+  }
+
+  #registerTab(restored: BrowserTabMetadata, view: WebContentsView): ManagedTab {
     const state: BrowserTab = {
       ...restored,
       loading: false,
@@ -538,7 +545,7 @@ export class BrowserManager {
     this.#tabs.set(state.tabId, managed)
     this.#order.push(state.tabId)
     this.#wireTab(managed)
-    return view.webContents.loadURL(state.url).then(() => undefined, () => undefined)
+    return managed
   }
 
   #wireTab(tab: ManagedTab): void {
@@ -603,10 +610,51 @@ export class BrowserManager {
     }
     contents.on('will-navigate', handleCancellableNavigation)
     contents.on('will-redirect', handleCancellableNavigation)
-    contents.setWindowOpenHandler(({ url }) => {
-      if (isOrdinaryWebUrl(url)) void this.create(url, tab.state.associatedJobId)
-      else blockExternalProtocol(url)
-      return { action: 'deny' }
+    contents.setWindowOpenHandler(details => {
+      if (!isOrdinaryWebUrl(details.url)) {
+        blockExternalProtocol(details.url)
+        return { action: 'deny' }
+      }
+      if (this.#order.length >= BROWSER_PERSISTENCE_LIMITS.tabs) {
+        this.#notice = `Tab limit reached (${BROWSER_PERSISTENCE_LIMITS.tabs}). Close a tab before opening another.`
+        this.#emit()
+        return { action: 'deny' }
+      }
+      return {
+        action: 'allow',
+        outlivesOpener: true,
+        createWindow: options => {
+          const popupOptions = options as typeof options & { webContents?: WebContents }
+          const view = this.#createView({
+            webContents: popupOptions.webContents,
+            webPreferences: popupOptions.webPreferences
+          })
+          const tabId = randomUUID()
+          this.#registerTab({
+            tabId,
+            url: normalizeBrowserInput(details.url),
+            title: 'New tab',
+            faviconUrl: null,
+            associatedJobId: tab.state.associatedJobId
+          }, view)
+          this.#hasExplicitAction = true
+          this.#activeTabId = tabId
+          this.#syncAttachedView()
+          this.#emit()
+          if (!popupOptions.webContents) {
+            const loadOptions: LoadURLOptions = { httpReferrer: details.referrer }
+            if (details.postBody) {
+              const contentType = details.postBody.boundary
+                ? `${details.postBody.contentType}; boundary=${details.postBody.boundary}`
+                : details.postBody.contentType
+              loadOptions.extraHeaders = `Content-Type: ${contentType}`
+              loadOptions.postData = details.postBody.data
+            }
+            void view.webContents.loadURL(details.url, loadOptions).catch(() => undefined)
+          }
+          return view.webContents
+        }
+      }
     })
   }
 

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -553,7 +553,10 @@ async function createWindow(): Promise<BrowserWindow> {
   browserManager = new BrowserManager({
     window,
     browserSession,
-    createView: () => new WebContentsView({ webPreferences: remoteBrowserPreferences() }),
+    createView: options => new WebContentsView({
+      webContents: options?.webContents,
+      webPreferences: { ...options?.webPreferences, ...remoteBrowserPreferences() }
+    }),
     dialog,
     clipboard,
     downloadsPath: app.getPath('downloads')


### PR DESCRIPTION
## What changed
- Preserve Electron's original popup WebContents instead of replaying only its URL.
- Keep promoted popup tabs alive after the opener closes.
- Preserve referrer and POST data for background-tab fallbacks.

## Why
LinkedIn external-apply redirects validate request context. Replaying the URL alone dropped that context and landed on LinkedIn's Page not found screen.

## Verification
- `pnpm check` passed: 61 desktop test files / 447 tests, 665 Python tests passed with 4 skipped, build/typecheck/lint/public checks passed.
- Focused browser regression: 14/14 passed.
- Electron runtime smoke reached the employer apply destination with the expected session and referrer.
- Independent exact-byte review approved.
