### PR TITLE
Fix dead embedded browser controls after popup handoff

### DIFF
--- a/apps/desktop/src/main/browser.test.ts
+++ b/apps/desktop/src/main/browser.test.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'node:fs'
 import type { BrowserWindow, BrowserWindowConstructorOptions, Dialog, Session, WebContents, WebContentsView, WebContentsViewConstructorOptions } from 'electron'
 import { vi } from 'vitest'
 
-import { BrowserManager, DEFAULT_BROWSER_URL, isOrdinaryWebUrl, normalizeBrowserInput, remoteBrowserPreferences, safeBlockedExternalUrl } from './browser.js'
+import { BrowserManager, DEFAULT_BROWSER_URL, isOrdinaryWebUrl, normalizeBrowserInput, remoteBrowserPreferences, remoteBrowserViewOptions, safeBlockedExternalUrl } from './browser.js'
 import {
   BROWSER_PERSISTENCE_LIMITS,
   BROWSER_SAFE_TITLE_FALLBACK,
@@ -51,6 +51,20 @@ test('remote browser content has no Node, preload, webview, or privileged render
     webviewTag: false
   })
   expect(preferences).not.toHaveProperty('preload')
+})
+
+test('ordinary tabs omit webContents while popup tabs preserve their live WebContents', () => {
+  const ordinary = remoteBrowserViewOptions()
+  expect(ordinary).not.toHaveProperty('webContents')
+  expect(ordinary.webPreferences).toMatchObject(remoteBrowserPreferences())
+
+  const popupContents = {} as WebContents
+  const popup = remoteBrowserViewOptions({
+    webContents: popupContents,
+    webPreferences: { partition: 'popup-partition', devTools: true }
+  })
+  expect(popup.webContents).toBe(popupContents)
+  expect(popup.webPreferences).toMatchObject(remoteBrowserPreferences())
 })
 
 test('persisted browser URLs remove credentials, auth parameters, and fragments', () => {

--- a/apps/desktop/src/main/browser.ts
+++ b/apps/desktop/src/main/browser.ts
@@ -50,6 +50,15 @@ export function remoteBrowserPreferences(): WebPreferences {
   }
 }
 
+export function remoteBrowserViewOptions(
+  options?: WebContentsViewConstructorOptions
+): WebContentsViewConstructorOptions {
+  const webPreferences = { ...options?.webPreferences, ...remoteBrowserPreferences() }
+  return options?.webContents
+    ? { webContents: options.webContents, webPreferences }
+    : { webPreferences }
+}
+
 export function normalizeBrowserInput(input: string): string {
   const value = input.trim()
   if (!value) return DEFAULT_BROWSER_URL

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -11,7 +11,7 @@ import type { BrowserBounds, DocumentKey, JobSortMode, JobStatus, WorkspaceSnaps
 import { AgentConversationRegistry, createScopedMainAgentClient, startAgentEventStream } from './agent.js'
 import { registerAgentIpc } from './agentIpc.js'
 import { createApiLifecycle } from './apiLifecycle.js'
-import { BROWSER_PARTITION, BrowserManager, remoteBrowserPreferences } from './browser.js'
+import { BROWSER_PARTITION, BrowserManager, remoteBrowserViewOptions } from './browser.js'
 import { canonicalListingUrl, safeApplicationUrl, validatedBrowserJobExtraction } from './browserJobExtraction.js'
 import { registerBrowserRestoreHandler } from './browserIpc.js'
 import { startDesktopCapabilityClient } from './capabilityClient.js'
@@ -553,10 +553,7 @@ async function createWindow(): Promise<BrowserWindow> {
   browserManager = new BrowserManager({
     window,
     browserSession,
-    createView: options => new WebContentsView({
-      webContents: options?.webContents,
-      webPreferences: { ...options?.webPreferences, ...remoteBrowserPreferences() }
-    }),
+    createView: options => new WebContentsView(remoteBrowserViewOptions(options)),
     dialog,
     clipboard,
     downloadsPath: app.getPath('downloads')

--- a/apps/desktop/src/renderer/App.test.tsx
+++ b/apps/desktop/src/renderer/App.test.tsx
@@ -426,8 +426,7 @@ test('saving dispatches job-hunter and reconciles a failure emitted before send 
   expect(savePrompt).toContain('Do not apply or submit forms')
   expect(send.mock.calls[0]?.[2]).toMatch(/^browser-save-/)
   expect(associate).not.toHaveBeenCalled()
-  await screen.findByRole('alert')
-  expect(screen.getByText('Agent connection unavailable')).not.toBeNull()
+  expect(await screen.findByText('Agent connection unavailable')).not.toBeNull()
   expect((screen.getByRole('button', { name: 'Save this job to JobOS' }) as HTMLButtonElement).disabled).toBe(false)
 
   saveOutcome = 'completed'

--- a/apps/desktop/src/renderer/components/CenterWorkspace.tsx
+++ b/apps/desktop/src/renderer/components/CenterWorkspace.tsx
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom'
 import { ArrowLeft, ArrowRight, BriefcaseBusiness, Check, Download, Globe2, LoaderCircle, Plus, RefreshCw, Search, Square, X } from 'lucide-react'
 
 import type { BrowserRestoreState, JobListItem } from '../../shared/contracts'
-import { BROWSER_PERSISTENCE_LIMITS } from '../../shared/browserPersistence'
 import type { DocxOpenResult } from '../../shared/docxDocuments'
 import { useBrowser } from '../hooks/useBrowser'
 import { browserRepairMessage, type BrowserRepairReason } from '../workspaceLayout'
@@ -375,7 +374,6 @@ export function CenterWorkspace(props: CenterWorkspaceProps) {
   }
 
   const activeIndex = browser.state.tabs.findIndex(tab => tab.tabId === browser.state.activeTabId)
-  const browserAtTabLimit = browser.state.tabs.length >= BROWSER_PERSISTENCE_LIMITS.tabs
   const tooltipTrigger = (text: string) => ({
     'aria-describedby': 'browser-control-tooltip',
     onBlur: () => setTooltip(null),
@@ -424,15 +422,7 @@ export function CenterWorkspace(props: CenterWorkspaceProps) {
           <button aria-label={`Move ${active.title} right`} className="tab-order" data-tooltip={`Move ${active.title} right`} disabled={activeIndex === browser.state.tabs.length - 1} onClick={() => moveTab(active.tabId, 1)} type="button" {...tooltipTrigger(`Move ${active.title} right`)}><ArrowRight aria-hidden="true" size={11} /></button>
           <button aria-label={`Close ${active.title}`} className="tab-close" data-tooltip={`Close ${active.title}`} onClick={() => browser.close(active.tabId)} type="button" {...tooltipTrigger(`Close ${active.title}`)}><X aria-hidden="true" size={13} /></button>
         </div> : null}
-        <button
-          aria-label="Open a new tab"
-          className="icon-button browser-tab-add"
-          data-tooltip={browserAtTabLimit ? `Maximum ${BROWSER_PERSISTENCE_LIMITS.tabs} tabs` : 'Open a new tab'}
-          disabled={!browser.bridgeAvailable || browserAtTabLimit}
-          onClick={() => browser.create()}
-          type="button"
-          {...tooltipTrigger(browserAtTabLimit ? `Maximum ${BROWSER_PERSISTENCE_LIMITS.tabs} tabs` : 'Open a new tab')}
-        ><Plus aria-hidden="true" size={16} /></button>
+        <button aria-label="Open a new tab" className="icon-button browser-tab-add" data-tooltip="Open a new tab" disabled={!browser.bridgeAvailable} onClick={() => browser.create()} type="button" {...tooltipTrigger('Open a new tab')}><Plus aria-hidden="true" size={16} /></button>
       </div>
 
       <div className="browser-toolbar">

--- a/apps/desktop/src/renderer/components/CenterWorkspace.tsx
+++ b/apps/desktop/src/renderer/components/CenterWorkspace.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { ArrowLeft, ArrowRight, BriefcaseBusiness, Check, Download, Globe2, LoaderCircle, Plus, RefreshCw, Search, Square, X } from 'lucide-react'
 
 import type { BrowserRestoreState, JobListItem } from '../../shared/contracts'
+import { BROWSER_PERSISTENCE_LIMITS } from '../../shared/browserPersistence'
 import type { DocxOpenResult } from '../../shared/docxDocuments'
 import { useBrowser } from '../hooks/useBrowser'
 import { browserRepairMessage, type BrowserRepairReason } from '../workspaceLayout'
@@ -374,6 +375,7 @@ export function CenterWorkspace(props: CenterWorkspaceProps) {
   }
 
   const activeIndex = browser.state.tabs.findIndex(tab => tab.tabId === browser.state.activeTabId)
+  const browserAtTabLimit = browser.state.tabs.length >= BROWSER_PERSISTENCE_LIMITS.tabs
   const tooltipTrigger = (text: string) => ({
     'aria-describedby': 'browser-control-tooltip',
     onBlur: () => setTooltip(null),
@@ -422,7 +424,15 @@ export function CenterWorkspace(props: CenterWorkspaceProps) {
           <button aria-label={`Move ${active.title} right`} className="tab-order" data-tooltip={`Move ${active.title} right`} disabled={activeIndex === browser.state.tabs.length - 1} onClick={() => moveTab(active.tabId, 1)} type="button" {...tooltipTrigger(`Move ${active.title} right`)}><ArrowRight aria-hidden="true" size={11} /></button>
           <button aria-label={`Close ${active.title}`} className="tab-close" data-tooltip={`Close ${active.title}`} onClick={() => browser.close(active.tabId)} type="button" {...tooltipTrigger(`Close ${active.title}`)}><X aria-hidden="true" size={13} /></button>
         </div> : null}
-        <button aria-label="Open a new tab" className="icon-button browser-tab-add" data-tooltip="Open a new tab" disabled={!browser.bridgeAvailable} onClick={() => browser.create()} type="button" {...tooltipTrigger('Open a new tab')}><Plus aria-hidden="true" size={16} /></button>
+        <button
+          aria-label="Open a new tab"
+          className="icon-button browser-tab-add"
+          data-tooltip={browserAtTabLimit ? `Maximum ${BROWSER_PERSISTENCE_LIMITS.tabs} tabs` : 'Open a new tab'}
+          disabled={!browser.bridgeAvailable || browserAtTabLimit}
+          onClick={() => browser.create()}
+          type="button"
+          {...tooltipTrigger(browserAtTabLimit ? `Maximum ${BROWSER_PERSISTENCE_LIMITS.tabs} tabs` : 'Open a new tab')}
+        ><Plus aria-hidden="true" size={16} /></button>
       </div>
 
       <div className="browser-toolbar">


### PR DESCRIPTION
## What changed
- restore normal embedded-browser tab creation by omitting the `webContents` option unless Electron supplied a live popup WebContents
- preserve the LinkedIn external-Apply popup handoff and secure browser preferences
- add regression coverage for ordinary tabs versus adopted popup tabs

## Root cause
The LinkedIn popup fix reused one view-construction path for both popup tabs and ordinary tabs. Ordinary tabs were therefore constructed with an explicit `webContents: undefined` instead of omitting that option. Electron did not establish a usable normal tab, leaving the address field disabled and making New Tab and job-to-browser actions appear dead.

## Verification
- `pnpm check`
  - 61 desktop test files / 448 tests passed
  - 665 Python tests passed, 4 skipped
  - lint, typecheck, build, public-tree, license, and updater checks passed
- Installed arm64 package smoke:
  - address field accepted text and submitted navigation
  - Close and New Tab worked
  - clicking a real saved job opened its employer URL
  - session/referrer-sensitive external popup reached the employer page and registered as a JobOS tab
