### PR TITLE
feat(desktop): add Career Profile work arrangement slice

### DIFF
--- a/apps/desktop/src/main/careerProfile.test.ts
+++ b/apps/desktop/src/main/careerProfile.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createMainCareerProfileClient } from './careerProfile.js'
+
+const originalFetch = globalThis.fetch
+
+const current = {
+  profile_revision: 2,
+  record: {
+    actor_principal: 'primary-device',
+    item_revision: 2,
+    namespace: 'search_preferences.work_arrangement',
+    profile_revision: 2,
+    record_id: 'career_work_arrangement',
+    updated_at: '2026-08-21T15:00:00Z',
+    value: { mode: 'remote', strength: 'requirement', note: '(FAKE) Iowa-based role' }
+  }
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+function client() {
+  return createMainCareerProfileClient({
+    baseUrl: 'http://127.0.0.1:8766',
+    deviceToken: 'test-device-token'
+  })
+}
+
+describe('Career Profile desktop client', () => {
+  it('reports the dormant feature without leaking an API error', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(
+      JSON.stringify({ detail: 'Career Profile is not enabled' }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } }
+    )) as typeof fetch
+
+    await expect(client().availability()).resolves.toEqual({ enabled: false })
+  })
+
+  it('maps the typed work-arrangement record and authenticates the request', async () => {
+    globalThis.fetch = vi.fn(async (input, init) => {
+      expect(String(input)).toBe('http://127.0.0.1:8766/v1/career-profile/work-arrangement')
+      expect(new Headers(init?.headers).get('Authorization')).toBe('Bearer test-device-token')
+      return new Response(JSON.stringify(current), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }) as typeof fetch
+
+    await expect(client().getWorkArrangement()).resolves.toMatchObject({
+      profileRevision: 2,
+      record: { value: { mode: 'remote', strength: 'requirement' } }
+    })
+  })
+
+  it('binds offline cache data to this API and device credential', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(
+      JSON.stringify(current),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )) as typeof fetch
+
+    const primary = client()
+    const protectedCurrent = await primary.getWorkArrangement()
+    expect(protectedCurrent.cacheProof).toMatch(/^[a-f0-9]{64}$/)
+    expect(primary.validateCachedWorkArrangement(protectedCurrent)).toEqual(protectedCurrent)
+    expect(primary.validateCachedWorkArrangement({ profileRevision: 0, record: null })).toBeNull()
+    expect(primary.validateCachedWorkArrangement({ ...protectedCurrent, profileRevision: 999 })).toBeNull()
+
+    const otherRuntime = createMainCareerProfileClient({
+      baseUrl: 'http://127.0.0.1:9999',
+      deviceToken: 'different-test-device-token'
+    })
+    expect(otherRuntime.validateCachedWorkArrangement(protectedCurrent)).toBeNull()
+  })
+
+  it('returns the latest value on a stale save instead of overwriting it', async () => {
+    globalThis.fetch = vi.fn(async (_input, init) => {
+      if (init?.method === 'PUT') {
+        return new Response(JSON.stringify({ detail: 'Career Profile revision conflict; current revision is 2' }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      return new Response(JSON.stringify(current), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }) as typeof fetch
+
+    await expect(client().saveWorkArrangement({
+      expectedProfileRevision: 1,
+      idempotencyKey: 'desktop-save-1',
+      value: { mode: 'hybrid', strength: 'preference', note: null }
+    })).resolves.toEqual(expect.objectContaining({ status: 'conflict', current: expect.objectContaining({ profileRevision: 2 }) }))
+  })
+
+  it('loads history and restores through the authenticated API', async () => {
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input)
+      if (url.endsWith('/history')) {
+        return new Response(JSON.stringify({
+          profile_revision: 2,
+          revisions: [{
+            actor_principal: 'primary-device', base_profile_revision: 1, changed_fields: ['mode'],
+            created_at: '2026-08-21T15:00:00Z', item_revision: 2, operation: 'set',
+            profile_revision: 2, record_id: 'career_work_arrangement', revision_id: 'rev_2',
+            restored_from_profile_revision: null,
+            value: { mode: 'remote', strength: 'requirement', note: null }
+          }]
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      expect(init?.method).toBe('POST')
+      return new Response(JSON.stringify(current), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    })
+    globalThis.fetch = fetchMock as typeof fetch
+
+    await expect(client().getWorkArrangementHistory()).resolves.toMatchObject({ profileRevision: 2 })
+    await expect(client().restoreWorkArrangement({
+      expectedProfileRevision: 2,
+      idempotencyKey: 'desktop-undo-1',
+      targetProfileRevision: 1
+    })).resolves.toMatchObject({ status: 'saved' })
+  })
+
+  it('rejects contradictory flexible strength before sending it', async () => {
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as typeof fetch
+
+    await expect(client().saveWorkArrangement({
+      expectedProfileRevision: 2,
+      idempotencyKey: 'desktop-save-flexible',
+      value: { mode: 'flexible', strength: 'dealbreaker', note: null }
+    })).rejects.toThrow('Flexible work arrangement must use preference strength')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a restore target that the API cannot represent', async () => {
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as typeof fetch
+
+    await expect(client().restoreWorkArrangement({
+      expectedProfileRevision: 2,
+      idempotencyKey: 'desktop-undo-empty',
+      targetProfileRevision: 0
+    })).rejects.toThrow('Invalid Career Profile revision')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/careerProfile.ts
+++ b/apps/desktop/src/main/careerProfile.ts
@@ -1,0 +1,192 @@
+import type {
+  WorkArrangementCurrent as ApiWorkArrangementCurrent,
+  WorkArrangementHistory as ApiWorkArrangementHistory,
+  WorkArrangementRecord as ApiWorkArrangementRecord,
+  WorkArrangementRevision as ApiWorkArrangementRevision
+} from '@jobos/contracts'
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+import type {
+  WorkArrangementCurrent,
+  WorkArrangementHistory,
+  WorkArrangementMutationRequest,
+  WorkArrangementMutationResult,
+  WorkArrangementRecord,
+  WorkArrangementRestoreRequest,
+  WorkArrangementRevision,
+  WorkArrangementValue
+} from '../shared/contracts.js'
+import type { JobsConfig } from './jobs.js'
+
+const ROUTE = '/v1/career-profile/work-arrangement'
+const modes = new Set(['remote', 'hybrid', 'onsite', 'flexible'])
+const strengths = new Set(['requirement', 'strong_preference', 'preference', 'dealbreaker'])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function mapValue(value: ApiWorkArrangementRecord['value']): WorkArrangementValue {
+  return { mode: value.mode, strength: value.strength, note: value.note ?? null }
+}
+
+function mapRecord(record: ApiWorkArrangementRecord): WorkArrangementRecord {
+  return {
+    actorPrincipal: record.actor_principal,
+    itemRevision: record.item_revision,
+    profileRevision: record.profile_revision,
+    recordId: record.record_id,
+    updatedAt: record.updated_at,
+    value: mapValue(record.value)
+  }
+}
+
+function mapCurrent(current: ApiWorkArrangementCurrent): WorkArrangementCurrent {
+  return {
+    profileRevision: current.profile_revision,
+    record: current.record ? mapRecord(current.record) : null
+  }
+}
+
+function mapRevision(revision: ApiWorkArrangementRevision): WorkArrangementRevision {
+  return {
+    actorPrincipal: revision.actor_principal,
+    baseProfileRevision: revision.base_profile_revision,
+    changedFields: revision.changed_fields,
+    createdAt: revision.created_at,
+    itemRevision: revision.item_revision,
+    operation: revision.operation,
+    profileRevision: revision.profile_revision,
+    recordId: revision.record_id,
+    restoredFromProfileRevision: revision.restored_from_profile_revision ?? null,
+    revisionId: revision.revision_id,
+    value: mapValue(revision.value)
+  }
+}
+
+function mapHistory(history: ApiWorkArrangementHistory): WorkArrangementHistory {
+  return {
+    profileRevision: history.profile_revision,
+    revisions: history.revisions.map(mapRevision)
+  }
+}
+
+function validateIdempotencyKey(value: string): string {
+  if (!/^[A-Za-z0-9_-]{8,128}$/.test(value)) throw new Error('Invalid Career Profile request')
+  return value
+}
+
+function validateRevision(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error('Invalid Career Profile revision')
+  return value
+}
+
+function validateExistingRevision(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error('Invalid Career Profile revision')
+  return value
+}
+
+function validateValue(value: WorkArrangementValue): WorkArrangementValue {
+  if (!modes.has(value.mode) || !strengths.has(value.strength)) throw new Error('Invalid work arrangement')
+  if (value.mode === 'flexible' && value.strength !== 'preference') throw new Error('Flexible work arrangement must use preference strength')
+  const note = value.note?.trim() || null
+  if (note && note.length > 500) throw new Error('Work arrangement note is too long')
+  return { mode: value.mode, strength: value.strength, note }
+}
+
+async function request(config: JobsConfig, route: string, init?: RequestInit): Promise<Response> {
+  return fetch(new URL(route, config.baseUrl), {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${config.deviceToken}`,
+      ...(init?.body ? { 'Content-Type': 'application/json' } : {})
+    },
+    redirect: 'error'
+  })
+}
+
+async function errorMessage(response: Response): Promise<string> {
+  const body = await response.json().catch(() => ({})) as { detail?: string; message?: string }
+  return body.detail ?? body.message ?? `Career Profile request failed (${response.status})`
+}
+
+export function createMainCareerProfileClient(config: JobsConfig) {
+  const protectCurrent = (current: WorkArrangementCurrent): WorkArrangementCurrent => {
+    const unsigned = { profileRevision: current.profileRevision, record: current.record }
+    const cacheProof = createHmac('sha256', config.deviceToken)
+      .update(JSON.stringify({ baseUrl: config.baseUrl, ...unsigned }))
+      .digest('hex')
+    return { cacheProof, ...unsigned }
+  }
+
+  const validateCachedWorkArrangement = (candidate: unknown): WorkArrangementCurrent | null => {
+    if (!isRecord(candidate) || typeof candidate.cacheProof !== 'string' || !/^[a-f0-9]{64}$/.test(candidate.cacheProof)) return null
+    if (!Number.isSafeInteger(candidate.profileRevision) || (candidate.profileRevision as number) < 0) return null
+    if (candidate.record !== null) {
+      if (!isRecord(candidate.record) || !isRecord(candidate.record.value)) return null
+      const record = candidate.record
+      const value = record.value as Record<string, unknown>
+      if (!Number.isSafeInteger(record.itemRevision) || (record.itemRevision as number) < 1) return null
+      if (!Number.isSafeInteger(record.profileRevision) || (record.profileRevision as number) < 1) return null
+      if ((record.profileRevision as number) > (candidate.profileRevision as number)) return null
+      if (typeof record.actorPrincipal !== 'string' || typeof record.recordId !== 'string' || typeof record.updatedAt !== 'string') return null
+      if (typeof value.mode !== 'string' || !modes.has(value.mode) || typeof value.strength !== 'string' || !strengths.has(value.strength)) return null
+      if (value.note !== null && (typeof value.note !== 'string' || value.note.length > 500)) return null
+      if (value.mode === 'flexible' && value.strength !== 'preference') return null
+    }
+    const unsigned = {
+      profileRevision: candidate.profileRevision as number,
+      record: candidate.record as WorkArrangementRecord | null
+    }
+    const expected = protectCurrent(unsigned).cacheProof!
+    const actualBuffer = Buffer.from(candidate.cacheProof, 'hex')
+    const expectedBuffer = Buffer.from(expected, 'hex')
+    return timingSafeEqual(actualBuffer, expectedBuffer) ? { cacheProof: candidate.cacheProof, ...unsigned } : null
+  }
+
+  const getWorkArrangement = async (): Promise<WorkArrangementCurrent> => {
+    const response = await request(config, ROUTE)
+    if (!response.ok) throw new Error(await errorMessage(response))
+    return protectCurrent(mapCurrent(await response.json() as ApiWorkArrangementCurrent))
+  }
+
+  const mutationResult = async (response: Response): Promise<WorkArrangementMutationResult> => {
+    if (response.status === 409) {
+      return { status: 'conflict', current: await getWorkArrangement() }
+    }
+    if (!response.ok) throw new Error(await errorMessage(response))
+    return { status: 'saved', current: protectCurrent(mapCurrent(await response.json() as ApiWorkArrangementCurrent)) }
+  }
+
+  return {
+    async availability(): Promise<{ enabled: boolean }> {
+      const response = await request(config, ROUTE)
+      if (response.status === 404) return { enabled: false }
+      if (!response.ok) throw new Error(await errorMessage(response))
+      return { enabled: true }
+    },
+    validateCachedWorkArrangement,
+    getWorkArrangement,
+    async saveWorkArrangement(requestBody: WorkArrangementMutationRequest): Promise<WorkArrangementMutationResult> {
+      const body = {
+        expected_profile_revision: validateRevision(requestBody.expectedProfileRevision),
+        idempotency_key: validateIdempotencyKey(requestBody.idempotencyKey),
+        value: validateValue(requestBody.value)
+      }
+      return mutationResult(await request(config, ROUTE, { method: 'PUT', body: JSON.stringify(body) }))
+    },
+    async getWorkArrangementHistory(): Promise<WorkArrangementHistory> {
+      const response = await request(config, `${ROUTE}/history`)
+      if (!response.ok) throw new Error(await errorMessage(response))
+      return mapHistory(await response.json() as ApiWorkArrangementHistory)
+    },
+    async restoreWorkArrangement(requestBody: WorkArrangementRestoreRequest): Promise<WorkArrangementMutationResult> {
+      const body = {
+        expected_profile_revision: validateExistingRevision(requestBody.expectedProfileRevision),
+        idempotency_key: validateIdempotencyKey(requestBody.idempotencyKey),
+        target_profile_revision: validateExistingRevision(requestBody.targetProfileRevision)
+      }
+      return mutationResult(await request(config, `${ROUTE}/restore`, { method: 'POST', body: JSON.stringify(body) }))
+    }
+  }
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -13,6 +13,7 @@ import { registerAgentIpc } from './agentIpc.js'
 import { createApiLifecycle } from './apiLifecycle.js'
 import { BROWSER_PARTITION, BrowserManager, remoteBrowserViewOptions } from './browser.js'
 import { canonicalListingUrl, safeApplicationUrl, validatedBrowserJobExtraction } from './browserJobExtraction.js'
+import { createMainCareerProfileClient } from './careerProfile.js'
 import { registerBrowserRestoreHandler } from './browserIpc.js'
 import { startDesktopCapabilityClient } from './capabilityClient.js'
 import { initializeDesktopRuntime } from './desktopRuntime.js'
@@ -239,6 +240,31 @@ function registerConnectivityInterface(): void {
     }
     return snapshot
   })
+}
+
+function registerCareerProfileInterface(): void {
+  const config = jobsConfig()
+  const careerProfile = config ? createMainCareerProfileClient(config) : null
+  const trusted = (event: IpcMainInvokeEvent) => {
+    assertTrustedRenderer(event)
+    if (!careerProfile) throw new Error('Device credential unavailable')
+    return careerProfile
+  }
+
+  ipcMain.handle('jobos:career-profile:availability', event => trusted(event).availability())
+  ipcMain.handle('jobos:career-profile:cache:validate', (event, candidate) => (
+    trusted(event).validateCachedWorkArrangement(candidate)
+  ))
+  ipcMain.handle('jobos:career-profile:work-arrangement:get', event => trusted(event).getWorkArrangement())
+  ipcMain.handle('jobos:career-profile:work-arrangement:save', (event, request) => (
+    trusted(event).saveWorkArrangement(request)
+  ))
+  ipcMain.handle('jobos:career-profile:work-arrangement:history', event => (
+    trusted(event).getWorkArrangementHistory()
+  ))
+  ipcMain.handle('jobos:career-profile:work-arrangement:restore', (event, request) => (
+    trusted(event).restoreWorkArrangement(request)
+  ))
 }
 
 function registerAgentInterface(): void {
@@ -671,6 +697,7 @@ app.whenReady().then(async () => {
   registerDiagnosticsInterface(configPath)
   registerShellInterface()
   registerConnectivityInterface()
+  registerCareerProfileInterface()
   registerAgentInterface()
   registerJobsInterface()
   registerWorkspaceInterface()

--- a/apps/desktop/src/preload/preload.cts
+++ b/apps/desktop/src/preload/preload.cts
@@ -3,7 +3,20 @@ import type { IpcRendererEvent } from 'electron'
 
 import type { DocxExternalChangeEvent, SaveDocxRequest } from '../shared/docxDocuments.js'
 
-import type { AgentSessionStreamUpdate, BrowserBounds, BrowserJobExtraction, BrowserRestoreState, BrowserState, JobEvent, JobOsRendererBridge, JobSortMode, JobStatus, WorkspaceSnapshot } from '../shared/contracts.js'
+import type {
+  AgentSessionStreamUpdate,
+  BrowserBounds,
+  BrowserJobExtraction,
+  BrowserRestoreState,
+  BrowserState,
+  JobEvent,
+  JobOsRendererBridge,
+  JobSortMode,
+  JobStatus,
+  WorkArrangementMutationRequest,
+  WorkArrangementRestoreRequest,
+  WorkspaceSnapshot
+} from '../shared/contracts.js'
 import type {
   ApplyEditableDocumentOperationsRequest,
   CreateEditableDocumentSnapshotRequest,
@@ -41,6 +54,20 @@ const bridge: JobOsRendererBridge = Object.freeze({
   }),
   connectivity: Object.freeze({
     get: () => ipcRenderer.invoke('jobos:connectivity:get')
+  }),
+  careerProfile: Object.freeze({
+    availability: () => ipcRenderer.invoke('jobos:career-profile:availability'),
+    validateCachedWorkArrangement: (candidate: unknown) => (
+      ipcRenderer.invoke('jobos:career-profile:cache:validate', candidate)
+    ),
+    getWorkArrangement: () => ipcRenderer.invoke('jobos:career-profile:work-arrangement:get'),
+    saveWorkArrangement: (request: WorkArrangementMutationRequest) => (
+      ipcRenderer.invoke('jobos:career-profile:work-arrangement:save', request)
+    ),
+    getWorkArrangementHistory: () => ipcRenderer.invoke('jobos:career-profile:work-arrangement:history'),
+    restoreWorkArrangement: (request: WorkArrangementRestoreRequest) => (
+      ipcRenderer.invoke('jobos:career-profile:work-arrangement:restore', request)
+    )
   }),
   agent: Object.freeze({
     list: () => ipcRenderer.invoke('jobos:agent:list'),

--- a/apps/desktop/src/renderer/App.test.tsx
+++ b/apps/desktop/src/renderer/App.test.tsx
@@ -844,10 +844,12 @@ test('filtering the list never clears the active job context', async () => {
 
   render(<App />)
   fireEvent.click(await screen.findByRole('button', { name: 'Select Northstar Product Manager' }))
+  expect(await screen.findByText('Northstar · Product Manager')).not.toBeNull()
+
   fireEvent.change(screen.getByRole('textbox', { name: 'Filter jobs' }), { target: { value: 'Apollo' } })
 
   await waitFor(() => expect(screen.queryByRole('button', { name: 'Select Northstar Product Manager' })).toBeNull())
-  expect(await screen.findByText('Northstar · Product Manager')).not.toBeNull()
+  expect(screen.getByText('Northstar · Product Manager')).not.toBeNull()
 })
 
 test('changing selected jobs preserves one mounted durable agent conversation and draft', async () => {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -4,7 +4,9 @@ import { JobNavigator } from './components/JobNavigator'
 import { SettingsPanel } from './components/SettingsPanel'
 import { StatusBar } from './components/StatusBar'
 import { WorkbenchLayout } from './components/WorkbenchLayout'
-import { WorkspaceBar } from './components/WorkspaceBar'
+import { CareerProfileWorkspace } from './components/CareerProfileWorkspace'
+import { hasCachedCareerProfile } from './hooks/useCareerProfile'
+import { WorkspaceBar, type WorkspaceBarWorkspace } from './components/WorkspaceBar'
 import { BrowseWorkspace } from './components/BrowseWorkspace'
 import { useAgentAvatarPreference } from './agent-avatar/useAgentAvatarPreference'
 import { DocxDocumentEditorShell } from './document-editor/DocxDocumentEditorShell'
@@ -55,6 +57,8 @@ function WorkbenchApp() {
   const agentAvatar = useAgentAvatarPreference()
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsPreparing, setSettingsPreparing] = useState(false)
+  const [careerProfileEnabled, setCareerProfileEnabled] = useState(false)
+  const [careerProfileOpen, setCareerProfileOpen] = useState(false)
   const [browseDetachState, setBrowseDetachState] = useState<'idle' | 'preparing' | 'ready' | 'error'>('idle')
   const [jobListingRequest, setJobListingRequest] = useState<JobListingRequest | null>(null)
   const [documentMutationGeneration, setDocumentMutationGeneration] = useState(0)
@@ -72,7 +76,20 @@ function WorkbenchApp() {
   const activeLayout = layoutState.workspace.layouts[activePreset]
   const browseVisible = activeTopLevelWorkspace === 'browse' && browseDetachState === 'ready'
   const browserTransitionPending = browseDetachState === 'preparing'
-  const nativeBrowserVisible = layoutState.hydrated && activeTopLevelWorkspace !== 'browse' && !browserTransitionPending && !activeLayout.collapsed.includes('center') && !settingsOpen && !settingsPreparing
+  const nativeBrowserVisible = layoutState.hydrated && activeTopLevelWorkspace !== 'browse' && !careerProfileOpen && !browserTransitionPending && !activeLayout.collapsed.includes('center') && !settingsOpen && !settingsPreparing
+
+  useEffect(() => {
+    const bridge = window.jobos?.careerProfile
+    if (!bridge) return
+    let active = true
+    void bridge.availability()
+      .then(result => { if (active) setCareerProfileEnabled(result.enabled) })
+      .catch(async () => {
+        const cached = await hasCachedCareerProfile(bridge)
+        if (active) setCareerProfileEnabled(cached)
+      })
+    return () => { active = false }
+  }, [])
 
   const changePanelReorderInteraction = useCallback(async (active: boolean) => {
     if (!active) {
@@ -217,7 +234,20 @@ function WorkbenchApp() {
     void detachBrowserForBrowse(generation)
   }, [activeTopLevelWorkspace, browseDetachState, detachBrowserForBrowse, layoutState.hydrated])
 
-  const changeTopLevelWorkspace = async (workspaceId: import('./workspaceLayout').TopLevelWorkspace) => {
+  const changeTopLevelWorkspace = async (workspaceId: WorkspaceBarWorkspace) => {
+    if (workspaceId === 'career-profile') {
+      if (!careerProfileEnabled || careerProfileOpen) return
+      browseTransitionGeneration.current += 1
+      setBrowseDetachState('idle')
+      try {
+        await window.jobos?.browser?.setBounds({ x: 0, y: 0, width: 0, height: 0, visible: false })
+      } catch {
+        return
+      }
+      setCareerProfileOpen(true)
+      return
+    }
+    setCareerProfileOpen(false)
     if (workspaceId !== 'browse') {
       browseTransitionGeneration.current += 1
       setBrowseDetachState(current => current === 'preparing' ? current : 'idle')
@@ -234,14 +264,15 @@ function WorkbenchApp() {
   return (
     <div className="app-shell" data-layout={activePreset} data-workspace={activeTopLevelWorkspace}>
       <WorkspaceBar
-        activeWorkspace={activeTopLevelWorkspace}
+        activeWorkspace={careerProfileOpen ? 'career-profile' : activeTopLevelWorkspace}
+        careerProfileEnabled={careerProfileEnabled}
         onWorkspaceChange={workspaceId => { void changeTopLevelWorkspace(workspaceId) }}
         onReset={layoutState.reset}
         onToggleMode={theme.toggleMode}
         themeMode={theme.mode}
       />
       <div className="workspace-content">
-      <div className="workbench-layer" hidden={browseVisible}>
+      <div className="workbench-layer" hidden={browseVisible || careerProfileOpen}>
       {editingDocument ? (
         <DocxDocumentEditorShell
           opened={editingDocument}
@@ -322,6 +353,12 @@ function WorkbenchApp() {
       />
       )}
       </div>
+      {careerProfileOpen ? (
+        <CareerProfileWorkspace
+          hasActiveTurn={Boolean(agentSessions.activeSession?.summary.activeTurn)}
+          online={connectivity.state === 'connected'}
+        />
+      ) : null}
       {browseVisible ? (
         <BrowseWorkspace
           activeJobId={jobState.selectedJobId}

--- a/apps/desktop/src/renderer/components/CareerProfileWorkspace.test.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileWorkspace.test.tsx
@@ -1,0 +1,314 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+import type { CareerProfileBridge } from '../../shared/contracts'
+import { CareerProfileWorkspace } from './CareerProfileWorkspace'
+
+const localCache = new Map<string, string>()
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  value: {
+    clear: () => localCache.clear(),
+    getItem: (key: string) => localCache.get(key) ?? null,
+    removeItem: (key: string) => localCache.delete(key),
+    setItem: (key: string, value: string) => { localCache.set(key, value) }
+  }
+})
+
+const current = {
+  profileRevision: 2,
+  record: {
+    actorPrincipal: 'primary-device', itemRevision: 2, profileRevision: 2,
+    recordId: 'career_work_arrangement', updatedAt: '2026-08-21T15:00:00Z',
+    value: { mode: 'remote' as const, strength: 'requirement' as const, note: '(FAKE) Remote in the US' }
+  }
+}
+
+function bridge(overrides: Partial<CareerProfileBridge> = {}): CareerProfileBridge {
+  return {
+    availability: vi.fn().mockResolvedValue({ enabled: true }),
+    validateCachedWorkArrangement: vi.fn().mockImplementation(async candidate => candidate),
+    getWorkArrangement: vi.fn().mockResolvedValue(current),
+    saveWorkArrangement: vi.fn().mockResolvedValue({ status: 'saved', current: { ...current, profileRevision: 3 } }),
+    getWorkArrangementHistory: vi.fn().mockResolvedValue({
+      profileRevision: 2,
+      revisions: [{
+        actorPrincipal: 'primary-device', baseProfileRevision: 1, changedFields: ['mode'],
+        createdAt: '2026-08-21T15:00:00Z', itemRevision: 2, operation: 'set',
+        profileRevision: 2, recordId: 'career_work_arrangement', revisionId: 'rev_2',
+        restoredFromProfileRevision: null, value: current.record.value
+      }, {
+        actorPrincipal: 'primary-device', baseProfileRevision: 0, changedFields: ['mode', 'strength', 'note'],
+        createdAt: '2026-08-20T15:00:00Z', itemRevision: 1, operation: 'set',
+        profileRevision: 1, recordId: 'career_work_arrangement', revisionId: 'rev_1',
+        restoredFromProfileRevision: null,
+        value: { mode: 'hybrid', strength: 'strong_preference', note: '(FAKE) One office day is okay' }
+      }]
+    }),
+    restoreWorkArrangement: vi.fn().mockResolvedValue({ status: 'saved', current }),
+    ...overrides
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+test('explains the saved preference in normal language without exposing plumbing', async () => {
+  render(<CareerProfileWorkspace bridge={bridge()} hasActiveTurn={false} />)
+
+  expect(await screen.findByRole('heading', { name: 'Work arrangement' })).not.toBeNull()
+  expect(screen.getByText(/Only show roles that support remote work/i)).not.toBeNull()
+  expect(screen.getByText(/A fully onsite role would be filtered out/i)).not.toBeNull()
+  expect(screen.queryByText(/search_preferences|namespace|JSON|weight/i)).toBeNull()
+})
+
+test('validates locally, saves accessible fields, and announces next-turn timing', async () => {
+  const api = bridge()
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn />)
+  await screen.findByDisplayValue('(FAKE) Remote in the US')
+
+  fireEvent.change(screen.getByLabelText('Work arrangement'), { target: { value: 'hybrid' } })
+  fireEvent.change(screen.getByLabelText('How important is this?'), { target: { value: 'strong_preference' } })
+  fireEvent.change(screen.getByLabelText('Additional context'), { target: { value: 'x'.repeat(501) } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save preference' }))
+  expect(screen.getByRole('alert').textContent).toContain('Keep the note to 500 characters or fewer.')
+
+  fireEvent.change(screen.getByLabelText('Additional context'), { target: { value: '(FAKE) Two office days are okay' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save preference' }))
+  await waitFor(() => expect(api.saveWorkArrangement).toHaveBeenCalledWith(expect.objectContaining({
+    expectedProfileRevision: 2,
+    value: { mode: 'hybrid', strength: 'strong_preference', note: '(FAKE) Two office days are okay' }
+  })))
+  expect(await screen.findByText('Saved — applies to the next turn.')).not.toBeNull()
+})
+
+test('preserves the proposed edit and shows the latest value after a stale conflict', async () => {
+  const latest = {
+    ...current,
+    profileRevision: 3,
+    record: { ...current.record, profileRevision: 3, value: { mode: 'onsite' as const, strength: 'preference' as const, note: null } }
+  }
+  const api = bridge({ saveWorkArrangement: vi.fn().mockResolvedValue({ status: 'conflict', current: latest }) })
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn={false} />)
+  await screen.findByDisplayValue('(FAKE) Remote in the US')
+
+  fireEvent.change(screen.getByLabelText('Work arrangement'), { target: { value: 'hybrid' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save preference' }))
+
+  expect((await screen.findByRole('alert')).textContent).toContain('This preference changed somewhere else')
+  const conflictCard = screen.getByRole('heading', { name: 'Review before saving' }).closest('section')
+  expect(conflictCard?.textContent).toContain('Current saved valueOnsite')
+  expect(conflictCard?.textContent).toContain('Your proposed valueHybrid')
+  fireEvent.click(screen.getByRole('button', { name: 'Reapply my change' }))
+  await waitFor(() => expect(api.saveWorkArrangement).toHaveBeenLastCalledWith(expect.objectContaining({ expectedProfileRevision: 3 })))
+})
+
+test('accepts the latest saved value when resolving a stale conflict', async () => {
+  const latest = {
+    ...current,
+    profileRevision: 3,
+    record: { ...current.record, profileRevision: 3, value: { mode: 'onsite' as const, strength: 'dealbreaker' as const, note: '(FAKE) Local only' } }
+  }
+  const api = bridge({ saveWorkArrangement: vi.fn().mockResolvedValue({ status: 'conflict', current: latest }) })
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn={false} />)
+  await screen.findByDisplayValue('(FAKE) Remote in the US')
+
+  fireEvent.change(screen.getByLabelText('Work arrangement'), { target: { value: 'hybrid' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save preference' }))
+  fireEvent.click(await screen.findByRole('button', { name: 'Keep current' }))
+
+  expect((screen.getByLabelText('Work arrangement') as HTMLSelectElement).value).toBe('onsite')
+  expect((screen.getByLabelText('How important is this?') as HTMLSelectElement).value).toBe('dealbreaker')
+  expect(screen.getByDisplayValue('(FAKE) Local only')).not.toBeNull()
+  expect(screen.queryByRole('heading', { name: 'Review before saving' })).toBeNull()
+  expect(screen.getByText('Kept the latest saved preference.')).not.toBeNull()
+})
+
+test('reloads history after accepting the latest value from a stale conflict', async () => {
+  const latest = {
+    ...current,
+    profileRevision: 3,
+    record: { ...current.record, profileRevision: 3, value: { mode: 'onsite' as const, strength: 'preference' as const, note: null } }
+  }
+  const getWorkArrangementHistory = vi.fn()
+    .mockResolvedValueOnce({ profileRevision: 2, revisions: [] })
+    .mockResolvedValueOnce({ profileRevision: 3, revisions: [] })
+  const api = bridge({
+    getWorkArrangementHistory,
+    saveWorkArrangement: vi.fn().mockResolvedValue({ status: 'conflict', current: latest })
+  })
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn={false} />)
+  await screen.findByDisplayValue('(FAKE) Remote in the US')
+
+  fireEvent.click(screen.getByRole('button', { name: 'View history' }))
+  await waitFor(() => expect(getWorkArrangementHistory).toHaveBeenCalledTimes(1))
+  fireEvent.click(screen.getByRole('button', { name: 'Close history' }))
+
+  fireEvent.change(screen.getByLabelText('Work arrangement'), { target: { value: 'hybrid' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save preference' }))
+  fireEvent.click(await screen.findByRole('button', { name: 'Keep current' }))
+
+  fireEvent.click(screen.getByRole('button', { name: 'View history' }))
+  await waitFor(() => expect(getWorkArrangementHistory).toHaveBeenCalledTimes(2))
+})
+
+test('shows history, performs Undo as a new revision, and closes the drawer', async () => {
+  const api = bridge()
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn={false} />)
+  await screen.findByRole('heading', { name: 'Work arrangement' })
+
+  const historyButton = screen.getByRole('button', { name: 'View history' })
+  fireEvent.click(historyButton)
+  const dialog = await screen.findByRole('dialog', { name: 'Work arrangement history' })
+  const closeButton = screen.getByRole('button', { name: 'Close history' })
+  const undoButton = screen.getByRole('button', { name: 'Undo to before revision 2' })
+  expect(document.activeElement).toBe(closeButton)
+  const workspaceRoot = document.querySelector('.career-profile-workspace')?.parentElement
+  expect(workspaceRoot).not.toBeNull()
+  expect((workspaceRoot as HTMLElement).inert).toBe(true)
+  fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true })
+  expect(document.activeElement).toBe(undoButton)
+  fireEvent.keyDown(dialog, { key: 'Tab' })
+  expect(document.activeElement).toBe(closeButton)
+  expect(within(dialog).getByText('Revision 2')).not.toBeNull()
+  fireEvent.click(undoButton)
+
+  await waitFor(() => expect(api.restoreWorkArrangement).toHaveBeenCalledWith(expect.objectContaining({
+    expectedProfileRevision: 2,
+    targetProfileRevision: 1
+  })))
+  await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Work arrangement history' })).toBeNull())
+  await waitFor(() => expect(document.activeElement).toBe(historyButton))
+
+  fireEvent.click(historyButton)
+  fireEvent.keyDown(await screen.findByRole('dialog', { name: 'Work arrangement history' }), { key: 'Escape' })
+  await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Work arrangement history' })).toBeNull())
+  expect(dialog.getAttribute('aria-modal')).toBe('true')
+})
+
+test('reuses mutation identities after ambiguous save and Undo failures', async () => {
+  const saveWorkArrangement = vi.fn()
+    .mockRejectedValueOnce(new Error('response lost'))
+    .mockResolvedValueOnce({ status: 'saved', current: { ...current, profileRevision: 3 } })
+  const restoreWorkArrangement = vi.fn()
+    .mockRejectedValueOnce(new Error('response lost'))
+    .mockResolvedValueOnce({ status: 'saved', current: { ...current, profileRevision: 3 } })
+  const api = bridge({ restoreWorkArrangement, saveWorkArrangement })
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn={false} />)
+  await screen.findByDisplayValue('(FAKE) Remote in the US')
+
+  fireEvent.click(screen.getByRole('button', { name: 'Save preference' }))
+  await screen.findByText(/could not save this preference/i)
+  fireEvent.click(screen.getByRole('button', { name: 'Save preference' }))
+  await waitFor(() => expect(saveWorkArrangement).toHaveBeenCalledTimes(2))
+  expect(saveWorkArrangement.mock.calls[1]?.[0].idempotencyKey).toBe(saveWorkArrangement.mock.calls[0]?.[0].idempotencyKey)
+
+  fireEvent.click(screen.getByRole('button', { name: 'View history' }))
+  const historyDialog = await screen.findByRole('dialog', { name: 'Work arrangement history' })
+  expect(within(historyDialog).getByText('Revision 2')).not.toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Undo to before revision 2' }))
+  const restoreErrorDialog = await screen.findByRole('dialog', { name: 'Work arrangement history' })
+  expect(within(restoreErrorDialog).getByRole('alert').textContent).toContain('could not restore that version')
+  fireEvent.click(within(restoreErrorDialog).getByRole('button', { name: 'Try again' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Undo to before revision 2' }))
+  await waitFor(() => expect(restoreWorkArrangement).toHaveBeenCalledTimes(2))
+  expect(restoreWorkArrangement.mock.calls[1]?.[0].idempotencyKey).toBe(restoreWorkArrangement.mock.calls[0]?.[0].idempotencyKey)
+})
+
+test('keeps offline data readable while blocking save and Undo', async () => {
+  const api = bridge()
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn={false} online={false} />)
+  expect(await screen.findByDisplayValue('(FAKE) Remote in the US')).not.toBeNull()
+  expect(screen.getByText(/Offline — your saved preference is still readable/i)).not.toBeNull()
+  expect(screen.getByRole('button', { name: 'Save preference' }).hasAttribute('disabled')).toBe(true)
+
+  fireEvent.click(screen.getByRole('button', { name: 'View history' }))
+  expect((await screen.findByRole('button', { name: 'Undo to before revision 2' })).hasAttribute('disabled')).toBe(true)
+  expect(api.saveWorkArrangement).not.toHaveBeenCalled()
+  expect(api.restoreWorkArrangement).not.toHaveBeenCalled()
+})
+
+test('reopens the last known profile for read-only use after a cold offline failure', async () => {
+  const first = render(<CareerProfileWorkspace bridge={bridge()} hasActiveTurn={false} />)
+  await screen.findByDisplayValue('(FAKE) Remote in the US')
+  first.unmount()
+
+  const offlineBridge = bridge({ getWorkArrangement: vi.fn().mockRejectedValue(new Error('offline')) })
+  render(<CareerProfileWorkspace bridge={offlineBridge} hasActiveTurn={false} online={false} />)
+  expect(await screen.findByDisplayValue('(FAKE) Remote in the US')).not.toBeNull()
+  expect(screen.getByText(/showing your last saved Career Profile/i)).not.toBeNull()
+  expect(screen.getByRole('button', { name: 'Save preference' }).hasAttribute('disabled')).toBe(true)
+})
+
+test('keeps flexible internally consistent and freezes fields during save', async () => {
+  let finishSave: ((value: unknown) => void) | undefined
+  const saveWorkArrangement = vi.fn().mockReturnValue(new Promise(resolve => { finishSave = resolve }))
+  const api = bridge({ saveWorkArrangement })
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn={false} />)
+  await screen.findByDisplayValue('(FAKE) Remote in the US')
+
+  fireEvent.change(screen.getByLabelText('Work arrangement'), { target: { value: 'flexible' } })
+  expect((screen.getByLabelText('How important is this?') as HTMLSelectElement).value).toBe('preference')
+  expect(screen.getByLabelText('How important is this?').hasAttribute('disabled')).toBe(true)
+  fireEvent.click(screen.getByRole('button', { name: 'Save preference' }))
+  await waitFor(() => expect(saveWorkArrangement).toHaveBeenCalledTimes(1))
+  expect(screen.getByLabelText('Work arrangement').hasAttribute('disabled')).toBe(true)
+  expect(screen.getByLabelText('Additional context').hasAttribute('disabled')).toBe(true)
+
+  finishSave?.({ status: 'saved', current: { ...current, profileRevision: 3 } })
+  await screen.findByText('Saved.')
+})
+
+test('reapplies a stale Undo as the selected restore, not as a normal save', async () => {
+  const latest = {
+    ...current,
+    profileRevision: 3,
+    record: { ...current.record, profileRevision: 3, value: { mode: 'onsite' as const, strength: 'dealbreaker' as const, note: '(FAKE) Local only' } }
+  }
+  const restoreWorkArrangement = vi.fn()
+    .mockResolvedValueOnce({ status: 'conflict', current: latest })
+    .mockResolvedValueOnce({ status: 'saved', current: { ...current, profileRevision: 4 } })
+  const api = bridge({ restoreWorkArrangement })
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn={false} />)
+  await screen.findByRole('heading', { name: 'Work arrangement' })
+
+  fireEvent.click(screen.getByRole('button', { name: 'View history' }))
+  fireEvent.click(await screen.findByRole('button', { name: 'Undo to before revision 2' }))
+  const conflict = await screen.findByRole('heading', { name: 'Review before saving' })
+  expect(conflict.closest('section')?.textContent).toContain('Onsite · Dealbreaker — (FAKE) Local only')
+  expect(conflict.closest('section')?.textContent).toContain('Hybrid · Strong preference — (FAKE) One office day is okay')
+
+  fireEvent.click(screen.getByRole('button', { name: 'Reapply my change' }))
+  await waitFor(() => expect(restoreWorkArrangement).toHaveBeenLastCalledWith(expect.objectContaining({
+    expectedProfileRevision: 3,
+    targetProfileRevision: 1
+  })))
+  expect(api.saveWorkArrangement).not.toHaveBeenCalled()
+})
+
+test('shows history load errors inside the drawer and retries in place', async () => {
+  const getWorkArrangementHistory = vi.fn()
+    .mockRejectedValueOnce(new Error('offline'))
+    .mockResolvedValueOnce(await bridge().getWorkArrangementHistory())
+  render(<CareerProfileWorkspace bridge={bridge({ getWorkArrangementHistory })} hasActiveTurn={false} />)
+  await screen.findByRole('heading', { name: 'Work arrangement' })
+
+  fireEvent.click(screen.getByRole('button', { name: 'View history' }))
+  expect(await screen.findByText('History could not load. Try again.')).not.toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+  await waitFor(() => expect(within(screen.getByRole('dialog', { name: 'Work arrangement history' })).getByText('Revision 2')).not.toBeNull())
+})
+
+test('keeps empty and failure states actionable', async () => {
+  const retry = vi.fn()
+    .mockRejectedValueOnce(new Error('offline'))
+    .mockResolvedValueOnce({ profileRevision: 0, record: null })
+  render(<CareerProfileWorkspace bridge={bridge({ getWorkArrangement: retry })} hasActiveTurn={false} />)
+
+  expect((await screen.findByRole('alert')).textContent).toContain('Career Profile is unavailable right now')
+  fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+  expect(await screen.findByText('Tell JobOS where you want to work')).not.toBeNull()
+})

--- a/apps/desktop/src/renderer/components/CareerProfileWorkspace.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileWorkspace.tsx
@@ -1,0 +1,263 @@
+import { BriefcaseBusiness, Check, Clock3, MapPin, RotateCcw, Save, Sparkles } from 'lucide-react'
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react'
+import { createPortal } from 'react-dom'
+
+import type { CareerProfileBridge, WorkArrangementMode, WorkArrangementStrength, WorkArrangementValue } from '../../shared/contracts'
+import { useCareerProfile } from '../hooks/useCareerProfile'
+
+interface CareerProfileWorkspaceProps {
+  bridge?: CareerProfileBridge
+  hasActiveTurn: boolean
+  online?: boolean
+}
+
+const modeLabels: Record<WorkArrangementMode, string> = {
+  remote: 'Remote',
+  hybrid: 'Hybrid',
+  onsite: 'Onsite',
+  flexible: 'Flexible'
+}
+
+const strengthLabels: Record<WorkArrangementStrength, string> = {
+  requirement: 'Requirement',
+  strong_preference: 'Strong preference',
+  preference: 'Preference',
+  dealbreaker: 'Dealbreaker'
+}
+
+function interpretation(value: WorkArrangementValue): string {
+  const mode = modeLabels[value.mode].toLowerCase()
+  if (value.mode === 'flexible') return 'Keep remote, hybrid, and onsite roles open unless another preference rules them out.'
+  if (value.strength === 'preference') return `Prefer ${mode} roles, but keep strong alternatives in consideration.`
+  if (value.strength === 'strong_preference') return `Prioritize ${mode} roles and only elevate alternatives when they are an unusually strong fit.`
+  return `Only show roles that support ${mode} work.`
+}
+
+function example(value: WorkArrangementValue): string {
+  if (value.mode === 'flexible') return 'Example: A strong remote role and a strong onsite role can both pass this preference.'
+  const label = modeLabels[value.mode]
+  if (value.strength === 'preference') return `Example: A ${label.toLowerCase()} role ranks higher, while an excellent alternative can still pass.`
+  if (value.strength === 'strong_preference') return `Example: ${label} roles lead the list; alternatives need a significantly stronger overall match.`
+  const rejected = value.mode === 'onsite' ? 'fully remote' : 'fully onsite'
+  return `Example: A ${rejected} role would be filtered out before it reaches your shortlist.`
+}
+
+function preferenceSummary(value: WorkArrangementValue): string {
+  const note = value.note ? ` — ${value.note}` : ' — No additional context'
+  return `${modeLabels[value.mode]} · ${strengthLabels[value.strength]}${note}`
+}
+
+export function CareerProfileWorkspace({ bridge = window.jobos.careerProfile, hasActiveTurn, online = true }: CareerProfileWorkspaceProps) {
+  const profile = useCareerProfile(bridge)
+  const [validation, setValidation] = useState('')
+  const historyDrawer = useRef<HTMLElement>(null)
+  const historyTrigger = useRef<HTMLButtonElement>(null)
+  const historyWasOpen = useRef(false)
+
+  useEffect(() => {
+    if (profile.historyOpen) {
+      historyWasOpen.current = true
+      const drawer = historyDrawer.current
+      const modalLayer = drawer?.closest('.career-history-modal-layer')
+      const background = Array.from(document.body.children)
+        .filter(element => element !== modalLayer) as HTMLElement[]
+      background.forEach(element => { element.inert = true })
+      drawer?.querySelector<HTMLButtonElement>('button')?.focus()
+      return () => { background.forEach(element => { element.inert = false }) }
+    }
+    if (historyWasOpen.current) {
+      historyWasOpen.current = false
+      window.requestAnimationFrame(() => historyTrigger.current?.focus())
+    }
+  }, [profile.historyOpen])
+
+  const update = <Key extends keyof WorkArrangementValue>(key: Key, value: WorkArrangementValue[Key]) => {
+    setValidation('')
+    profile.setDraft(current => ({
+      ...current,
+      [key]: value,
+      ...(key === 'mode' && value === 'flexible' ? { strength: 'preference' as const } : {})
+    }))
+  }
+
+  const submit = () => {
+    if (!online) {
+      setValidation('Reconnect to JobOS before saving. Your edit will stay here.')
+      return
+    }
+    if (profile.draft.mode === 'flexible' && profile.draft.strength !== 'preference') {
+      setValidation('Flexible work keeps every arrangement open, so its strength must stay as Preference.')
+      return
+    }
+    if ((profile.draft.note?.length ?? 0) > 500) {
+      setValidation('Keep the note to 500 characters or fewer.')
+      return
+    }
+    setValidation('')
+    void profile.save(hasActiveTurn ? 'Saved — applies to the next turn.' : 'Saved.')
+  }
+
+  const closeHistory = () => {
+    profile.setHistoryOpen(false)
+  }
+
+  const handleHistoryKeys = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeHistory()
+      return
+    }
+    if (event.key !== 'Tab') return
+    const focusable = Array.from(historyDrawer.current?.querySelectorAll<HTMLElement>('button:not(:disabled), [href], [tabindex]:not([tabindex="-1"])') ?? [])
+    if (focusable.length === 0) return
+    const first = focusable[0]!
+    const last = focusable[focusable.length - 1]!
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  if (profile.status === 'loading') {
+    return (
+      <main aria-busy="true" aria-label="Career Profile" className="career-profile-workspace">
+        <aside className="career-profile-rail"><div className="career-skeleton rail" /></aside>
+        <section className="career-profile-main"><div className="career-skeleton title" /><div className="career-skeleton card" role="status">Loading Career Profile…</div></section>
+      </main>
+    )
+  }
+
+  if (!profile.current && profile.status === 'error') {
+    return (
+      <main className="career-profile-workspace career-profile-centered">
+        <section className="career-state-card" role="alert">
+          <Sparkles aria-hidden="true" size={22} />
+          <h1>Career Profile is unavailable right now</h1>
+          <p>Your existing JobOS work is safe. Reconnect to the staging service and try again.</p>
+          <button className="career-secondary-button" onClick={() => { void profile.load() }} type="button">Try again</button>
+        </section>
+      </main>
+    )
+  }
+
+  const currentValue = profile.current?.record?.value
+  const empty = !currentValue
+
+  return (
+    <main className="career-profile-workspace">
+      <aside aria-label="Career Profile sections" className="career-profile-rail">
+        <div className="career-profile-heading">
+          <span className="career-eyebrow">Your shared context</span>
+          <h1>Career Profile</h1>
+          <p>The information JobOS uses to understand your career and preferences.</p>
+        </div>
+        <nav className="career-profile-nav">
+          <button className="career-nav-item" disabled type="button"><BriefcaseBusiness aria-hidden="true" size={17} /><span><strong>My Career</strong><small>Coming later</small></span></button>
+          <button aria-current="page" className="career-nav-item active" type="button"><MapPin aria-hidden="true" size={17} /><span><strong>What I’m Looking For</strong><small>1 preference</small></span></button>
+          <button className="career-nav-item" disabled type="button"><Sparkles aria-hidden="true" size={17} /><span><strong>My Evidence</strong><small>Coming later</small></span></button>
+        </nav>
+        <div className="career-staging-note"><span>(FAKE) staging profile</span><p>This preview does not replace your live career context.</p></div>
+      </aside>
+
+      <section className="career-profile-main">
+        <span className="career-mobile-staging">(FAKE) staging profile</span>
+        <header className="career-detail-header">
+          <div>
+            <span className="career-breadcrumb">What I’m Looking For</span>
+            <h2>Work arrangement</h2>
+            <p>Tell JobOS where you want to work and how firmly it should apply that choice.</p>
+          </div>
+          {profile.current?.record ? <span className="career-revision-badge">Revision {profile.current.profileRevision}</span> : null}
+        </header>
+
+        {empty ? (
+          <section className="career-empty-card">
+            <MapPin aria-hidden="true" size={24} />
+            <h3>Tell JobOS where you want to work</h3>
+            <p>Start with a flexible preference, then make it stronger if location should filter opportunities.</p>
+          </section>
+        ) : null}
+
+        <div className="career-detail-grid">
+          <form className="career-form-card" onSubmit={event => { event.preventDefault(); submit() }}>
+            <div className="career-card-heading"><div><span className="career-kicker">Preference</span><h3>Your work arrangement</h3></div>{currentValue ? <span className="career-status"><Check aria-hidden="true" size={13} /> User stated</span> : null}</div>
+
+            <label className="career-field">
+              <span>Work arrangement</span>
+              <select aria-label="Work arrangement" disabled={profile.status === 'saving'} onChange={event => update('mode', event.target.value as WorkArrangementMode)} value={profile.draft.mode}>
+                {Object.entries(modeLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </label>
+
+            <fieldset className="career-strength-field">
+              <legend>How important is this?</legend>
+              <select aria-label="How important is this?" disabled={profile.status === 'saving' || profile.draft.mode === 'flexible'} onChange={event => update('strength', event.target.value as WorkArrangementStrength)} value={profile.draft.strength}>
+                {Object.entries(strengthLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+              <p>{profile.draft.mode === 'flexible' ? 'Flexible keeps every arrangement open, so no additional strength is applied.' : 'Requirements and dealbreakers filter roles. Preferences change how opportunities are ranked.'}</p>
+            </fieldset>
+
+            <label className="career-field">
+              <span>Additional context <small>Optional</small></span>
+              <textarea aria-describedby="career-note-count" aria-label="Additional context" disabled={profile.status === 'saving'} maxLength={550} onChange={event => update('note', event.target.value)} placeholder="(FAKE) Two office days per week are okay…" rows={4} value={profile.draft.note ?? ''} />
+              <small id="career-note-count">{profile.draft.note?.length ?? 0}/500</small>
+            </label>
+
+            {validation ? <p className="career-inline-alert" role="alert">{validation}</p> : null}
+            {!online ? <p className="career-feedback error" role="status">Offline — your saved preference is still readable. Reconnect before saving or using Undo.</p> : null}
+            {profile.message ? <p className={`career-feedback ${profile.status}`} role={profile.status === 'error' || profile.status === 'conflict' ? 'alert' : 'status'}>{profile.message}</p> : null}
+
+            {profile.conflict ? (
+              <section className="career-conflict-card">
+                <h4>Review before saving</h4>
+                <dl>
+                  <div><dt>Current saved value</dt><dd>{preferenceSummary(profile.conflict.current.record?.value ?? { mode: 'flexible', strength: 'preference', note: null })}</dd></div>
+                  <div><dt>Your proposed value</dt><dd>{preferenceSummary(profile.conflict.proposed)}</dd></div>
+                </dl>
+                <div className="career-conflict-actions">
+                  <button className="career-secondary-button" onClick={profile.keepCurrent} type="button">Keep current</button>
+                  <button className="career-secondary-button" disabled={!online || profile.status === 'saving'} onClick={() => { void profile.reapplyConflict(hasActiveTurn ? 'Saved — applies to the next turn.' : 'Saved.') }} type="button">Reapply my change</button>
+                </div>
+              </section>
+            ) : null}
+
+            <div className="career-form-actions">
+              <button className="career-primary-button" disabled={!online || profile.status === 'saving'} type="submit"><Save aria-hidden="true" size={15} />{profile.status === 'saving' ? 'Saving…' : 'Save preference'}</button>
+              <button className="career-text-button" disabled={profile.status === 'saving'} onClick={() => { void profile.openHistory() }} ref={historyTrigger} type="button"><Clock3 aria-hidden="true" size={15} />View history</button>
+            </div>
+          </form>
+
+          <aside className="career-interpretation-card">
+            <span className="career-kicker">How JobOS uses this</span>
+            <h3>{interpretation(profile.draft)}</h3>
+            <p>{example(profile.draft)}</p>
+            <div className="career-impact-list"><span>Used in</span><ul><li>Job research</li><li>Browse ranking</li><li>Agent recommendations</li></ul></div>
+          </aside>
+        </div>
+
+        {profile.historyOpen ? createPortal(
+          <div className="career-history-modal-layer">
+            <div aria-hidden="true" className="career-history-backdrop" onClick={closeHistory} />
+            <aside aria-label="Work arrangement history" aria-modal="true" className="career-history-drawer" onKeyDown={handleHistoryKeys} ref={historyDrawer} role="dialog">
+            <div className="career-history-heading"><div><span className="career-kicker">Change log</span><h3>Work arrangement history</h3></div><button aria-label="Close history" className="career-text-button" onClick={closeHistory} type="button">Close</button></div>
+            {profile.historyError ? <div className="career-history-error" role="alert"><p>{profile.historyError}</p><button className="career-secondary-button" onClick={() => { void profile.openHistory() }} type="button">Try again</button></div> : !profile.history ? <p role="status">Loading history…</p> : (
+              <ol className="career-history-list">
+                {profile.history.revisions.map(revision => (
+                  <li key={revision.revisionId}>
+                    <div><strong>Revision {revision.profileRevision}</strong><span>{modeLabels[revision.value.mode]} · {strengthLabels[revision.value.strength]}</span><small>{revision.operation === 'restore' ? 'Restored by you' : 'Changed by you'} · {new Date(revision.createdAt).toLocaleString()}</small></div>
+                    {revision.baseProfileRevision >= 1 ? <button aria-label={`Undo to before revision ${revision.profileRevision}`} className="career-icon-action" disabled={!online || profile.status === 'saving'} onClick={() => { void profile.restore(revision.baseProfileRevision) }} title={online ? 'Undo to this previous value' : 'Reconnect before using Undo'} type="button"><RotateCcw aria-hidden="true" size={15} /></button> : null}
+                  </li>
+                ))}
+              </ol>
+            )}
+            </aside>
+          </div>,
+          document.body
+        ) : null}
+      </section>
+    </main>
+  )
+}

--- a/apps/desktop/src/renderer/components/WorkspaceBar.test.tsx
+++ b/apps/desktop/src/renderer/components/WorkspaceBar.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+import { WorkspaceBar } from './WorkspaceBar'
+
+afterEach(cleanup)
+
+function renderBar(careerProfileEnabled: boolean) {
+  const onWorkspaceChange = vi.fn()
+  render(
+    <WorkspaceBar
+      activeWorkspace="research"
+      careerProfileEnabled={careerProfileEnabled}
+      onReset={vi.fn()}
+      onToggleMode={vi.fn()}
+      onWorkspaceChange={onWorkspaceChange}
+      themeMode="dark"
+    />
+  )
+  return onWorkspaceChange
+}
+
+test('keeps Career Profile out of live navigation while the API slice is dormant', () => {
+  renderBar(false)
+  expect(screen.queryByRole('button', { name: 'Career Profile' })).toBeNull()
+})
+
+test('reveals and opens Career Profile only when staging availability is enabled', () => {
+  const onWorkspaceChange = renderBar(true)
+  fireEvent.click(screen.getByRole('button', { name: 'Career Profile' }))
+  expect(onWorkspaceChange).toHaveBeenCalledWith('career-profile')
+})

--- a/apps/desktop/src/renderer/components/WorkspaceBar.tsx
+++ b/apps/desktop/src/renderer/components/WorkspaceBar.tsx
@@ -2,22 +2,25 @@ import { Moon, RotateCcw, Sun } from 'lucide-react'
 import type { TopLevelWorkspace } from '../workspaceLayout'
 import type { ThemeMode } from '../theme/themes'
 
+export type WorkspaceBarWorkspace = TopLevelWorkspace | 'career-profile'
+
 interface WorkspaceBarProps {
-  activeWorkspace: TopLevelWorkspace
-  onWorkspaceChange: (workspace: TopLevelWorkspace) => void
+  activeWorkspace: WorkspaceBarWorkspace
+  careerProfileEnabled: boolean
+  onWorkspaceChange: (workspace: WorkspaceBarWorkspace) => void
   onReset: () => void
   onToggleMode: () => void
   themeMode: ThemeMode
 }
 
-const workspaces: Array<{ id: TopLevelWorkspace; label: string }> = [
+const workspaces: Array<{ id: WorkspaceBarWorkspace; label: string }> = [
   { id: 'research', label: 'Research' },
   { id: 'review', label: 'Review' },
   { id: 'agent-focus', label: 'Agent Focus' },
   { id: 'browse', label: 'Browse' }
 ]
 
-export function WorkspaceBar({ activeWorkspace, onWorkspaceChange, onReset, onToggleMode, themeMode }: WorkspaceBarProps) {
+export function WorkspaceBar({ activeWorkspace, careerProfileEnabled, onWorkspaceChange, onReset, onToggleMode, themeMode }: WorkspaceBarProps) {
   const dark = themeMode === 'dark'
   return (
     <header className="workspace-bar">
@@ -26,7 +29,7 @@ export function WorkspaceBar({ activeWorkspace, onWorkspaceChange, onReset, onTo
       </div>
 
       <nav aria-label="Workspace layouts" className="layout-switcher">
-        {workspaces.map(workspace => (
+        {[...workspaces, ...(careerProfileEnabled ? [{ id: 'career-profile' as const, label: 'Career Profile' }] : [])].map(workspace => (
           <button
             aria-pressed={activeWorkspace === workspace.id}
             className="layout-option"
@@ -52,7 +55,7 @@ export function WorkspaceBar({ activeWorkspace, onWorkspaceChange, onReset, onTo
             ? <Sun aria-hidden="true" size={16} strokeWidth={1.5} />
             : <Moon aria-hidden="true" size={16} strokeWidth={1.5} />}
         </button>
-        <button className="reset-layout" disabled={activeWorkspace === 'browse'} onClick={onReset} type="button">
+        <button className="reset-layout" disabled={activeWorkspace === 'browse' || activeWorkspace === 'career-profile'} onClick={onReset} type="button">
           <RotateCcw aria-hidden="true" size={16} strokeWidth={1.5} />
           Reset layout
         </button>

--- a/apps/desktop/src/renderer/hooks/useCareerProfile.ts
+++ b/apps/desktop/src/renderer/hooks/useCareerProfile.ts
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type {
+  CareerProfileBridge,
+  WorkArrangementCurrent,
+  WorkArrangementHistory,
+  WorkArrangementMutationResult,
+  WorkArrangementValue
+} from '../../shared/contracts'
+
+export type CareerProfileStatus = 'loading' | 'ready' | 'saving' | 'saved' | 'conflict' | 'error'
+
+interface ConflictState {
+  current: WorkArrangementCurrent
+  operation: 'save' | 'restore'
+  proposed: WorkArrangementValue
+  targetProfileRevision?: number
+}
+
+interface PendingMutation {
+  idempotencyKey: string
+  signature: string
+}
+
+const careerProfileCacheKey = 'jobos:career-profile:last-known-work-arrangement'
+
+async function readCachedCareerProfile(bridge: CareerProfileBridge): Promise<WorkArrangementCurrent | null> {
+  try {
+    const parsed: unknown = JSON.parse(window.localStorage.getItem(careerProfileCacheKey) ?? 'null')
+    return await bridge.validateCachedWorkArrangement(parsed)
+  } catch {
+    return null
+  }
+}
+
+export async function hasCachedCareerProfile(bridge: CareerProfileBridge): Promise<boolean> {
+  return await readCachedCareerProfile(bridge) !== null
+}
+
+function cacheCareerProfile(current: WorkArrangementCurrent): void {
+  try {
+    window.localStorage.setItem(careerProfileCacheKey, JSON.stringify(current))
+  } catch {
+    // The API remains authoritative; a blocked local cache must not block normal use.
+  }
+}
+
+const emptyValue: WorkArrangementValue = {
+  mode: 'flexible',
+  strength: 'preference',
+  note: null
+}
+
+function requestId(prefix: string): string {
+  const id = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2)
+  return `${prefix}_${id}`
+}
+
+export function useCareerProfile(bridge: CareerProfileBridge) {
+  const [current, setCurrent] = useState<WorkArrangementCurrent | null>(null)
+  const [draft, setDraft] = useState<WorkArrangementValue>(emptyValue)
+  const [history, setHistory] = useState<WorkArrangementHistory | null>(null)
+  const [historyError, setHistoryError] = useState('')
+  const [historyOpen, setHistoryOpen] = useState(false)
+  const [status, setStatus] = useState<CareerProfileStatus>('loading')
+  const [message, setMessage] = useState('')
+  const [conflict, setConflict] = useState<ConflictState | null>(null)
+  const pendingSave = useRef<PendingMutation | null>(null)
+  const pendingRestore = useRef<PendingMutation | null>(null)
+
+  const applyCurrent = useCallback((value: WorkArrangementCurrent) => {
+    cacheCareerProfile(value)
+    setCurrent(value)
+    setDraft(value.record?.value ?? emptyValue)
+  }, [])
+
+  const load = useCallback(async () => {
+    setStatus('loading')
+    setMessage('')
+    try {
+      applyCurrent(await bridge.getWorkArrangement())
+      setStatus('ready')
+    } catch {
+      const cached = await readCachedCareerProfile(bridge)
+      if (cached) {
+        applyCurrent(cached)
+        setStatus('ready')
+        setMessage('Offline — showing your last saved Career Profile. Reconnect before making changes.')
+        return
+      }
+      setStatus('error')
+      setMessage('Career Profile is unavailable right now. Your changes have not been lost.')
+    }
+  }, [applyCurrent, bridge])
+
+  useEffect(() => { void load() }, [load])
+
+  const handleMutation = useCallback((
+    result: WorkArrangementMutationResult,
+    proposed: WorkArrangementValue,
+    success: string,
+    operation: ConflictState['operation'] = 'save',
+    targetProfileRevision?: number
+  ) => {
+    if (result.status === 'conflict') {
+      applyCurrent(result.current)
+      setDraft(proposed)
+      setHistory(null)
+      setConflict({ current: result.current, operation, proposed, targetProfileRevision })
+      setStatus('conflict')
+      setMessage('This preference changed somewhere else. Review the latest saved value before reapplying your change.')
+      return false
+    }
+    applyCurrent(result.current)
+    setConflict(null)
+    setHistory(null)
+    setStatus('saved')
+    setMessage(success)
+    return true
+  }, [applyCurrent])
+
+  const save = useCallback(async (successMessage = 'Saved.') => {
+    if (!current) return false
+    const proposed = { ...draft, note: draft.note?.trim() || null }
+    const signature = JSON.stringify({ expectedProfileRevision: current.profileRevision, value: proposed })
+    if (pendingSave.current?.signature !== signature) {
+      pendingSave.current = { idempotencyKey: requestId('career_save'), signature }
+    }
+    setStatus('saving')
+    setMessage('')
+    try {
+      const result = await bridge.saveWorkArrangement({
+        expectedProfileRevision: current.profileRevision,
+        idempotencyKey: pendingSave.current.idempotencyKey,
+        value: proposed
+      })
+      pendingSave.current = null
+      return handleMutation(result, proposed, successMessage)
+    } catch {
+      setStatus('error')
+      setMessage('JobOS could not save this preference. Your edit is still here—try again when the connection returns.')
+      return false
+    }
+  }, [bridge, current, draft, handleMutation])
+
+  const openHistory = useCallback(async () => {
+    setHistoryOpen(true)
+    setHistoryError('')
+    if (history) return
+    try {
+      setHistory(await bridge.getWorkArrangementHistory())
+    } catch {
+      setHistoryError('History could not load. Try again.')
+    }
+  }, [bridge, history])
+
+  const restore = useCallback(async (targetProfileRevision: number, proposedOverride?: WorkArrangementValue) => {
+    if (!current) return false
+    const proposed = proposedOverride
+      ?? history?.revisions.find(revision => revision.profileRevision === targetProfileRevision)?.value
+    if (!proposed) {
+      setStatus('error')
+      setMessage('That earlier value is no longer available. Reload history and try again.')
+      return false
+    }
+    const signature = JSON.stringify({ expectedProfileRevision: current.profileRevision, targetProfileRevision })
+    if (pendingRestore.current?.signature !== signature) {
+      pendingRestore.current = { idempotencyKey: requestId('career_undo'), signature }
+    }
+    setStatus('saving')
+    setMessage('')
+    try {
+      const result = await bridge.restoreWorkArrangement({
+        expectedProfileRevision: current.profileRevision,
+        idempotencyKey: pendingRestore.current.idempotencyKey,
+        targetProfileRevision
+      })
+      pendingRestore.current = null
+      const restored = handleMutation(
+        result,
+        proposed,
+        'Previous preference restored as a new revision.',
+        'restore',
+        targetProfileRevision
+      )
+      setHistoryOpen(false)
+      return restored
+    } catch {
+      setStatus('error')
+      setMessage('')
+      setHistoryError('JobOS could not restore that version. Nothing was changed.')
+      return false
+    }
+  }, [bridge, current, handleMutation, history])
+
+  const keepCurrent = useCallback(() => {
+    if (!conflict) return
+    applyCurrent(conflict.current)
+    setConflict(null)
+    setStatus('ready')
+    setMessage('Kept the latest saved preference.')
+  }, [applyCurrent, conflict])
+
+  const reapplyConflict = useCallback(async (successMessage = 'Saved.') => {
+    if (!conflict) return false
+    if (conflict.operation === 'restore' && conflict.targetProfileRevision !== undefined) {
+      return restore(conflict.targetProfileRevision, conflict.proposed)
+    }
+    return save(successMessage)
+  }, [conflict, restore, save])
+
+  return {
+    conflict,
+    current,
+    draft,
+    history,
+    historyError,
+    historyOpen,
+    keepCurrent,
+    load,
+    message,
+    openHistory,
+    reapplyConflict,
+    restore,
+    save,
+    setDraft,
+    setHistoryOpen,
+    status
+  }
+}

--- a/apps/desktop/src/renderer/hooks/useJobs.ts
+++ b/apps/desktop/src/renderer/hooks/useJobs.ts
@@ -78,7 +78,9 @@ export function useJobs(
   useEffect(() => {
     const selected = activeJobContext?.selectedJobId ?? null
     setSelectedJobId(selected)
-    setSelectedJob(jobs.find(job => job.jobId === selected) ?? null)
+    setSelectedJob(current => selected
+      ? jobs.find(job => job.jobId === selected) ?? (current?.jobId === selected ? current : null)
+      : null)
     void loadDetail(selected)
   }, [activeConversationId, activeJobContext?.selectedJobId, jobs, loadDetail])
 

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -1435,3 +1435,288 @@ button:focus-visible {
 .demo-reset { display: grid; gap: 8px; margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border); }
 .demo-reset p { margin: 0; }
 .remove-demo-button { margin-top: 8px; }
+
+/* Career Profile — intentionally isolated while the feature is staging-only. */
+.career-profile-workspace {
+  min-height: 0;
+  height: 100%;
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  overflow: hidden;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 74% 4%, var(--accent-tint), transparent 32%),
+    var(--bg);
+}
+
+.career-profile-centered { grid-template-columns: minmax(0, 1fr); place-items: center; padding: 32px; }
+
+.career-profile-rail {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 34px 22px 22px;
+  overflow-y: auto;
+  border-right: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+}
+
+.career-profile-heading { display: grid; gap: 8px; }
+.career-profile-heading h1,
+.career-profile-heading p,
+.career-detail-header h2,
+.career-detail-header p,
+.career-form-card h3,
+.career-interpretation-card h3,
+.career-empty-card h3,
+.career-empty-card p,
+.career-state-card h1,
+.career-state-card p,
+.career-conflict-card h4,
+.career-history-heading h3 { margin: 0; }
+.career-profile-heading h1 { font-size: 27px; letter-spacing: -.035em; }
+.career-profile-heading p { color: var(--muted); font-size: var(--text-sm); line-height: 1.55; }
+.career-eyebrow,
+.career-kicker,
+.career-breadcrumb {
+  color: var(--accent-text);
+  font-size: 10px;
+  font-weight: var(--weight-bold);
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+.career-profile-nav { display: grid; gap: 7px; }
+.career-nav-item {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+  padding: 11px 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  text-align: left;
+  background: transparent;
+}
+.career-nav-item span { display: grid; gap: 3px; }
+.career-nav-item strong { color: inherit; font-size: var(--text-base); }
+.career-nav-item small { color: var(--muted); font-size: var(--text-xs); }
+.career-nav-item.active { border-color: var(--accent-border); color: var(--text); background: var(--accent-tint-strong); box-shadow: inset 0 1px 0 var(--highlight-inset); }
+.career-nav-item:disabled { opacity: .72; cursor: default; }
+
+.career-staging-note {
+  margin-top: auto;
+  padding: 13px;
+  border: 1px solid var(--warn-border);
+  border-radius: var(--radius-md);
+  background: var(--warn-tint);
+}
+.career-staging-note span { color: var(--warn-text); font-size: var(--text-xs); font-weight: var(--weight-bold); text-transform: uppercase; letter-spacing: .06em; }
+.career-staging-note p { margin: 6px 0 0; color: var(--muted); font-size: var(--text-xs); line-height: 1.45; }
+
+.career-profile-main {
+  position: relative;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 42px clamp(28px, 5vw, 72px) 64px;
+}
+.career-mobile-staging { display: none; }
+.career-detail-header {
+  max-width: 1040px;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 0 auto 26px;
+}
+.career-detail-header > div { display: grid; gap: 7px; }
+.career-detail-header h2 { font-size: 30px; line-height: 1.12; letter-spacing: -.04em; }
+.career-detail-header p { max-width: 610px; color: var(--muted); line-height: 1.55; }
+.career-revision-badge,
+.career-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+  background: var(--surface-inset);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+}
+.career-status { border-color: var(--green-border); color: var(--green-text); background: var(--green-tint); }
+
+.career-detail-grid {
+  max-width: 1040px;
+  display: grid;
+  grid-template-columns: minmax(420px, 1.45fr) minmax(280px, .8fr);
+  align-items: start;
+  gap: 18px;
+  margin: 0 auto;
+}
+.career-form-card,
+.career-interpretation-card,
+.career-empty-card,
+.career-state-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--surface-raised) 96%, transparent);
+  box-shadow: 0 18px 46px var(--shadow-color-soft), inset 0 1px 0 var(--highlight-inset);
+}
+.career-form-card { display: grid; gap: 20px; padding: 24px; }
+.career-card-heading { display: flex; align-items: start; justify-content: space-between; gap: 16px; padding-bottom: 18px; border-bottom: 1px solid var(--border-soft); }
+.career-card-heading > div { display: grid; gap: 5px; }
+.career-card-heading h3 { font-size: var(--text-xl); letter-spacing: -.02em; }
+
+.career-field,
+.career-strength-field { display: grid; gap: 8px; margin: 0; padding: 0; border: 0; }
+.career-field > span,
+.career-strength-field legend { color: var(--text-soft); font-size: var(--text-sm); font-weight: var(--weight-bold); }
+.career-field > span small { margin-left: 5px; color: var(--muted); font-weight: var(--weight-normal); }
+.career-field select,
+.career-strength-field select,
+.career-field textarea {
+  width: 100%;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  background: var(--surface-inset);
+  font: inherit;
+  transition: border-color var(--motion-fast), background-color var(--motion-fast), box-shadow var(--motion-fast);
+}
+.career-field select,
+.career-strength-field select { min-height: 40px; padding: 0 11px; }
+.career-field textarea { min-height: 104px; resize: vertical; padding: 11px; line-height: 1.5; }
+.career-field select:focus-visible,
+.career-strength-field select:focus-visible,
+.career-field textarea:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-tint-strong); }
+.career-field > small { justify-self: end; color: var(--muted); font-size: var(--text-xs); }
+.career-strength-field p { margin: 0; color: var(--muted); font-size: var(--text-xs); line-height: 1.5; }
+
+.career-feedback,
+.career-inline-alert { margin: -4px 0 0; padding: 10px 12px; border-radius: var(--radius-md); font-size: var(--text-sm); line-height: 1.45; }
+.career-inline-alert,
+.career-feedback.error { border: 1px solid var(--danger-border); color: var(--danger-text); background: var(--danger-tint); }
+.career-feedback.saved { border: 1px solid var(--green-border); color: var(--green-text); background: var(--green-tint); }
+.career-feedback.conflict { border: 1px solid var(--warn-border); color: var(--warn-text); background: var(--warn-tint); }
+
+.career-conflict-card { display: grid; gap: 13px; padding: 15px; border: 1px solid var(--warn-border); border-radius: var(--radius-md); background: var(--warn-tint); }
+.career-conflict-card dl { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin: 0; }
+.career-conflict-card dl div { display: grid; gap: 3px; }
+.career-conflict-card dt { color: var(--muted); font-size: var(--text-xs); }
+.career-conflict-card dd { margin: 0; font-weight: var(--weight-bold); }
+.career-conflict-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+
+.career-form-actions { display: flex; align-items: center; gap: 10px; padding-top: 4px; }
+.career-primary-button,
+.career-secondary-button,
+.career-text-button,
+.career-icon-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 36px;
+  border-radius: var(--radius-md);
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color var(--motion-fast), background-color var(--motion-fast), transform var(--motion-fast), opacity var(--motion-fast);
+}
+.career-primary-button { padding: 0 14px; border: 1px solid var(--accent-border-strong); color: var(--on-accent); background: var(--accent-solid); font-weight: var(--weight-bold); }
+.career-primary-button:hover:not(:disabled) { border-color: var(--accent); background: var(--accent-solid-hover); }
+.career-primary-button:active:not(:disabled),
+.career-secondary-button:active,
+.career-text-button:active { transform: translateY(1px); }
+.career-primary-button:disabled { opacity: var(--disabled-opacity); cursor: wait; }
+.career-secondary-button:disabled,
+.career-text-button:disabled,
+.career-icon-action:disabled { opacity: var(--disabled-opacity); cursor: not-allowed; }
+.career-secondary-button { width: fit-content; padding: 0 13px; border: 1px solid var(--border-strong); background: var(--surface-hover); }
+.career-secondary-button:hover { border-color: var(--accent-border); background: var(--surface-selected); }
+.career-text-button { padding: 0 9px; border: 1px solid transparent; color: var(--muted); background: transparent; }
+.career-text-button:hover { color: var(--text); background: var(--surface-hover); }
+.career-icon-action { width: 34px; min-height: 34px; padding: 0; border: 1px solid var(--border); background: var(--surface-inset); }
+.career-icon-action:hover { border-color: var(--accent-border); color: var(--accent-text); }
+
+.career-interpretation-card { position: sticky; top: 0; display: grid; gap: 14px; padding: 24px; overflow: hidden; }
+.career-interpretation-card::before { content: ""; position: absolute; inset: 0 0 auto; height: 3px; background: linear-gradient(90deg, var(--accent-solid), var(--accent)); }
+.career-interpretation-card h3 { font-size: var(--text-lg); line-height: 1.45; letter-spacing: -.015em; }
+.career-interpretation-card > p { margin: 0; color: var(--muted); line-height: 1.55; }
+.career-impact-list { display: grid; gap: 8px; padding-top: 13px; border-top: 1px solid var(--border-soft); }
+.career-impact-list > span { color: var(--muted); font-size: var(--text-xs); font-weight: var(--weight-bold); text-transform: uppercase; letter-spacing: .06em; }
+.career-impact-list ul { display: grid; gap: 6px; margin: 0; padding: 0; list-style: none; color: var(--text-soft); }
+.career-impact-list li::before { content: "✓"; margin-right: 8px; color: var(--green); }
+
+.career-empty-card { max-width: 1040px; display: grid; justify-items: start; gap: 7px; margin: 0 auto 16px; padding: 18px 20px; border-style: dashed; }
+.career-empty-card svg { color: var(--accent); }
+.career-empty-card p { color: var(--muted); }
+.career-state-card { width: min(470px, 100%); display: grid; justify-items: start; gap: 12px; padding: 28px; }
+.career-state-card svg { color: var(--accent); }
+.career-state-card p { color: var(--muted); line-height: 1.55; }
+
+.career-history-modal-layer {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+}
+.career-history-backdrop {
+  position: fixed;
+  z-index: 0;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 54%, transparent);
+}
+.career-history-drawer {
+  position: fixed;
+  z-index: 1;
+  inset: 0 0 0 auto;
+  width: min(430px, 78%);
+  padding: 28px 24px;
+  overflow-y: auto;
+  border-left: 1px solid var(--border-strong);
+  background: var(--surface);
+  box-shadow: -24px 0 70px var(--shadow-color);
+}
+.career-history-heading { display: flex; align-items: start; justify-content: space-between; gap: 18px; padding-bottom: 18px; border-bottom: 1px solid var(--border); }
+.career-history-heading > div { display: grid; gap: 5px; }
+.career-history-list { display: grid; gap: 0; margin: 0; padding: 0; list-style: none; }
+.career-history-list li { display: flex; align-items: start; justify-content: space-between; gap: 14px; padding: 17px 0; border-bottom: 1px solid var(--border-soft); }
+.career-history-list li > div { display: grid; gap: 4px; }
+.career-history-list span { color: var(--text-soft); }
+.career-history-list small { color: var(--muted); }
+.career-history-error { display: grid; justify-items: start; gap: 10px; margin-top: 18px; padding: 14px; border: 1px solid var(--danger-border); border-radius: var(--radius-md); color: var(--danger-text); background: var(--danger-tint); }
+.career-history-error p { margin: 0; }
+
+.career-skeleton { border-radius: var(--radius-md); background: linear-gradient(90deg, var(--surface-raised), var(--surface-hover), var(--surface-raised)); background-size: 200% 100%; animation: career-shimmer 1.4s ease infinite; }
+.career-skeleton.rail { height: 240px; }
+.career-skeleton.title { width: 42%; height: 34px; margin: 12px 0 24px; }
+.career-skeleton.card { height: 330px; display: grid; place-items: center; color: var(--quiet); }
+@keyframes career-shimmer { to { background-position: -200% 0; } }
+
+@media (max-width: 1120px) {
+  .career-profile-workspace { grid-template-columns: 230px minmax(0, 1fr); }
+  .career-profile-rail { padding-inline: 16px; }
+  .career-profile-main { padding-inline: 24px; }
+  .career-detail-grid { grid-template-columns: minmax(0, 1fr); }
+  .career-interpretation-card { position: static; }
+}
+
+@media (max-width: 1000px) {
+  .career-profile-workspace { grid-template-columns: minmax(0, 1fr); }
+  .career-profile-rail { display: none; }
+  .career-profile-main { padding: 22px 16px 48px; }
+  .career-mobile-staging { display: inline-flex; width: fit-content; margin-bottom: 14px; padding: 5px 8px; border: 1px solid var(--warn-border); border-radius: 999px; color: var(--warn-text); background: var(--warn-tint); font-size: var(--text-xs); font-weight: var(--weight-bold); }
+  .career-detail-header { align-items: start; }
+  .career-detail-header h2 { font-size: 26px; }
+  .career-form-card,
+  .career-interpretation-card { padding: 18px; }
+  .career-history-drawer { position: fixed; width: 100%; padding: 22px 18px; border-left: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .career-skeleton { animation: none; }
+}

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -14,6 +14,75 @@ import type {
 } from './editableDocuments.js'
 
 export type ConnectivityState = 'connecting' | 'connected' | 'degraded' | 'disconnected'
+
+export type WorkArrangementMode = 'remote' | 'hybrid' | 'onsite' | 'flexible'
+export type WorkArrangementStrength = 'requirement' | 'strong_preference' | 'preference' | 'dealbreaker'
+
+export interface WorkArrangementValue {
+  mode: WorkArrangementMode
+  strength: WorkArrangementStrength
+  note: string | null
+}
+
+export interface WorkArrangementRecord {
+  actorPrincipal: string
+  itemRevision: number
+  profileRevision: number
+  recordId: string
+  updatedAt: string
+  value: WorkArrangementValue
+}
+
+export interface WorkArrangementCurrent {
+  cacheProof?: string
+  profileRevision: number
+  record: WorkArrangementRecord | null
+}
+
+export interface WorkArrangementRevision {
+  actorPrincipal: string
+  baseProfileRevision: number
+  changedFields: string[]
+  createdAt: string
+  itemRevision: number
+  operation: 'set' | 'restore'
+  profileRevision: number
+  recordId: string
+  restoredFromProfileRevision: number | null
+  revisionId: string
+  value: WorkArrangementValue
+}
+
+export interface WorkArrangementHistory {
+  profileRevision: number
+  revisions: WorkArrangementRevision[]
+}
+
+export interface WorkArrangementMutationRequest {
+  expectedProfileRevision: number
+  idempotencyKey: string
+  value: WorkArrangementValue
+}
+
+export interface WorkArrangementRestoreRequest {
+  expectedProfileRevision: number
+  idempotencyKey: string
+  targetProfileRevision: number
+}
+
+export type WorkArrangementMutationResult =
+  | { status: 'saved'; current: WorkArrangementCurrent }
+  | { status: 'conflict'; current: WorkArrangementCurrent }
+
+export interface CareerProfileBridge {
+  availability: () => Promise<{ enabled: boolean }>
+  validateCachedWorkArrangement: (candidate: unknown) => Promise<WorkArrangementCurrent | null>
+  getWorkArrangement: () => Promise<WorkArrangementCurrent>
+  saveWorkArrangement: (request: WorkArrangementMutationRequest) => Promise<WorkArrangementMutationResult>
+  getWorkArrangementHistory: () => Promise<WorkArrangementHistory>
+  restoreWorkArrangement: (request: WorkArrangementRestoreRequest) => Promise<WorkArrangementMutationResult>
+}
+
 export type JobSortMode = 'manual' | 'recent' | 'alphabetical' | 'status'
 export type JobStatus = 'discovered' | 'scored' | 'reviewed' | 'shortlisted' | 'apply_now' | 'maybe' | 'stretch' | 'skipped' | 'applied' | 'interviewing' | 'closed' | 'archived'
 
@@ -346,6 +415,7 @@ export interface JobOsRendererBridge {
   connectivity: {
     get: () => Promise<ConnectivitySnapshot>
   }
+  careerProfile: CareerProfileBridge
   agent: {
     list: () => Promise<AgentSessionSummary[]>
     create: (initialSelectedJobId?: string | null) => Promise<AgentConversationSnapshot>


### PR DESCRIPTION
## What changed

- adds the first desktop **Career Profile** workspace for **What I’m Looking For → Work arrangement**
- lets the user edit remote/hybrid/onsite/flexible preferences, importance, and plain-language context
- explains how the saved preference affects JobOS recommendations
- adds revision history, compensating Undo, stale-conflict review, and safe idempotent retries
- keeps saved data readable while offline and blocks mutations until reconnection
- preserves the device credential in Electron’s trusted main process and validates renderer requests before calling the API
- labels the entire experience as a `(FAKE) staging profile`; it does not activate or replace live career context

## Verification

- `pnpm contracts:check`
- `pnpm check`
  - desktop: 474 passed
  - API: 689 passed, 4 skipped
  - updater: 10 passed
  - lint, type checks, public-tree checks, license checks, production builds passed
- focused Career Profile/Workspace tests: 22 passed
- `git diff --cached --check`
- visual review of the staged synthetic-data UI

## Safety boundary

No live profile activation, legacy-context migration, agent projection, authority cutover, or production deployment is included.

Closes #51
