### PR TITLE
Bind every agent turn to an immutable Career Profile snapshot

### DIFF
--- a/services/api/jobos_api/agent_gateway.py
+++ b/services/api/jobos_api/agent_gateway.py
@@ -12,6 +12,7 @@ class AgentContext:
     workspace: dict[str, object]
     conversation_id: str
     selected_job: dict[str, str] | None = None
+    career_profile: dict[str, object] | None = None
 
 
 @dataclass(frozen=True)

--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -464,7 +464,11 @@ def create_app(
         )
         configured_gateway = True
     conversation_manager = ConversationManager(
-        state_store, gateway_factory or OfflineAgentGatewayFactory()
+        state_store,
+        gateway_factory or OfflineAgentGatewayFactory(),
+        career_profile_principal=(
+            principal_for_device(settings.device_id) if settings.career_profile_enabled else None
+        ),
     )
     browser_capabilities = capability_broker or CapabilityBroker()
     browser_command_locks: dict[tuple[str, str], asyncio.Lock] = {}
@@ -1473,6 +1477,8 @@ def create_app(
         command: SendMessageRequest,
         identity: Annotated[DeviceIdentity, Depends(authenticated_device)],
     ) -> TurnMutationResponse:
+        if settings.career_profile_enabled:
+            require_career_profile_owner(identity)
         try:
             return await conversation_service(conversation_id, identity).send(
                 command,
@@ -1508,6 +1514,8 @@ def create_app(
         command: RetryTurnRequest,
         identity: Annotated[DeviceIdentity, Depends(authenticated_device)],
     ) -> TurnMutationResponse:
+        if settings.career_profile_enabled:
+            require_career_profile_owner(identity)
         try:
             result = await conversation_service(conversation_id, identity).retry(
                 validated_turn_id(turn_id), command, actor_id=identity.device_id

--- a/services/api/jobos_api/career_profile.py
+++ b/services/api/jobos_api/career_profile.py
@@ -161,6 +161,93 @@ def _snapshot_hash(
     ).hexdigest()
 
 
+def create_snapshot_in_transaction(
+    connection: sqlite3.Connection,
+    *,
+    principal: str,
+    request: CareerProfileSnapshotRequest,
+) -> CareerProfileSnapshot:
+    """Create an immutable authorized projection inside the caller's transaction."""
+    scopes = list(dict.fromkeys(request.scopes))
+    head_row = connection.execute(
+        "SELECT head_revision FROM career_profiles WHERE profile_id = ?",
+        (PROFILE_ID,),
+    ).fetchone()
+    if head_row is None:
+        raise RuntimeError("Career Profile storage is not initialized")
+    head = int(head_row[0])
+    record_row = connection.execute(
+        """
+        SELECT record_id, value_json, item_revision, actor_principal, updated_at
+        FROM career_profile_records
+        WHERE profile_id = ? AND namespace = ?
+        """,
+        (PROFILE_ID, WORK_ARRANGEMENT_NAMESPACE),
+    ).fetchone()
+    record = CareerProfileStore._record_from_row(record_row, head) if record_row else None
+    projection = CareerProfileProjection(work_arrangement=record)
+    snapshot_id = _opaque_id("cps_")
+    content_hash = _snapshot_hash(head, scopes, projection)
+    connection.execute(
+        """
+        INSERT INTO career_profile_snapshots(
+            snapshot_id, profile_revision, content_hash, authorized_principal,
+            scopes_json, projection_json
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            snapshot_id,
+            head,
+            content_hash,
+            principal,
+            _canonical_json(scopes),
+            _canonical_json(projection.model_dump(mode="json")),
+        ),
+    )
+    row = connection.execute(
+        """
+        SELECT snapshot_id, profile_revision, content_hash, authorized_principal,
+               scopes_json, projection_json, created_at
+        FROM career_profile_snapshots WHERE snapshot_id = ?
+        """,
+        (snapshot_id,),
+    ).fetchone()
+    connection.execute(
+        """
+        INSERT INTO career_profile_audit_events(
+            actor_principal, action, profile_revision, affected_fields_json
+        ) VALUES (?, 'snapshot.create', ?, ?)
+        """,
+        (principal, head, _canonical_json(scopes)),
+    )
+    assert row is not None
+    return CareerProfileStore._snapshot_from_row(row)
+
+
+def get_snapshot_in_connection(
+    connection: sqlite3.Connection, snapshot_id: str, *, principal: str
+) -> CareerProfileSnapshot:
+    row = connection.execute(
+        """
+        SELECT snapshot_id, profile_revision, content_hash, authorized_principal,
+               scopes_json, projection_json, created_at
+        FROM career_profile_snapshots WHERE snapshot_id = ?
+        """,
+        (snapshot_id,),
+    ).fetchone()
+    if row is None:
+        raise CareerProfileSnapshotNotFound
+    if not secrets.compare_digest(str(row[3]), principal):
+        raise CareerProfileSnapshotForbidden
+    snapshot = CareerProfileStore._snapshot_from_row(row)
+    expected_hash = _snapshot_hash(
+        snapshot.profile_revision, list(snapshot.scopes), snapshot.projection
+    )
+    if not secrets.compare_digest(snapshot.content_hash, expected_hash):
+        raise CareerProfileSnapshotIntegrityError
+    return snapshot
+
+
 def _changed_fields(previous: dict[str, object] | None, current: dict[str, object]) -> list[str]:
     fields = ("mode", "strength", "note")
     return [
@@ -326,86 +413,21 @@ class CareerProfileStore:
         principal: str,
         request: CareerProfileSnapshotRequest,
     ) -> CareerProfileSnapshot:
-        scopes = list(dict.fromkeys(request.scopes))
         with connect_sqlite(self._path) as connection:
             connection.execute("BEGIN IMMEDIATE")
             try:
-                head = self._head_revision(connection)
-                row = connection.execute(
-                    """
-                    SELECT record_id, value_json, item_revision, actor_principal, updated_at
-                    FROM career_profile_records
-                    WHERE profile_id = ? AND namespace = ?
-                    """,
-                    (PROFILE_ID, WORK_ARRANGEMENT_NAMESPACE),
-                ).fetchone()
-                record = self._record_from_row(row, head) if row is not None else None
-                projection = CareerProfileProjection(work_arrangement=record)
-                projection_json = _canonical_json(projection.model_dump(mode="json"))
-                content_hash = _snapshot_hash(head, scopes, projection)
-                snapshot_id = _opaque_id("cps_")
-                connection.execute(
-                    """
-                    INSERT INTO career_profile_snapshots(
-                        snapshot_id, profile_revision, content_hash, authorized_principal,
-                        scopes_json, projection_json
-                    ) VALUES (?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        snapshot_id,
-                        head,
-                        content_hash,
-                        principal,
-                        _canonical_json(scopes),
-                        projection_json,
-                    ),
-                )
-                row = connection.execute(
-                    """
-                    SELECT snapshot_id, profile_revision, content_hash, authorized_principal,
-                           scopes_json, projection_json, created_at
-                    FROM career_profile_snapshots WHERE snapshot_id = ?
-                    """,
-                    (snapshot_id,),
-                ).fetchone()
-                connection.execute(
-                    """
-                    INSERT INTO career_profile_audit_events(
-                        actor_principal, action, profile_revision, affected_fields_json
-                    ) VALUES (?, 'snapshot.create', ?, ?)
-                    """,
-                    (principal, head, _canonical_json(scopes)),
+                snapshot = create_snapshot_in_transaction(
+                    connection, principal=principal, request=request
                 )
                 connection.commit()
             except Exception:
                 connection.rollback()
                 raise
-        assert row is not None
-        return self._snapshot_from_row(row)
+        return snapshot
 
     def get_snapshot(self, snapshot_id: str, *, principal: str) -> CareerProfileSnapshot:
         with connect_sqlite(f"file:{self._path}?mode=ro", uri=True) as connection:
-            row = connection.execute(
-                """
-                SELECT snapshot_id, profile_revision, content_hash, authorized_principal,
-                       scopes_json, projection_json, created_at
-                FROM career_profile_snapshots WHERE snapshot_id = ?
-                """,
-                (snapshot_id,),
-            ).fetchone()
-        if row is None:
-            raise CareerProfileSnapshotNotFound
-        if not secrets.compare_digest(row[3], principal):
-            raise CareerProfileSnapshotForbidden
-        snapshot = self._snapshot_from_row(row)
-        expected_hash = _snapshot_hash(
-            snapshot.profile_revision,
-            list(snapshot.scopes),
-            snapshot.projection,
-        )
-        if not secrets.compare_digest(snapshot.content_hash, expected_hash):
-            raise CareerProfileSnapshotIntegrityError
-        return snapshot
+            return get_snapshot_in_connection(connection, snapshot_id, principal=principal)
 
     def _mutate(
         self,

--- a/services/api/jobos_api/conversation_manager.py
+++ b/services/api/jobos_api/conversation_manager.py
@@ -31,9 +31,16 @@ class ConversationListResponse(ConversationModel):
 
 
 class ConversationManager:
-    def __init__(self, store: JobOsStateStore, gateway_factory: AgentGatewayFactory) -> None:
+    def __init__(
+        self,
+        store: JobOsStateStore,
+        gateway_factory: AgentGatewayFactory,
+        *,
+        career_profile_principal: str | None = None,
+    ) -> None:
         self.store = store
         self.gateway_factory = gateway_factory
+        self.career_profile_principal = career_profile_principal
         self._services: dict[str, ConversationService] = {}
         self._lifecycle_lock = asyncio.Lock()
 
@@ -77,6 +84,7 @@ class ConversationManager:
             self.store.conversation_store(conversation_id),
             self.gateway_factory.create(conversation_id),
             conversation_id,
+            career_profile_principal=self.career_profile_principal,
         )
 
     def list(self, *, owner_device_id: str) -> ConversationListResponse:

--- a/services/api/jobos_api/conversation_store.py
+++ b/services/api/jobos_api/conversation_store.py
@@ -8,6 +8,12 @@ import sqlite3
 from hashlib import sha256
 from pathlib import Path
 
+from .career_profile import (
+    CareerProfileSnapshot,
+    CareerProfileSnapshotRequest,
+    create_snapshot_in_transaction,
+    get_snapshot_in_connection,
+)
 from .redaction import redact_detail, sanitize_summary, sanitize_user_text
 from .sqlite_connection import connect_sqlite
 from .state_store import (
@@ -162,6 +168,7 @@ class ConversationStore:
         idempotency_key: str,
         actor_id: str,
         source_turn_id: str | None = None,
+        career_profile_principal: str | None = None,
     ) -> dict[str, str | bool | None]:
         safe_text = sanitize_user_text(text)
         command = (
@@ -191,14 +198,18 @@ class ConversationStore:
                 result = json.loads(str(prior[1]))
                 connection.rollback()
                 return {**result, "created": False}
-            if (
-                source_turn_id
-                and connection.execute(
-                    "SELECT 1 FROM conversation_turns WHERE turn_id = ? AND conversation_id = ?",
+            source = None
+            if source_turn_id:
+                source = connection.execute(
+                    """
+                    SELECT career_profile_snapshot_id, career_profile_revision,
+                           career_profile_content_hash
+                    FROM conversation_turns
+                    WHERE turn_id = ? AND conversation_id = ?
+                    """,
                     (source_turn_id, self.conversation_id),
                 ).fetchone()
-                is None
-            ):
+            if source_turn_id and source is None:
                 connection.rollback()
                 raise ConversationNotFound("Turn not found")
             if connection.execute(
@@ -215,12 +226,42 @@ class ConversationStore:
                 raise ConversationBusy("Remote agent cleanup must be confirmed before new work")
             message_id = f"msg_{secrets.token_urlsafe(16)}"
             turn_id = f"turn_{secrets.token_urlsafe(16)}"
+            bound_snapshot: CareerProfileSnapshot | None = None
+            if career_profile_principal is not None:
+                if source is None:
+                    bound_snapshot = create_snapshot_in_transaction(
+                        connection,
+                        principal=career_profile_principal,
+                        request=CareerProfileSnapshotRequest(),
+                    )
+                else:
+                    snapshot_id, revision, content_hash = source
+                    if snapshot_id is None or revision is None or content_hash is None:
+                        connection.rollback()
+                        raise RuntimeError("Source turn has no valid Career Profile binding")
+                    bound_snapshot = get_snapshot_in_connection(
+                        connection, str(snapshot_id), principal=career_profile_principal
+                    )
+                    if (
+                        bound_snapshot.profile_revision != int(revision)
+                        or not secrets.compare_digest(
+                            bound_snapshot.content_hash, str(content_hash)
+                        )
+                    ):
+                        connection.rollback()
+                        raise RuntimeError("Source turn Career Profile binding is invalid")
             safe_context = redact_detail(context)
             safe_context.pop("redacted", None)
             public_context = dict(safe_context)
             public_context.pop("_fresh_agent_session", None)
             connection.execute(
-                "INSERT INTO conversation_turns(turn_id, conversation_id, message_id, source_turn_id, text, context_json, status) VALUES (?, ?, ?, ?, ?, ?, 'running')",
+                """
+                INSERT INTO conversation_turns(
+                    turn_id, conversation_id, message_id, source_turn_id, text,
+                    context_json, status, career_profile_snapshot_id,
+                    career_profile_revision, career_profile_content_hash
+                ) VALUES (?, ?, ?, ?, ?, ?, 'running', ?, ?, ?)
+                """,
                 (
                     turn_id,
                     self.conversation_id,
@@ -228,6 +269,9 @@ class ConversationStore:
                     source_turn_id,
                     safe_text,
                     json.dumps(safe_context, separators=(",", ":"), sort_keys=True),
+                    bound_snapshot.snapshot_id if bound_snapshot else None,
+                    bound_snapshot.profile_revision if bound_snapshot else None,
+                    bound_snapshot.content_hash if bound_snapshot else None,
                 ),
             )
             connection.execute(
@@ -274,6 +318,28 @@ class ConversationStore:
 
     create_conversation_turn = create_turn
 
+    def bound_career_profile_snapshot(
+        self, turn_id: str, *, principal: str
+    ) -> CareerProfileSnapshot:
+        with connect_sqlite(f"file:{self._path}?mode=ro", uri=True) as connection:
+            row = connection.execute(
+                """
+                SELECT career_profile_snapshot_id, career_profile_revision,
+                       career_profile_content_hash
+                FROM conversation_turns
+                WHERE turn_id = ? AND conversation_id = ?
+                """,
+                (turn_id, self.conversation_id),
+            ).fetchone()
+            if row is None or any(value is None for value in row):
+                raise RuntimeError("Turn has no valid Career Profile binding")
+            snapshot = get_snapshot_in_connection(connection, str(row[0]), principal=principal)
+        if snapshot.profile_revision != int(row[1]) or not secrets.compare_digest(
+            snapshot.content_hash, str(row[2])
+        ):
+            raise RuntimeError("Turn Career Profile binding is invalid")
+        return snapshot
+
     def record_agent_continuation(
         self,
         *,
@@ -283,6 +349,7 @@ class ConversationStore:
         summary: str,
         detail: dict[str, object],
         source_event_id: str | None = None,
+        career_profile_principal: str | None = None,
     ) -> bool:
         """Atomically append one terminal assistant-only continuation."""
         if not re.fullmatch(r"turn_[A-Za-z0-9_-]{8,200}", turn_id):
@@ -301,14 +368,59 @@ class ConversationStore:
             ).fetchone():
                 connection.rollback()
                 return False
+            continuation_id = detail.get("continuation_id")
+            continuation_digest = (
+                sha256(continuation_id.encode()).hexdigest()
+                if isinstance(continuation_id, str)
+                and re.fullmatch(r"[A-Za-z0-9_-]{8,200}", continuation_id)
+                else None
+            )
+            binding = (
+                connection.execute(
+                    """
+                    SELECT turn.career_profile_snapshot_id, turn.career_profile_revision,
+                           turn.career_profile_content_hash
+                    FROM conversation_continuation_bindings AS continuation
+                    JOIN conversation_turns AS turn
+                      ON turn.turn_id = continuation.source_turn_id
+                     AND turn.conversation_id = continuation.conversation_id
+                    WHERE continuation.conversation_id = ?
+                      AND continuation.continuation_digest = ?
+                    """,
+                    (self.conversation_id, continuation_digest),
+                ).fetchone()
+                if continuation_digest is not None
+                else None
+            )
+            if career_profile_principal is not None:
+                if binding is None or any(value is None for value in binding):
+                    connection.rollback()
+                    return False
+                snapshot = get_snapshot_in_connection(
+                    connection, str(binding[0]), principal=career_profile_principal
+                )
+                if snapshot.profile_revision != int(binding[1]) or not secrets.compare_digest(
+                    snapshot.content_hash, str(binding[2])
+                ):
+                    connection.rollback()
+                    return False
             connection.execute(
-                "INSERT INTO conversation_turns(turn_id, conversation_id, message_id, source_turn_id, text, context_json, status) VALUES (?, ?, ?, NULL, '', ?, ?)",
+                """
+                INSERT INTO conversation_turns(
+                    turn_id, conversation_id, message_id, source_turn_id, text,
+                    context_json, status, career_profile_snapshot_id,
+                    career_profile_revision, career_profile_content_hash
+                ) VALUES (?, ?, ?, NULL, '', ?, ?, ?, ?, ?)
+                """,
                 (
                     turn_id,
                     self.conversation_id,
                     message_id,
                     json.dumps(context, separators=(",", ":"), sort_keys=True),
                     status,
+                    binding[0] if binding else None,
+                    binding[1] if binding else None,
+                    binding[2] if binding else None,
                 ),
             )
             connection.execute(
@@ -338,6 +450,32 @@ class ConversationStore:
             connection.commit()
         return True
 
+    def bind_agent_continuation(self, *, turn_id: str, continuation_id: str) -> None:
+        """Bind a Hermes background continuation to the turn that spawned it."""
+        if not re.fullmatch(r"turn_[A-Za-z0-9_-]{8,200}", turn_id):
+            raise ValueError("Invalid source turn id")
+        if not re.fullmatch(r"[A-Za-z0-9_-]{8,200}", continuation_id):
+            raise ValueError("Invalid continuation id")
+        digest = sha256(continuation_id.encode()).hexdigest()
+        with connect_sqlite(self._path) as connection:
+            self._require_active(connection)
+            source = connection.execute(
+                """SELECT 1 FROM conversation_turns
+                   WHERE conversation_id = ? AND turn_id = ?""",
+                (self.conversation_id, turn_id),
+            ).fetchone()
+            if source is None:
+                raise ValueError("Unknown source turn")
+            connection.execute(
+                """INSERT INTO conversation_continuation_bindings(
+                       conversation_id, continuation_digest, source_turn_id
+                   ) VALUES (?, ?, ?)
+                   ON CONFLICT(conversation_id, continuation_digest) DO UPDATE SET
+                       source_turn_id = excluded.source_turn_id
+                   WHERE source_turn_id = excluded.source_turn_id""",
+                (self.conversation_id, digest, turn_id),
+            )
+
     def append_event(
         self,
         *,
@@ -347,9 +485,16 @@ class ConversationStore:
         summary: str,
         detail: dict[str, object] | None = None,
         source_event_id: str | None = None,
+        continuation_ids: tuple[str, ...] = (),
     ) -> int | None:
         safe_detail = _conversation_detail(event_type, detail)
+        continuation_digests: list[str] = []
+        for continuation_id in continuation_ids:
+            if not re.fullmatch(r"[A-Za-z0-9_-]{8,200}", continuation_id):
+                raise ValueError("Invalid continuation id")
+            continuation_digests.append(sha256(continuation_id.encode()).hexdigest())
         with connect_sqlite(self._path) as connection:
+            connection.execute("BEGIN IMMEDIATE")
             self._require_active(connection)
             if (
                 turn_id
@@ -374,7 +519,23 @@ class ConversationStore:
                     ),
                 )
             except sqlite3.IntegrityError:
+                connection.rollback()
                 return None
+            if continuation_digests:
+                if turn_id is None:
+                    connection.rollback()
+                    raise ValueError("Continuation binding requires a source turn")
+                for continuation_digest in continuation_digests:
+                    connection.execute(
+                        """INSERT INTO conversation_continuation_bindings(
+                               conversation_id, continuation_digest, source_turn_id
+                           ) VALUES (?, ?, ?)
+                           ON CONFLICT(conversation_id, continuation_digest) DO UPDATE SET
+                               source_turn_id = excluded.source_turn_id
+                           WHERE source_turn_id = excluded.source_turn_id""",
+                        (self.conversation_id, continuation_digest, turn_id),
+                    )
+            connection.commit()
         return int(cursor.lastrowid)
 
     append_conversation_event = append_event

--- a/services/api/jobos_api/conversations.py
+++ b/services/api/jobos_api/conversations.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import re
 import time
 from collections.abc import AsyncIterator
 from contextlib import suppress
@@ -94,6 +95,7 @@ class ConversationService:
         store: ConversationStore | JobOsStateStore,
         gateway: AgentGateway,
         conversation_id: str | None = None,
+        career_profile_principal: str | None = None,
     ) -> None:
         if isinstance(store, JobOsStateStore):
             conversation_id = conversation_id or store.first_active_conversation_id()
@@ -101,6 +103,7 @@ class ConversationService:
         self.conversation_id = conversation_id or store.conversation_id
         self.store = store
         self.gateway = gateway
+        self.career_profile_principal = career_profile_principal
         self._event_task: asyncio.Task[None] | None = None
         self._connection_task: asyncio.Task[None] | None = None
         self._recovery_turn_id: str | None = None
@@ -266,6 +269,7 @@ class ConversationService:
             context=stored_context,
             idempotency_key=command.idempotency_key,
             actor_id=actor_id,
+            career_profile_principal=self.career_profile_principal,
         )
         turn = self.store.turn_record(str(created["turn_id"]))
         if turn and turn["status"] == "running" and created["created"] is True:
@@ -296,6 +300,7 @@ class ConversationService:
             source_turn_id=turn_id,
             idempotency_key=command.idempotency_key,
             actor_id=actor_id,
+            career_profile_principal=self.career_profile_principal,
         )
         turn = self.store.turn_record(str(created["turn_id"]))
         if turn and created["created"] is True:
@@ -377,6 +382,23 @@ class ConversationService:
             prior_stored_id = self.store.stored_session_id()
             context = turn["context"]
             assert isinstance(context, dict)
+            career_profile = None
+            if self.career_profile_principal is not None:
+                snapshot = self.store.bound_career_profile_snapshot(
+                    turn_id, principal=self.career_profile_principal
+                )
+                career_profile = {
+                    "snapshot_id": snapshot.snapshot_id,
+                    "profile_revision": snapshot.profile_revision,
+                    "content_hash": snapshot.content_hash,
+                    "projection": {
+                        "work_arrangement": (
+                            snapshot.projection.work_arrangement.value.model_dump(mode="json")
+                            if snapshot.projection.work_arrangement is not None
+                            else None
+                        )
+                    },
+                }
             requested_session_id = (
                 None if context.get(FRESH_AGENT_SESSION_CONTEXT_KEY) is True else prior_stored_id
             )
@@ -419,6 +441,7 @@ class ConversationService:
                             if isinstance(selected_job, dict)
                             else None
                         ),
+                        career_profile=career_profile,
                     ),
                 )
         except Exception as error:
@@ -478,6 +501,7 @@ class ConversationService:
                         summary=event.summary,
                         detail={**event.detail, "activity_id": event.activity_id},
                         source_event_id=event.source_event_id,
+                        career_profile_principal=self.career_profile_principal,
                     )
                 continue
             is_terminal = bool(
@@ -498,6 +522,11 @@ class ConversationService:
                 if won:
                     self._restore_session_after_isolated_turn(str(turn_id))
                 continue
+            continuation_ids = (
+                tuple(_continuation_ids(event.detail))
+                if turn_id and event.event_type == "activity"
+                else ()
+            )
             event_id = self.store.append_conversation_event(
                 turn_id=turn_id,
                 event_type=event.event_type,
@@ -505,6 +534,7 @@ class ConversationService:
                 summary=event.summary,
                 detail={**event.detail, "activity_id": event.activity_id},
                 source_event_id=event.source_event_id,
+                continuation_ids=continuation_ids,
             )
             if (
                 event_id is not None
@@ -567,6 +597,25 @@ class ConversationService:
                 except Exception:
                     logger.exception("Unable to persist agent event consumer quarantine")
                 await asyncio.sleep(self._event_consumer_restart_delay)
+
+
+def _continuation_ids(value: object) -> set[str]:
+    """Extract only explicit Hermes continuation identifiers from a tool result."""
+    found: set[str] = set()
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if (
+                key in {"continuation_id", "delegation_id"}
+                and isinstance(item, str)
+                and re.fullmatch(r"[A-Za-z0-9_-]{8,200}", item)
+            ):
+                found.add(item)
+            else:
+                found.update(_continuation_ids(item))
+    elif isinstance(value, list):
+        for item in value:
+            found.update(_continuation_ids(item))
+    return found
 
 
 def encode_sse(entry: dict[str, object]) -> str:

--- a/services/api/jobos_api/hermes_adapter.py
+++ b/services/api/jobos_api/hermes_adapter.py
@@ -62,10 +62,51 @@ def _bounded_prompt_context(context: dict[str, object]) -> dict[str, object]:
         if isinstance(zoom, (int, float)) and not isinstance(zoom, bool) and 0.5 <= zoom <= 3:
             workspace["active_artifact_zoom"] = zoom
 
+    career_profile = None
+    raw_profile = context.get("career_profile")
+    if isinstance(raw_profile, dict):
+        snapshot_id = _bounded_reference(raw_profile.get("snapshot_id"), 200)
+        revision = raw_profile.get("profile_revision")
+        content_hash = raw_profile.get("content_hash")
+        projection = raw_profile.get("projection")
+        if (
+            snapshot_id
+            and isinstance(revision, int)
+            and not isinstance(revision, bool)
+            and revision >= 0
+            and isinstance(content_hash, str)
+            and re.fullmatch(r"[a-f0-9]{64}", content_hash)
+            and isinstance(projection, dict)
+        ):
+            work_arrangement = None
+            raw_arrangement = projection.get("work_arrangement")
+            if isinstance(raw_arrangement, dict):
+                mode = raw_arrangement.get("mode")
+                strength = raw_arrangement.get("strength")
+                note = _bounded_reference(raw_arrangement.get("note"), 1000)
+                if mode in {"remote", "hybrid", "onsite", "flexible"} and strength in {
+                    "requirement",
+                    "strong_preference",
+                    "preference",
+                    "dealbreaker",
+                }:
+                    work_arrangement = {
+                        "mode": mode,
+                        "strength": strength,
+                        "note": note,
+                    }
+            career_profile = {
+                "snapshot_id": snapshot_id,
+                "profile_revision": revision,
+                "content_hash": content_hash,
+                "projection": {"work_arrangement": work_arrangement},
+            }
+
     return {
         "selected_job_id": selected_job_id,
         "selected_job": selected_job,
         "workspace": workspace,
+        "career_profile": career_profile,
     }
 
 
@@ -157,6 +198,10 @@ class HermesWebSocketGateway:
         self._attaching_session = False
         self._pending_session_info: dict[str, tuple[bool, GatewayEvent | None]] = {}
         self._pending_continuation_frames: list[dict[str, object]] = []
+        self._pending_async_continuation_id: str | None = None
+        self._pending_async_continuation_stage: str | None = None
+        self._pending_async_continuation_blocking_turn_id: str | None = None
+        self._pending_async_continuation_start_count = 0
         self._activity = ActivityNormalizer()
         self._closed = False
         self._start_lock = asyncio.Lock()
@@ -331,6 +376,7 @@ class HermesWebSocketGateway:
         self._attaching_session = True
         self._pending_session_info.clear()
         self._pending_continuation_frames = []
+        self._clear_pending_async_continuation()
 
     def _reset_live_session(self) -> None:
         if self._session_isolation_state == "unverified":
@@ -342,6 +388,13 @@ class HermesWebSocketGateway:
         self._attaching_session = False
         self._pending_session_info.clear()
         self._pending_continuation_frames = []
+        self._clear_pending_async_continuation()
+
+    def _clear_pending_async_continuation(self) -> None:
+        self._pending_async_continuation_id = None
+        self._pending_async_continuation_stage = None
+        self._pending_async_continuation_blocking_turn_id = None
+        self._pending_async_continuation_start_count = 0
 
     def _record_session_verification(self, verified: bool) -> None:
         if self._session_isolation_state in {"failed", "verified"}:
@@ -400,11 +453,13 @@ class HermesWebSocketGateway:
         if not self._live_session_id:
             raise RuntimeError("Hermes session is not attached")
         await self._require_session_verification()
+        self._clear_pending_async_continuation()
         self._active_turn_id = context.turn_id
         bounded_context = {
             "selected_job_id": context.selected_job_id,
             "selected_job": context.selected_job,
             "workspace": context.workspace,
+            "career_profile": context.career_profile,
         }
         prompt = _prompt_with_context(text, bounded_context, context.conversation_id)
         try:
@@ -634,19 +689,74 @@ class HermesWebSocketGateway:
         }
         if frame_type not in supported_types:
             return None
+        if frame_type == "status.update" and frame.get("kind") == "process":
+            marker = re.match(
+                r"^\[ASYNC DELEGATION(?: BATCH)? COMPLETE — ([A-Za-z0-9_-]{8,200})\](?:\n|$)",
+                str(frame.get("text") or ""),
+            )
+            if marker is not None:
+                # Hermes emits this trusted process-status frame before it
+                # attempts the synthetic completion turn. The attempt can be
+                # requeued behind an active user turn, so only arm the identity
+                # until the exact metadata-free message.start arrives.
+                self._clear_pending_async_continuation()
+                self._pending_async_continuation_id = marker.group(1)
+                self._pending_async_continuation_stage = "awaiting_start"
+                self._pending_async_continuation_blocking_turn_id = self._active_turn_id
+                return None
         continuation_id = frame.get("continuation_id")
-        if frame.get("display_kind") == "async_delegation_complete":
+        is_explicit_continuation = frame.get("display_kind") == "async_delegation_complete"
+        if self._pending_async_continuation_id is not None:
+            is_metadata_free_start = frame_type == "message.start" and set(frame) <= {
+                "type",
+                "session_id",
+            }
+            blocking_turn_is_active = (
+                self._pending_async_continuation_blocking_turn_id is not None
+                and self._active_turn_id
+                == self._pending_async_continuation_blocking_turn_id
+            )
+            if self._pending_async_continuation_stage == "awaiting_start":
+                if not blocking_turn_is_active and is_metadata_free_start:
+                    self._pending_async_continuation_stage = "awaiting_terminal"
+                    self._pending_async_continuation_start_count = 1
+                    return None
+                # Hermes emits the marker before checking whether the session is
+                # busy. Preserve it while the already-running JobOS turn settles;
+                # that turn's frames continue through ordinary normalization.
+            elif self._pending_async_continuation_stage == "awaiting_terminal":
+                if is_metadata_free_start:
+                    if self._pending_async_continuation_start_count < 2:
+                        self._pending_async_continuation_start_count += 1
+                        return None
+                    self._clear_pending_async_continuation()
+                else:
+                    is_metadata_free_terminal = (
+                        frame_type in {"message.complete", "error"}
+                        and frame.get("display_kind") is None
+                        and frame.get("continuation_id") is None
+                    )
+                    if is_metadata_free_terminal:
+                        continuation_id = self._pending_async_continuation_id
+                        is_explicit_continuation = True
+                    elif frame_type in {"message.start", "message.complete", "error"}:
+                        self._clear_pending_async_continuation()
+            else:
+                self._clear_pending_async_continuation()
+        if is_explicit_continuation:
             if not isinstance(continuation_id, str) or not re.fullmatch(
                 r"[A-Za-z0-9_-]{8,200}", continuation_id
             ):
                 return None
             if frame_type not in {"message.complete", "error"}:
                 return None
+            self._clear_pending_async_continuation()
             continuation_digest = hashlib.sha256(continuation_id.encode()).hexdigest()[:32]
             turn_id = f"turn_cont_{continuation_digest}"
             source_event_id = f"async_delegation:{continuation_digest}:terminal"
             safe_detail = redact_detail(frame)
             safe_detail["agent_continuation"] = True
+            safe_detail["continuation_id"] = continuation_id
             if frame_type == "error":
                 return GatewayEvent(
                     event_type="error",

--- a/services/api/jobos_api/state_store.py
+++ b/services/api/jobos_api/state_store.py
@@ -977,6 +977,28 @@ MIGRATIONS = (
             """,
         ),
     ),
+    Migration(
+        version=21,
+        statements=(
+            "ALTER TABLE conversation_turns ADD COLUMN career_profile_snapshot_id TEXT",
+            """ALTER TABLE conversation_turns
+               ADD COLUMN career_profile_revision INTEGER
+               CHECK (career_profile_revision >= 0)""",
+            "ALTER TABLE conversation_turns ADD COLUMN career_profile_content_hash TEXT",
+            """CREATE INDEX conversation_turns_career_profile_snapshot
+               ON conversation_turns(career_profile_snapshot_id)
+               WHERE career_profile_snapshot_id IS NOT NULL""",
+            """CREATE TABLE conversation_continuation_bindings (
+                conversation_id TEXT NOT NULL,
+                continuation_digest TEXT NOT NULL,
+                source_turn_id TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (conversation_id, continuation_digest),
+                FOREIGN KEY (conversation_id) REFERENCES conversations(conversation_id),
+                FOREIGN KEY (source_turn_id) REFERENCES conversation_turns(turn_id)
+            )""",
+        ),
+    ),
 )
 SCHEMA_VERSION = MIGRATIONS[-1].version
 

--- a/services/api/tests/test_career_profile_turn_binding.py
+++ b/services/api/tests/test_career_profile_turn_binding.py
@@ -1,0 +1,375 @@
+import asyncio
+import json
+import sqlite3
+
+import pytest
+from jobos_api.agent_gateway import AgentContext
+from jobos_api.career_profile import (
+    CareerProfileSnapshotForbidden,
+    CareerProfileSnapshotIntegrityError,
+    CareerProfileStore,
+    WorkArrangementMutation,
+    WorkArrangementValue,
+    principal_for_device,
+)
+from jobos_api.conversations import (
+    ConversationService,
+    RetryTurnRequest,
+    SendMessageRequest,
+)
+from jobos_api.state_store import JobOsStateStore
+
+
+class CapturingGateway:
+    def __init__(self) -> None:
+        self.submissions: list[tuple[str, AgentContext]] = []
+
+    @property
+    def connection_state(self):
+        return "online"
+
+    async def start(self):
+        return None
+
+    async def create_or_resume_conversation(self, stored_session_id):
+        return "stored-session", "live-session"
+
+    async def submit_turn(self, text, context):
+        self.submissions.append((text, context))
+
+    async def stream_events(self):
+        if False:
+            yield
+
+    async def detach_conversation(self):
+        return None
+
+    async def interrupt_turn(self, turn_id):
+        return None
+
+    async def recover_active_turn(self, stored_session_id, turn_id):
+        return None
+
+    async def close(self):
+        return None
+
+
+def configured_service(tmp_path):
+    database = tmp_path / "jobos.db"
+    state = JobOsStateStore(database)
+    state.initialize(owner_device_id="device-a")
+    profile = CareerProfileStore(database)
+    profile.initialize()
+    principal = principal_for_device("device-a")
+    gateway = CapturingGateway()
+    conversation_id = state.first_active_conversation_id("device-a")
+    service = ConversationService(
+        state.conversation_store(conversation_id),
+        gateway,
+        conversation_id,
+        career_profile_principal=principal,
+    )
+    return database, profile, service, gateway, principal
+
+
+def set_arrangement(profile, principal, *, revision, mode, key):
+    return profile.set_work_arrangement(
+        principal=principal,
+        command=WorkArrangementMutation(
+            expected_profile_revision=revision,
+            idempotency_key=key,
+            value=WorkArrangementValue(
+                mode=mode, strength="strong_preference", note=f"Prefer {mode}"
+            ),
+        ),
+    )
+
+
+def test_new_turn_binds_latest_snapshot_and_retry_keeps_original(tmp_path):
+    async def scenario():
+        database, profile, service, gateway, principal = configured_service(tmp_path)
+        set_arrangement(profile, principal, revision=0, mode="remote", key="set-remote-0001")
+
+        first = await service.send(
+            SendMessageRequest(text="Find roles", idempotency_key="send-profile-0001"),
+            actor_id="device-a",
+            context={"selected_job_id": None, "workspace": {}},
+        )
+        first_context = gateway.submissions[-1][1].career_profile
+        assert first_context is not None
+        assert first_context["profile_revision"] == 1
+        first_projection = first_context["projection"]
+        assert isinstance(first_projection, dict)
+        first_arrangement = first_projection["work_arrangement"]
+        assert isinstance(first_arrangement, dict)
+        assert first_arrangement["mode"] == "remote"
+
+        service.store.update_turn_status(first.turn_id, "failed")
+        set_arrangement(profile, principal, revision=1, mode="hybrid", key="set-hybrid-0002")
+        retry = await service.retry(
+            first.turn_id,
+            RetryTurnRequest(idempotency_key="retry-profile-0001"),
+            actor_id="device-a",
+        )
+        assert retry is not None
+        retry_context = gateway.submissions[-1][1].career_profile
+        assert retry_context == first_context
+
+        service.store.update_turn_status(retry.turn_id, "completed")
+        await service.send(
+            SendMessageRequest(text="Find more", idempotency_key="send-profile-0002"),
+            actor_id="device-a",
+            context={"selected_job_id": None, "workspace": {}},
+        )
+        latest_context = gateway.submissions[-1][1].career_profile
+        assert latest_context is not None
+        assert latest_context["profile_revision"] == 2
+        latest_projection = latest_context["projection"]
+        assert isinstance(latest_projection, dict)
+        latest_arrangement = latest_projection["work_arrangement"]
+        assert isinstance(latest_arrangement, dict)
+        assert latest_arrangement["mode"] == "hybrid"
+
+        with sqlite3.connect(database) as connection:
+            turn_payloads = "\n".join(
+                row[0] for row in connection.execute("SELECT detail_json FROM conversation_events")
+            )
+            audit_payloads = "\n".join(
+                row[0]
+                for row in connection.execute(
+                    "SELECT affected_fields_json FROM career_profile_audit_events"
+                )
+            )
+        assert "Prefer remote" not in turn_payloads
+        assert "Prefer hybrid" not in turn_payloads
+        assert "Prefer remote" not in audit_payloads
+        assert "Prefer hybrid" not in audit_payloads
+
+    asyncio.run(scenario())
+
+
+def test_missing_or_tampered_bound_snapshot_fails_closed(tmp_path):
+    async def scenario():
+        database, profile, service, gateway, principal = configured_service(tmp_path)
+        set_arrangement(profile, principal, revision=0, mode="remote", key="set-remote-0003")
+        created = service.store.create_turn(
+            text="Do not dispatch stale context",
+            context={},
+            idempotency_key="tampered-profile-turn",
+            actor_id="device-a",
+            career_profile_principal=principal,
+        )
+        with sqlite3.connect(database) as connection:
+            connection.execute(
+                """
+                UPDATE career_profile_snapshots SET projection_json = ?
+                WHERE snapshot_id = (
+                    SELECT career_profile_snapshot_id FROM conversation_turns WHERE turn_id = ?
+                )
+                """,
+                (json.dumps({"work_arrangement": None}), created["turn_id"]),
+            )
+        with pytest.raises(CareerProfileSnapshotIntegrityError):
+            service.store.bound_career_profile_snapshot(
+                str(created["turn_id"]), principal=principal
+            )
+        turn = service.store.turn_record(str(created["turn_id"]))
+        assert turn is not None
+        await service._dispatch(turn)
+        assert gateway.submissions == []
+        settled = service.store.turn_record(str(created["turn_id"]))
+        assert settled is not None
+        assert settled["status"] == "failed"
+
+    asyncio.run(scenario())
+
+
+def test_background_continuation_keeps_spawning_turn_binding(tmp_path):
+    database, profile, service, _gateway, principal = configured_service(tmp_path)
+    set_arrangement(profile, principal, revision=0, mode="remote", key="set-remote-0004")
+    first = service.store.create_turn(
+        text="Spawn background work",
+        context={},
+        idempotency_key="continuation-source-a",
+        actor_id="device-a",
+        career_profile_principal=principal,
+    )
+    service.store.append_conversation_event(
+        turn_id=str(first["turn_id"]),
+        event_type="activity",
+        state="working",
+        summary="Delegated background work",
+        detail={"activity_id": "delegate-activity-0001"},
+        source_event_id="source-delegate-activity-0001",
+        continuation_ids=("delegation-binding-0001",),
+    )
+    service.store.update_turn_status(str(first["turn_id"]), "completed")
+
+    set_arrangement(profile, principal, revision=1, mode="hybrid", key="set-hybrid-0004")
+    second = service.store.create_turn(
+        text="A genuinely new turn",
+        context={},
+        idempotency_key="continuation-source-b",
+        actor_id="device-a",
+        career_profile_principal=principal,
+    )
+    service.store.update_turn_status(str(second["turn_id"]), "completed")
+    reopened = ConversationService(
+        service.store,
+        service.gateway,
+        service.conversation_id,
+        career_profile_principal=principal,
+    )
+    assert reopened.store.record_agent_continuation(
+        turn_id="turn_continuation_binding_0001",
+        status="completed",
+        event_type="assistant_message",
+        summary="Background work finished",
+        detail={
+            "agent_continuation": True,
+            "continuation_id": "delegation-binding-0001",
+        },
+        career_profile_principal=principal,
+    )
+
+    with sqlite3.connect(database) as connection:
+        source_binding = connection.execute(
+            """SELECT career_profile_snapshot_id, career_profile_revision,
+                      career_profile_content_hash
+               FROM conversation_turns WHERE turn_id = ?""",
+            (first["turn_id"],),
+        ).fetchone()
+        continuation_binding = connection.execute(
+            """SELECT career_profile_snapshot_id, career_profile_revision,
+                      career_profile_content_hash
+               FROM conversation_turns WHERE turn_id = 'turn_continuation_binding_0001'"""
+        ).fetchone()
+    assert continuation_binding == source_binding
+    assert continuation_binding is not None
+    assert continuation_binding[1] == 1
+
+
+def test_background_continuation_without_durable_binding_fails_closed(tmp_path):
+    database, profile, service, _gateway, principal = configured_service(tmp_path)
+    set_arrangement(profile, principal, revision=0, mode="remote", key="set-remote-0005")
+
+    assert not service.store.record_agent_continuation(
+        turn_id="turn_unbound_continuation_0001",
+        status="completed",
+        event_type="assistant_message",
+        summary="Untrusted background result",
+        detail={
+            "agent_continuation": True,
+            "continuation_id": "unknown-continuation-0001",
+        },
+        career_profile_principal=principal,
+    )
+    with sqlite3.connect(database) as connection:
+        assert connection.execute(
+            "SELECT 1 FROM conversation_turns WHERE turn_id = ?",
+            ("turn_unbound_continuation_0001",),
+        ).fetchone() is None
+
+
+def test_background_continuation_rejects_unauthorized_source_snapshot(tmp_path):
+    database, profile, service, _gateway, principal = configured_service(tmp_path)
+    set_arrangement(profile, principal, revision=0, mode="remote", key="set-remote-0007")
+    source = service.store.create_turn(
+        text="Owner-only background work",
+        context={},
+        idempotency_key="continuation-owner-source",
+        actor_id="device-a",
+        career_profile_principal=principal,
+    )
+    service.store.append_conversation_event(
+        turn_id=str(source["turn_id"]),
+        event_type="activity",
+        state="working",
+        summary="Delegated background work",
+        detail={"activity_id": "delegate-activity-owner"},
+        continuation_ids=("delegation-owner-binding",),
+    )
+
+    with pytest.raises(CareerProfileSnapshotForbidden):
+        service.store.record_agent_continuation(
+            turn_id="turn_unauthorized_continuation_0001",
+            status="completed",
+            event_type="assistant_message",
+            summary="Background result",
+            detail={
+                "agent_continuation": True,
+                "continuation_id": "delegation-owner-binding",
+            },
+            career_profile_principal=principal_for_device("device-b"),
+        )
+    with sqlite3.connect(database) as connection:
+        assert connection.execute(
+            "SELECT 1 FROM conversation_turns WHERE turn_id = ?",
+            ("turn_unauthorized_continuation_0001",),
+        ).fetchone() is None
+
+
+def test_retry_after_service_restart_keeps_original_and_fresh_session_gets_latest(tmp_path):
+    async def scenario():
+        _database, profile, service, gateway, principal = configured_service(tmp_path)
+        set_arrangement(profile, principal, revision=0, mode="remote", key="set-remote-0006")
+        original = await service.send(
+            SendMessageRequest(text="Long-running work", idempotency_key="restart-source-0001"),
+            actor_id="device-a",
+            context={},
+        )
+        original_context = gateway.submissions[-1][1].career_profile
+        service.store.update_turn_status(original.turn_id, "interrupted")
+        set_arrangement(profile, principal, revision=1, mode="hybrid", key="set-hybrid-0006")
+
+        restarted_gateway = CapturingGateway()
+        restarted = ConversationService(
+            service.store,
+            restarted_gateway,
+            service.conversation_id,
+            career_profile_principal=principal,
+        )
+        retry = await restarted.retry(
+            original.turn_id,
+            RetryTurnRequest(idempotency_key="restart-retry-0001"),
+            actor_id="device-a",
+        )
+        assert retry is not None
+        assert restarted_gateway.submissions[-1][1].career_profile == original_context
+
+        restarted.store.update_turn_status(retry.turn_id, "completed")
+        await restarted.send(
+            SendMessageRequest(
+                text="Fresh isolated work",
+                idempotency_key="browser-save-fresh-profile-0001",
+            ),
+            actor_id="device-a",
+            context={},
+        )
+        fresh_context = restarted_gateway.submissions[-1][1].career_profile
+        assert fresh_context is not None
+        assert fresh_context["profile_revision"] == 2
+        fresh_projection = fresh_context["projection"]
+        assert isinstance(fresh_projection, dict)
+        fresh_arrangement = fresh_projection["work_arrangement"]
+        assert isinstance(fresh_arrangement, dict)
+        assert fresh_arrangement["mode"] == "hybrid"
+
+    asyncio.run(scenario())
+
+
+def test_idempotent_replay_reuses_turn_and_snapshot(tmp_path):
+    async def scenario():
+        database, profile, service, gateway, principal = configured_service(tmp_path)
+        set_arrangement(profile, principal, revision=0, mode="onsite", key="set-onsite-0001")
+        command = SendMessageRequest(text="One turn", idempotency_key="same-turn-profile")
+        first = await service.send(command, actor_id="device-a", context={})
+        replay = await service.send(command, actor_id="device-a", context={})
+        assert replay.turn_id == first.turn_id
+        with sqlite3.connect(database) as connection:
+            count = connection.execute(
+                "SELECT COUNT(*) FROM career_profile_snapshots"
+            ).fetchone()[0]
+        assert count == 1
+
+    asyncio.run(scenario())

--- a/services/api/tests/test_health_contract.py
+++ b/services/api/tests/test_health_contract.py
@@ -54,7 +54,7 @@ def test_health_reports_truthful_public_capability_states(tmp_path):
         "status": "ready",
         "service": "jobos-api",
         "version": "0.1.0",
-        "state_schema": 20,
+        "state_schema": 21,
         "transport": "local-loopback",
         "agent": "not-configured",
         "artifact_storage": "available",

--- a/services/api/tests/test_hermes_adapter.py
+++ b/services/api/tests/test_hermes_adapter.py
@@ -4,6 +4,12 @@ from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from jobos_api.agent_gateway import AgentContext, GatewayEvent
+from jobos_api.career_profile import (
+    CareerProfileStore,
+    WorkArrangementMutation,
+    WorkArrangementValue,
+    principal_for_device,
+)
 from jobos_api.conversations import ConversationService, RetryTurnRequest, SendMessageRequest
 from jobos_api.hermes_adapter import HermesWebSocketGateway, _prompt_with_context
 from jobos_api.state_store import JobOsStateStore
@@ -262,7 +268,8 @@ def test_prompt_context_is_bounded_parseable_untrusted_reference_data():
         "\n</jobos_untrusted_context>", 1
     )[0]
     context = json.loads(serialized)
-    assert set(context) == {"selected_job_id", "selected_job", "workspace"}
+    assert set(context) == {"selected_job_id", "selected_job", "workspace", "career_profile"}
+    assert context["career_profile"] is None
     assert set(context["selected_job"]) == {"job_id", "company", "title"}
     assert set(context["workspace"]) == {
         "selected_preset",
@@ -275,6 +282,49 @@ def test_prompt_context_is_bounded_parseable_untrusted_reference_data():
     assert max(len(value) for value in context["selected_job"].values()) <= 200
     assert prompt.index("</jobos_untrusted_context>") < prompt.index("User request:")
     assert prompt.endswith("User request:\nReview the selected role")
+
+
+def test_prompt_context_exposes_only_bounded_career_profile_projection():
+    prompt = _prompt_with_context(
+        "Find a role",
+        {
+            "career_profile": {
+                "snapshot_id": "cps_snapshot_reference_1234",
+                "profile_revision": 7,
+                "content_hash": "a" * 64,
+                "projection": {
+                    "work_arrangement": {
+                        "mode": "remote",
+                        "strength": "requirement",
+                        "note": "Remote only",
+                        "unrelated": "omit me",
+                    },
+                    "evidence": {"absolute_path": "/private/sensitive"},
+                },
+                "credentials": "omit me",
+            }
+        },
+        "conv_profile_prompt",
+    )
+    serialized = prompt.split("<jobos_untrusted_context>\n", 1)[1].split(
+        "\n</jobos_untrusted_context>", 1
+    )[0]
+    profile = json.loads(serialized)["career_profile"]
+    assert profile == {
+        "snapshot_id": "cps_snapshot_reference_1234",
+        "profile_revision": 7,
+        "content_hash": "a" * 64,
+        "projection": {
+            "work_arrangement": {
+                "mode": "remote",
+                "strength": "requirement",
+                "note": "Remote only",
+            }
+        },
+    }
+    assert "record-private" not in prompt
+    assert "/private/sensitive" not in prompt
+    assert "device:private" not in prompt
 
 
 def test_prompt_rejects_unbounded_conversation_correlation():
@@ -476,29 +526,103 @@ def test_service_records_late_continuation_without_disturbing_active_user_turn(t
             connector=FakeConnector(socket),
         )
         store = JobOsStateStore(tmp_path / "jobos.db")
-        store.initialize()
+        store.initialize(owner_device_id="device-a")
+        profile = CareerProfileStore(tmp_path / "jobos.db")
+        profile.initialize()
+        principal = principal_for_device("device-a")
+        profile.set_work_arrangement(
+            principal=principal,
+            command=WorkArrangementMutation(
+                expected_profile_revision=0,
+                idempotency_key="adapter-source-profile-0001",
+                value=WorkArrangementValue(
+                    mode="remote", strength="strong_preference", note="Source A"
+                ),
+            ),
+        )
+        conversation_id = store.first_active_conversation_id("device-a")
+        conversation = store.conversation_store(conversation_id)
         await gateway.start()
         await gateway.create_or_resume_conversation(None)
-        service = ConversationService(store, gateway)
+        service = ConversationService(
+            conversation,
+            gateway,
+            conversation_id,
+            career_profile_principal=principal,
+        )
         await service.start()
-        active = store.create_conversation_turn(
+        source = conversation.create_turn(
+            text="Spawn background work",
+            context={},
+            idempotency_key="adapter-source-turn-0001",
+            actor_id="device-a",
+            career_profile_principal=principal,
+        )
+        gateway._active_turn_id = str(source["turn_id"])
+        socket.incoming.put_nowait(
+            json.dumps(
+                event(
+                    "tool.complete",
+                    "live-1",
+                    {
+                        "event_id": "adapter-delegation-source-0001",
+                        "tool_id": "adapter-delegation-tool-0001",
+                        "name": "delegate_task",
+                        "status": "complete",
+                        "result": {"delegation_id": "delegation-service-1234"},
+                    },
+                )
+            )
+        )
+        socket.incoming.put_nowait(
+            json.dumps(
+                event(
+                    "message.complete",
+                    "live-1",
+                    {"status": "complete", "text": "Source A foreground work finished"},
+                )
+            )
+        )
+        source_record = None
+        for _ in range(50):
+            source_record = conversation.turn_record(str(source["turn_id"]))
+            if source_record is not None and source_record["status"] == "completed":
+                break
+            await asyncio.sleep(0.01)
+        assert source_record is not None
+        assert source_record["status"] == "completed"
+        profile.set_work_arrangement(
+            principal=principal,
+            command=WorkArrangementMutation(
+                expected_profile_revision=1,
+                idempotency_key="adapter-newer-profile-0001",
+                value=WorkArrangementValue(
+                    mode="hybrid", strength="strong_preference", note="Newer B"
+                ),
+            ),
+        )
+        active = conversation.create_turn(
             text="A newer follow-up",
             context={"selected_job_id": None, "workspace": {}},
             idempotency_key="active-during-late-continuation",
             actor_id="device-a",
+            career_profile_principal=principal,
         )
         gateway._active_turn_id = str(active["turn_id"])
-        snapshot = store.conversation_snapshot()
+        snapshot = conversation.snapshot()
         gateway_active_turn_id = None
         try:
             socket.incoming.put_nowait(
                 json.dumps(
                     event(
-                        "message.start",
+                        "status.update",
                         "live-1",
                         {
-                            "display_kind": "async_delegation_complete",
-                            "continuation_id": "delegation-service-1234",
+                            "kind": "process",
+                            "text": (
+                                "[ASYNC DELEGATION BATCH COMPLETE — delegation-service-1234]\n"
+                                "A background fan-out has finished."
+                            ),
                         },
                     )
                 )
@@ -508,17 +632,26 @@ def test_service_records_late_continuation_without_disturbing_active_user_turn(t
                     event(
                         "message.complete",
                         "live-1",
+                        {"status": "complete", "text": "Newer B finished first"},
+                    )
+                )
+            )
+            socket.incoming.put_nowait(json.dumps(event("message.start", "live-1")))
+            socket.incoming.put_nowait(json.dumps(event("message.start", "live-1")))
+            socket.incoming.put_nowait(
+                json.dumps(
+                    event(
+                        "message.complete",
+                        "live-1",
                         {
                             "status": "complete",
                             "text": "Background work finished",
-                            "display_kind": "async_delegation_complete",
-                            "continuation_id": "delegation-service-1234",
                         },
                     )
                 )
             )
             for _ in range(50):
-                snapshot = store.conversation_snapshot()
+                snapshot = conversation.snapshot()
                 entries = snapshot["entries"]
                 assert isinstance(entries, list)
                 if any(
@@ -550,13 +683,101 @@ def test_service_records_late_continuation_without_disturbing_active_user_turn(t
             and entry["state"] == "completed"
             for entry in typed_entries
         )
-        assert sum(entry["type"] == "user_message" for entry in typed_entries) == 1
-        active_turn = snapshot["active_turn"]
-        assert isinstance(active_turn, dict)
-        assert active_turn["turn_id"] == active["turn_id"]
-        assert gateway_active_turn_id == active["turn_id"]
+        assert sum(entry["type"] == "user_message" for entry in typed_entries) == 2
+        assert any(
+            entry["turn_id"] == active["turn_id"]
+            and entry["type"] == "assistant_message"
+            and entry["summary"] == "Newer B finished first"
+            for entry in typed_entries
+        )
+        assert snapshot["active_turn"] is None
+        assert gateway_active_turn_id is None
+        continuation_record = conversation.turn_record(continuation_id)
+        source_record = conversation.turn_record(str(source["turn_id"]))
+        assert continuation_record is not None
+        assert source_record is not None
+        assert continuation_record["career_profile_snapshot_id"] == source_record[
+            "career_profile_snapshot_id"
+        ]
+        assert continuation_record["career_profile_revision"] == 1
+        active_record = conversation.turn_record(str(active["turn_id"]))
+        assert active_record is not None
+        assert active_record["career_profile_revision"] == 2
 
     asyncio.run(scenario())
+
+
+def test_async_continuation_marker_does_not_capture_metadata_bearing_turn(tmp_path):
+    gateway = HermesWebSocketGateway(
+        url="ws://127.0.0.1:9119/api/ws", token=TOKEN, cwd=tmp_path
+    )
+    gateway._live_session_id = "live-1"
+    gateway._active_turn_id = "turn-newer-b"
+
+    marker = gateway.normalize_frame(
+        event(
+            "status.update",
+            "live-1",
+            {
+                "kind": "process",
+                "text": "[ASYNC DELEGATION COMPLETE — delegation-stale-1234]\nReady",
+            },
+        )
+    )
+    ordinary_start = gateway.normalize_frame(
+        event(
+            "message.start",
+            "live-1",
+            {"display_kind": "ordinary_assistant_message"},
+        )
+    )
+    ordinary_complete = gateway.normalize_frame(
+        event(
+            "message.complete",
+            "live-1",
+            {"status": "complete", "text": "Newer B finished"},
+        )
+    )
+
+    assert marker is None
+    assert ordinary_start is not None
+    assert ordinary_complete is not None
+    assert ordinary_complete.turn_id == "turn-newer-b"
+    assert ordinary_complete.detail.get("agent_continuation") is not True
+    assert gateway._pending_async_continuation_id == "delegation-stale-1234"
+    assert gateway._pending_async_continuation_stage == "awaiting_start"
+
+
+def test_async_continuation_marker_without_expected_start_does_not_capture_completion(tmp_path):
+    gateway = HermesWebSocketGateway(
+        url="ws://127.0.0.1:9119/api/ws", token=TOKEN, cwd=tmp_path
+    )
+    gateway._live_session_id = "live-1"
+    gateway._active_turn_id = "turn-newer-b"
+
+    gateway.normalize_frame(
+        event(
+            "status.update",
+            "live-1",
+            {
+                "kind": "process",
+                "text": "[ASYNC DELEGATION BATCH COMPLETE — delegation-requeued-1234]\nReady",
+            },
+        )
+    )
+    ordinary_complete = gateway.normalize_frame(
+        event(
+            "message.complete",
+            "live-1",
+            {"status": "complete", "text": "Newer B finished first"},
+        )
+    )
+
+    assert ordinary_complete is not None
+    assert ordinary_complete.turn_id == "turn-newer-b"
+    assert ordinary_complete.detail.get("agent_continuation") is not True
+    assert gateway._pending_async_continuation_id == "delegation-requeued-1234"
+    assert gateway._pending_async_continuation_stage == "awaiting_start"
 
 
 def test_verified_live_attachment_fast_path_preserves_state_and_rotated_id(tmp_path):

--- a/services/api/tests/test_state_store.py
+++ b/services/api/tests/test_state_store.py
@@ -143,7 +143,7 @@ def test_initialization_applies_every_migration_once(tmp_path):
     first = store.initialize()
     second = store.initialize()
 
-    assert first.schema_version == SCHEMA_VERSION == 20
+    assert first.schema_version == SCHEMA_VERSION == 21
     assert second.schema_version == SCHEMA_VERSION
     assert applied_versions(database) == [
         1,
@@ -166,6 +166,7 @@ def test_initialization_applies_every_migration_once(tmp_path):
         18,
         19,
         20,
+        21,
     ]
     assert metadata_columns(database) == {"key", "value", "updated_at"}
 
@@ -224,6 +225,7 @@ def test_initialization_upgrades_a_behind_database(tmp_path):
         18,
         19,
         20,
+        21,
     ]
     assert metadata_columns(database) == {"key", "value", "updated_at"}
 
@@ -321,7 +323,7 @@ def test_migration_15_reconciles_dirty_v14_publications_deterministically(tmp_pa
             (document_id,),
         ).fetchone()
 
-    assert health.schema_version == 20
+    assert health.schema_version == 21
     assert associated == [
         ("art_old_pdf_1234567", "application/pdf", "source-shared"),
         ("art_old_docx_123456", docx_media, "source-shared"),
@@ -435,7 +437,7 @@ def test_migration_15_preserves_valid_owner_and_clears_mixed_wrong_owner_pointer
             (document_id,),
         ).fetchall()
 
-    assert health.schema_version == 20
+    assert health.schema_version == 21
     assert owner_state == (
         "art_owner_pdf_123456",
         "art_owner_pdf_123456",
@@ -623,7 +625,7 @@ def test_migration_15_detaches_every_malformed_v14_publication_and_allows_republ
             connection=connection,
         )
 
-    assert health.schema_version == 20
+    assert health.schema_version == 21
     assert detached == sorted((row[0],) for row in legacy_rows)
     assert state == (None, None, None, None)
     assert published == (None,)
@@ -692,7 +694,7 @@ def test_document_identity_migration_clears_legacy_docx_approval(tmp_path):
 @pytest.mark.parametrize(
     "versions",
     (
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
         [2],
     ),
 )


### PR DESCRIPTION
## What changed

- atomically freezes the latest authorized Career Profile snapshot when a new user turn is created
- persists the snapshot ID, revision, and content hash on the turn before agent dispatch
- sends only the bounded work-arrangement projection and immutable snapshot identity to Hermes
- keeps retries and resumed work bound to the originating snapshot instead of silently upgrading to a newer profile
- durably binds asynchronous continuation/delegation IDs to their source turns, including Hermes’ real metadata-free terminal wire sequence, so late continuations retain the original profile context
- rejects missing, unauthorized, or tampered snapshots before gateway submission
- keeps Career Profile values out of conversation events and audit details
- advances the SQLite schema to version 21 with turn-binding columns and durable continuation bindings

## Product result

A JobOS agent turn now uses one frozen version of the user’s Career Profile from start to finish. If the user changes their profile while work is running, the existing turn stays internally consistent and the next new turn receives the update.

## Verification

- focused Career Profile turn-binding, adapter, state-store, and health tests — passed
- focused Ruff checks — passed
- `pnpm contracts:check` — passed
- `pnpm check` — passed on canonical rerun
  - desktop: 474 passed
  - API: 699 passed, 4 skipped
  - updater: 10 passed
  - lint, type checks, public-tree checks, license checks, production build, and packaged-renderer verification passed
- `git diff --cached --check` — passed
- exact staged candidate SHA-256: `97194d7bc04ccb0e23e879977598713d9a04893cd848fc6fcae3aecdfc9ff7d2`

No production runtime, live profile, migration cutover, or installed JobOS instance was changed.

Closes #52
