### PR TITLE
feat: complete approved Career Profile authority cutover

### DIFF
--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.tsx
@@ -1379,7 +1379,7 @@ function RestoreDialog({ bridge, hasActiveTurn, onClose, onRestored, online, pro
     <Dialog label="Restore Career Profile baseline" onClose={onClose}>
       <DialogHeading closeLabel="Close restore" eyebrow="High-impact profile change" onClose={onClose} title="Restore Career Profile baseline" />
       <div className="career-product-dialog-body">
-        <div className="career-restore-warning"><ArchiveRestore aria-hidden="true" size={20} /><div><strong>This creates a new baseline.</strong><span>The archive’s current state replaces the staging profile. The old timeline is not restored or mixed into it.</span></div></div>
+        <div className="career-restore-warning"><ArchiveRestore aria-hidden="true" size={20} /><div><strong>This creates a new baseline.</strong><span>The archive’s current state replaces the current Career Profile. The old timeline is not restored or mixed into it.</span></div></div>
         {hasActiveTurn ? <p className="career-feedback error" role="alert">Finish or stop the active agent turn before restoring the Career Profile.</p> : null}
         <button className="career-secondary-button" disabled={!online || hasActiveTurn || status === 'choosing' || status === 'restoring'} onClick={() => { void choose() }} type="button">{status === 'choosing' ? 'Choosing…' : 'Choose archive'}</button>
         {archive ? <div className="career-archive-selection"><FileCheck2 aria-hidden="true" size={18} /><div><strong>{archive.filename}</strong><span>{formatBytes(archive.byteCount)}</span></div></div> : null}

--- a/apps/desktop/src/renderer/components/CareerProfileWorkspace.test.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileWorkspace.test.tsx
@@ -88,6 +88,9 @@ test('explains the saved preference in normal language without exposing plumbing
   render(<CareerProfileWorkspace bridge={bridge()} hasActiveTurn={false} />)
 
   expect(await screen.findByRole('heading', { name: 'Work arrangement' })).not.toBeNull()
+  expect(screen.getAllByText('JobOS Career Profile').length).toBeGreaterThan(0)
+  expect(screen.getByText('This is the shared context JobOS and connected agents use.')).not.toBeNull()
+  expect(screen.queryByText(/staging profile/i)).toBeNull()
   expect(screen.getByText(/Only show roles that support remote work/i)).not.toBeNull()
   expect(screen.getByText(/A fully onsite role would be filtered out/i)).not.toBeNull()
   expect(screen.queryByText(/search_preferences|namespace|JSON|weight/i)).toBeNull()
@@ -342,7 +345,10 @@ test('keeps empty and failure states actionable', async () => {
     .mockResolvedValueOnce({ profileRevision: 0, record: null })
   render(<CareerProfileWorkspace bridge={bridge({ getWorkArrangement: retry })} hasActiveTurn={false} />)
 
-  expect((await screen.findByRole('alert')).textContent).toContain('Career Profile is unavailable right now')
+  const alert = await screen.findByRole('alert')
+  expect(alert.textContent).toContain('Career Profile is unavailable right now')
+  expect(alert.textContent).toContain('Check the JobOS service connection and try again.')
+  expect(alert.textContent).not.toMatch(/staging/i)
   fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
   expect(await screen.findByText('Tell JobOS where you want to work')).not.toBeNull()
 })

--- a/apps/desktop/src/renderer/components/CareerProfileWorkspace.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileWorkspace.tsx
@@ -254,7 +254,7 @@ export function CareerProfileWorkspace({ active = true, bridge = window.jobos.ca
         <section className="career-state-card" role="alert">
           <Sparkles aria-hidden="true" size={22} />
           <h1>Career Profile is unavailable right now</h1>
-          <p>Your existing JobOS work is safe. Reconnect to the staging service and try again.</p>
+          <p>Your existing JobOS work is safe. Check the JobOS service connection and try again.</p>
           <button className="career-secondary-button" onClick={() => { void profile.load() }} type="button">Try again</button>
         </section>
       </main>
@@ -299,11 +299,11 @@ export function CareerProfileWorkspace({ active = true, bridge = window.jobos.ca
           <button aria-current={activeArea === 'what_im_looking_for' ? 'page' : undefined} className={`career-nav-item ${activeArea === 'what_im_looking_for' ? 'active' : ''}`} onClick={() => setActiveArea('what_im_looking_for')} type="button"><MapPin aria-hidden="true" size={17} /><span><strong>What I’m Looking For</strong><small>{lookingCount} preference{lookingCount === 1 ? '' : 's'}</small></span></button>
           <button aria-current={activeArea === 'my_evidence' ? 'page' : undefined} className={`career-nav-item ${activeArea === 'my_evidence' ? 'active' : ''}`} onClick={() => setActiveArea('my_evidence')} type="button"><Sparkles aria-hidden="true" size={17} /><span><strong>My Evidence</strong><small>{evidenceCount} source{evidenceCount === 1 ? '' : 's'}</small></span></button>
         </nav>
-        <div className="career-staging-note"><span>(FAKE) staging profile</span><p>This preview does not replace your live career context.</p></div>
+        <div className="career-staging-note"><span>JobOS Career Profile</span><p>This is the shared context JobOS and connected agents use.</p></div>
       </aside>
 
       <section className="career-profile-main">
-        <span className="career-mobile-staging">(FAKE) staging profile</span>
+        <span className="career-mobile-staging">JobOS Career Profile</span>
         <label className="career-mobile-nav">
           <span>Profile section</span>
           <select aria-label="Career Profile section" onChange={event => setActiveArea(event.target.value as CareerProfileArea)} value={activeArea}>

--- a/docs/acceptance/career-profile-live-cutover/README.md
+++ b/docs/acceptance/career-profile-live-cutover/README.md
@@ -1,0 +1,81 @@
+# Career Profile live cutover acceptance
+
+This is sanitized Issue #58 evidence. It contains counts, checksums, release identifiers, and verification outcomes only. Real profile values, credentials, migration inputs, exports, and screenshots remain outside the repository.
+
+## Approval and recovery boundary
+
+Cobi explicitly approved the live handoff in this conversation: **“i approve. back up jobhunters workspace to github first before the cutover”**. The approval preceded the verified GitHub backup commit created at `2026-08-22T11:53:04-05:00` and all live migration actions.
+
+Accepted limitation: authority rollback was not rehearsed. The pre-cutover JobOS database and legacy JobHunter source commit are recovery inputs, not active co-authorities. Local Career Profile erasure cannot erase the separate GitHub backup.
+
+## Pre-cutover recovery inputs
+
+- Private JobHunter GitHub backup: verified before cutover
+- Backup branch: `backup/pre-career-profile-cutover-20260822-112848`
+- Backup commit: `287ce9997f1bbd7fd183354eca82f074106e9913`
+- Pre-cutover JobOS database SHA-256: `f79c5d714dcab470baa77579a130f859c1f89cf675b03bc81151dfb518a74cc7`
+- Private migration bundle file SHA-256: `808d5701dae875446e8a0c6c04b922cc26b5c3409e12708ff96014b1f06b2665`
+- The SQLite backup passed `quick_check`.
+
+## Atomic handoff result
+
+- JobOS authority persisted as `cutover`, profile revision `1`, authority epoch `1`.
+- Migration produced `120` accepted items, `6` reviewable Proposals, `12` managed Evidence objects, and `0` conflicts.
+- Idempotent replay created no duplicate revision, Proposal, or Evidence.
+- The required JobHunter consumer change merged at `48f891e33615181429bccb5b0b0e2fbc5e5e2d54` through private PR #3.
+- Legacy post-cutover migration failed closed with `career_profile_legacy_writer_fenced`.
+- A temporary edit to a backed-up legacy canonical source changed its source hash but did not change the persisted JobOS authority hash; the source was restored byte-for-byte.
+- API restart preserved authority, profile, Evidence, Proposals, and context state.
+
+## Installed app verification
+
+The arm64 app was packaged, installed at `/Applications/JobOS.app`, and exercised through its installed Electron window.
+
+- `codesign --verify --deep --strict` passed.
+- Installed `app.asar` SHA-256: `1e0079c3464b512fcbcef632815041747e60583802e8e33fdde7126f04683001`
+- Package ZIP SHA-256: `4c51a3713d0318332108b30900fddbf547ad8cf7b4e1d60f5180a9a9ef99468c`
+- The installed `app.asar` matched the packaged candidate exactly.
+- All three Career Profile areas rendered migrated data.
+- All six migration Proposals exposed Accept and Reject controls; none were decided during acceptance.
+- History, Agent Access, and explicit export controls rendered.
+- The installed UI identified JobOS Career Profile as shared authority and contained no stale staging or `(FAKE)` migration-reviewer copy.
+
+Private screenshots were not committed because the installed view contains real user values.
+
+## Behavioral verification
+
+Focused acceptance tests passed for:
+
+- new-turn immutable snapshot binding;
+- exact retry, recovery, and continuation reuse;
+- fail-closed unauthorized scope expansion before dispatch;
+- `none`, exact `selected`, and authorized `broader` context modes;
+- proposal review, direct edit history, and compensating Undo;
+- profile-only, selected-Evidence, and explicit all-Evidence export behavior;
+- no silent Evidence inclusion and historical unavailable-link round trips;
+- restart/readback, import, edit, Proposal, and generated-output provenance;
+- sparse, zero-Evidence, accepted Evidence-free, and inactive historical Evidence cases.
+- confirmed permanent Evidence erasure removed managed bytes, metadata, and source history;
+- complete-profile reset scrubbed profile data, Proposals, snapshots, history, vault files, context payloads, bindings, and grants;
+- partial destructive failure remained journaled and completed safely after restart;
+- restore/migration journal recovery removed or reconciled partial state before returning success.
+
+The combined focused API acceptance run passed `72` tests. Desktop verification passed `67` files / `524` tests, and updater verification passed `10` tests.
+
+The destructive-operation subset was re-exercised with:
+
+```text
+uv run pytest \
+  services/api/tests/test_career_profile_complete_model.py::test_confirmed_evidence_erasure_removes_managed_bytes_metadata_and_source_history \
+  services/api/tests/test_career_profile_complete_model.py::test_full_profile_reset_erases_profile_proposals_snapshots_history_and_all_vault_files \
+  services/api/tests/test_career_profile_complete_model.py::test_partial_erasure_failure_is_not_reported_and_restart_finishes_pending_work \
+  services/api/tests/test_career_profile_portability_hardening.py::test_restore_journals_before_staging_so_crash_recovery_removes_partial_bytes \
+  services/api/tests/test_career_profile_migration.py::test_partial_failure_is_journaled_startup_fails_closed_and_same_bundle_recovers
+```
+
+## Residual risk
+
+- Authority rollback remains a manual engineering operation and was not rehearsed.
+- The private GitHub backup is intentionally outside JobOS local-erasure control.
+- The six imported Proposals still require Cobi’s individual review; migration acceptance did not silently decide them.
+- Delivery to another workstation remains gated on the operator confirming the source-machine manual test.

--- a/services/api/jobos_api/career_profile_migration.py
+++ b/services/api/jobos_api/career_profile_migration.py
@@ -363,7 +363,7 @@ class CareerProfileMigrationService:
                     "connected_at, updated_at) VALUES (?, ?, ?, ?, 'review', 1, ?, ?)",
                     (
                         MIGRATION_REVIEW_AGENT_ID,
-                        "(FAKE) Migration reviewer",
+                        "Migration reviewer",
                         MIGRATION_PRINCIPAL,
                         sha256(b"disabled-internal-migration-review-principal").hexdigest(),
                         timestamp,

--- a/services/api/tests/test_career_profile_migration.py
+++ b/services/api/tests/test_career_profile_migration.py
@@ -132,6 +132,7 @@ def test_full_bundle_is_journaled_idempotent_and_preserves_exact_provenance(tmp_
         if proposal.after
     )
     assert any(len(proposal.evidence_ids) == 2 for proposal in proposals)
+    assert {proposal.agent_display_name for proposal in proposals} == {"Migration reviewer"}
 
     collaboration = CareerProfileCollaborationStore(migration.database, complete)
     head = report.profile_revision


### PR DESCRIPTION
## Product outcome

Completes the approved atomic Career Profile authority cutover and records sanitized acceptance evidence. JobOS is now the sole authority; legacy writers fail closed; installed UI copy reflects the live service rather than staging terminology.

## Safety and evidence

- Fresh user approval was received before live action.
- The private Job Hunter workspace was backed up to its private GitHub repository before cutover.
- Full Career Profile and Evidence authority moved together; no dual-write or compatibility copy was introduced.
- Live readback after restart confirmed authority, revision, epoch, accepted items, proposals, and Evidence.
- Idempotent replay, least-privilege projections, legacy-write refusal, installed UI, and destructive-operation guards were verified.
- No proposal was accepted or rejected during cutover.
- Public evidence is sanitized in `docs/acceptance/career-profile-live-cutover/README.md`; private values and recovery inputs remain outside this repository.

## Verification

- `pnpm check`
- `pnpm contracts:check`
- focused Career Profile workspace tests: 16 passed
- focused destructive-operation tests: 5 passed
- full desktop: 524 passed
- full Python: 841 passed, 4 skipped
- public-tree and fixture-manifest checks passed

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Career Profile messaging to use consistent JobOS branding.
  * Clarified that restoring an archive replaces the current Career Profile.
  * Improved unavailable-profile guidance to reference the JobOS service connection.
  * Removed staging and fake-profile terminology from user-visible migration information.
* **Documentation**
  * Added a sanitized acceptance record for the Career Profile live cutover.
* **Tests**
  * Expanded coverage for branding, messaging, and migration display names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->