### PR TITLE
Fix Career Profile proposal decisions after revision advances

### DIFF
--- a/apps/desktop/src/renderer/components/CareerProfileWorkspace.test.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileWorkspace.test.tsx
@@ -353,7 +353,7 @@ test('keeps empty and failure states actionable', async () => {
   expect(await screen.findByText('Tell JobOS where you want to work')).not.toBeNull()
 })
 
-test('shows an exact zero-Evidence proposal and binds approval to its revision and payload', async () => {
+test('uses the latest loaded profile revision when accepting an exact zero-Evidence proposal', async () => {
   const proposal = {
     after: {
       actorPrincipal: 'agent:job-hunter',
@@ -369,7 +369,7 @@ test('shows an exact zero-Evidence proposal and binds approval to its revision a
     },
     agentDisplayName: 'Job Hunter',
     agentId: 'job-hunter',
-    baseProfileRevision: 2,
+    baseProfileRevision: 1,
     before: {
       actorPrincipal: 'primary-device',
       area: 'my_career' as const,

--- a/apps/desktop/src/renderer/hooks/useCareerProfileCollaboration.ts
+++ b/apps/desktop/src/renderer/hooks/useCareerProfileCollaboration.ts
@@ -86,7 +86,8 @@ export function useCareerProfileCollaboration(
     decision: 'accept' | 'reject'
   ) => {
     if (!online || status === 'saving') return false
-    const signature = `proposal:${proposal.proposalId}:${decision}:${proposal.proposalSha256}:${proposal.baseProfileRevision}`
+    const expectedProfileRevision = history?.profileRevision ?? proposal.baseProfileRevision
+    const signature = `proposal:${proposal.proposalId}:${decision}:${proposal.proposalSha256}:${expectedProfileRevision}`
     const idempotencyKey = pendingKeys.current.get(signature) ?? requestId('career_proposal')
     pendingKeys.current.set(signature, idempotencyKey)
     setStatus('saving')
@@ -94,7 +95,7 @@ export function useCareerProfileCollaboration(
     try {
       await bridge.decideCareerProfileProposal(proposal.proposalId, {
         decision,
-        expectedProfileRevision: proposal.baseProfileRevision,
+        expectedProfileRevision,
         idempotencyKey,
         proposalSha256: proposal.proposalSha256
       })
@@ -113,7 +114,7 @@ export function useCareerProfileCollaboration(
       await refresh()
       return false
     }
-  }, [bridge, onProfileChanged, online, refresh, status])
+  }, [bridge, history, onProfileChanged, online, refresh, status])
 
   const undo = useCallback(async (revision: CareerProfileChangeRevision) => {
     if (!history || !online || status === 'saving') return false


### PR DESCRIPTION
Closes #85

## User impact
Users can review imported Career Profile proposals sequentially after an earlier decision advances the live profile revision.

## Approach
- Use the latest loaded profile revision as the optimistic concurrency boundary.
- Preserve the proposal's exact ID, SHA-256, and payload.
- Fall back to the proposal base revision until current history is available.

## Verification
- Regression test sabotage: confirmed the focused test fails with revision 1 submitted instead of loaded revision 2.
- `pnpm exec vitest run src/renderer/components/CareerProfileWorkspace.test.tsx` — 16 passed.
- `pnpm check` — 524 desktop tests and 844 Python tests passed; 2 Python tests skipped; lint, typecheck, public checks, and build passed.
- `pnpm contracts:check` — passed.

## Risk
Narrow renderer-only concurrency fix. No schema, API contract, profile data, or proposal payload changes. No live proposal was accepted or rejected during verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured proposal decisions use the latest available career profile revision.
  * Improved handling when the latest revision is unavailable by falling back to the proposal’s original revision.
  * Updated zero-evidence proposal acceptance behavior to reflect the current profile state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->