### PR TITLE
Render Career Profile list values in human-readable form

### DIFF
--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
@@ -186,6 +186,28 @@ test('navigates all three real areas and explains item provenance without scorin
   expect(screen.getByRole('button', { name: /Resume\.pdf/i })).not.toBeNull()
 })
 
+test('renders list-valued career details as human-readable words', async () => {
+  const targetRoles: CareerProfileItemSnapshot = {
+    ...skill,
+    area: 'what_im_looking_for',
+    itemId: 'cpi_fakeproductroles1234',
+    value: { kind: 'target_roles', roles: ['applied_ai_builder', 'internal_ai_enablement'] }
+  }
+  const api = bridge({
+    getCareerProfile: vi.fn().mockResolvedValue(savedProfile({ items: [skill, targetRoles] }))
+  })
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn={false} />)
+
+  await screen.findByRole('heading', { name: 'Work arrangement' })
+  expect(screen.getByRole('button', { name: /applied ai builder, internal ai enablement/i })).not.toBeNull()
+  expect(screen.queryByText(/applied_ai_builder|internal_ai_enablement/)).toBeNull()
+
+  fireEvent.click(screen.getByRole('button', { name: /applied ai builder, internal ai enablement/i }))
+  const detail = await screen.findByRole('dialog', { name: /applied ai builder, internal ai enablement details/i })
+  expect(within(detail).getAllByText('applied ai builder, internal ai enablement')).toHaveLength(2)
+  expect(detail.textContent).not.toMatch(/applied_ai_builder|internal_ai_enablement/)
+})
+
 test('adds a typed career detail using accessible fields rather than JSON', async () => {
   const nextSkill = { ...skill, itemId: 'cpi_fakeproductskill5678', value: { kind: 'skill', name: 'React', level: 'expert' } }
   const createCareerProfileItem = vi.fn().mockResolvedValue({

--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.tsx
@@ -291,9 +291,9 @@ function itemTitle(item: CareerProfileItemSnapshot): string {
     value.credential,
     value.label,
     value.statement,
-    Array.isArray(value.roles) ? value.roles.join(', ') : null,
-    Array.isArray(value.locations) ? value.locations.join(', ') : null,
-    Array.isArray(value.industries) ? value.industries.join(', ') : null
+    Array.isArray(value.roles) ? readableValue(value.roles) : null,
+    Array.isArray(value.locations) ? readableValue(value.locations) : null,
+    Array.isArray(value.industries) ? readableValue(value.industries) : null
   ]
   const title = candidates.find(candidate => typeof candidate === 'string' && candidate.trim())
   const kind = itemKind(item)
@@ -329,7 +329,7 @@ function readableLabel(value: string): string {
 }
 
 function readableValue(value: unknown): string {
-  if (Array.isArray(value)) return value.join(', ')
+  if (Array.isArray(value)) return value.map(item => readableValue(item)).join(', ')
   if (typeof value === 'boolean') return value ? 'Yes' : 'No'
   if (typeof value === 'number') return value.toLocaleString()
   if (value === null || value === undefined || value === '') return 'Not specified'
@@ -541,7 +541,7 @@ function importanceMeaning(value: string | undefined): string {
 
 function preferenceGuidance(kind: EditableItemKind, draft: Record<string, string>): PreferenceGuidance | null {
   if (kind === 'target_roles') {
-    const roles = draftLines(draft.roles)
+    const roles = draftLines(draft.roles).map(role => readableValue(role))
     const target = roles[0] ?? 'a role you add'
     return {
       affectedBehavior: 'Affects research, matching, and agent focus.',
@@ -562,7 +562,7 @@ function preferenceGuidance(kind: EditableItemKind, draft: Record<string, string
     }
   }
   if (kind === 'location') {
-    const locations = draftLines(draft.locations)
+    const locations = draftLines(draft.locations).map(location => readableValue(location))
     const place = locations[0] ?? 'a place you add'
     const relocation = draft.relocation === 'yes'
       ? 'You are open to relocating.'
@@ -578,7 +578,7 @@ function preferenceGuidance(kind: EditableItemKind, draft: Record<string, string
     }
   }
   if (kind === 'industries') {
-    const industries = draftLines(draft.industries)
+    const industries = draftLines(draft.industries).map(industry => readableValue(industry))
     const industry = industries[0] ?? 'an industry you add'
     return {
       affectedBehavior: 'Affects research, matching, and agent focus.',


### PR DESCRIPTION
Closes #86

## User impact
Career Profile cards, drawers, and preference guidance now show list values as ordinary words instead of raw underscore-delimited implementation values.

## Approach
- Recursively format every array item through `readableValue`.
- Use the formatter for list-backed card titles.
- Humanize target-role, location, and industry values inside interpretation and example copy.

## Verification
- Regression test failed before the fix because the only accessible card name was `applied_ai_builder, internal_ai_enablement details`.
- Focused test: 28 passed.
- `pnpm check`: 525 desktop tests and 844 Python tests passed; 2 Python tests skipped; lint, typecheck, public checks, and build passed.
- `pnpm contracts:check`: passed.

## Risk
Renderer-only formatting change. Canonical values, persisted data, schemas, API contracts, and agent context remain unchanged.