### PR TITLE
Make Career Profile success feedback transient

### DIFF
--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
@@ -163,6 +163,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   cleanup()
   window.localStorage.clear()
   vi.restoreAllMocks()
@@ -208,7 +209,7 @@ test('renders list-valued career details as human-readable words', async () => {
   expect(detail.textContent).not.toMatch(/applied_ai_builder|internal_ai_enablement/)
 })
 
-test('adds a typed career detail using accessible fields rather than JSON', async () => {
+test('adds a typed career detail and dismisses its success feedback', async () => {
   const nextSkill = { ...skill, itemId: 'cpi_fakeproductskill5678', value: { kind: 'skill', name: 'React', level: 'expert' } }
   const createCareerProfileItem = vi.fn().mockResolvedValue({
     status: 'saved',
@@ -233,6 +234,23 @@ test('adds a typed career detail using accessible fields rather than JSON', asyn
   })))
   expect(await screen.findByRole('button', { name: /React/i })).not.toBeNull()
   expect(screen.queryByText(/"kind"|JSON/i)).toBeNull()
+  expect(await screen.findByText('Career detail added.')).not.toBeNull()
+  await waitFor(() => expect(screen.queryByText('Career detail added.')).toBeNull(), { timeout: 6_000 })
+}, 7_000)
+
+test('keeps an actionable career-detail error visible', async () => {
+  const api = bridge({
+    createCareerProfileItem: vi.fn().mockRejectedValue(new Error('offline'))
+  })
+  render(<CareerProfileWorkspace bridge={api} hasActiveTurn={false} />)
+  await screen.findByRole('heading', { name: 'Work arrangement' })
+  fireEvent.click(screen.getByRole('button', { name: /My Career/i }))
+  fireEvent.click(await screen.findByRole('button', { name: 'Add career detail' }))
+  const editor = screen.getByRole('dialog', { name: 'Add career detail' })
+  fireEvent.change(within(editor).getByLabelText('Detail type'), { target: { value: 'skill' } })
+  fireEvent.change(within(editor).getByLabelText('Skill name'), { target: { value: 'React' } })
+  fireEvent.click(within(editor).getByRole('button', { name: 'Save detail' }))
+  expect((await within(editor).findByRole('alert')).textContent).toMatch(/draft is still here/i)
 })
 
 test('imports Evidence with live recovery and retries the full original mutation identity after an ambiguous failure', async () => {

--- a/apps/desktop/src/renderer/components/CareerProfileWorkspace.test.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileWorkspace.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, expect, test, vi } from 'vitest'
 
 import type { CareerProfileBridge } from '../../shared/contracts'
@@ -409,6 +409,7 @@ test('uses the latest loaded profile revision when accepting an exact zero-Evide
   expect(screen.getAllByText('Level')).toHaveLength(2)
   expect(screen.queryByText(/"level":/)).toBeNull()
 
+  const timeout = vi.spyOn(window, 'setTimeout')
   fireEvent.click(screen.getByRole('button', { name: 'Accept exact change' }))
   await waitFor(() => expect(decideCareerProfileProposal).toHaveBeenCalledWith(
     'cpp_fakeproposal123456',
@@ -418,6 +419,12 @@ test('uses the latest loaded profile revision when accepting an exact zero-Evide
       proposalSha256: 'a'.repeat(64)
     })
   ))
+  expect(await screen.findByText('Exact change accepted.')).not.toBeNull()
+  const dismiss = timeout.mock.calls.find(([, delay]) => delay === 5_000)?.[0]
+  expect(dismiss).toBeTypeOf('function')
+  if (typeof dismiss !== 'function') throw new Error('Expected a transient feedback timer')
+  act(() => { dismiss() })
+  expect(screen.queryByText('Exact change accepted.')).toBeNull()
 })
 
 test('surfaces a direct agent edit as a lightweight confirmation with prominent Undo', async () => {

--- a/apps/desktop/src/renderer/hooks/useCareerProfileCollaboration.ts
+++ b/apps/desktop/src/renderer/hooks/useCareerProfileCollaboration.ts
@@ -32,6 +32,12 @@ export function useCareerProfileCollaboration(
   const refreshSequence = useRef(0)
 
   useEffect(() => {
+    if (status !== 'idle' || !message) return undefined
+    const timeout = window.setTimeout(() => { setMessage('') }, 5_000)
+    return () => { window.clearTimeout(timeout) }
+  }, [message, status])
+
+  useEffect(() => {
     mounted.current = true
     return () => { mounted.current = false }
   }, [])
@@ -107,11 +113,11 @@ export function useCareerProfileCollaboration(
       return true
     } catch (error) {
       const stale = /revision|stale|changed|regenerat|payload/i.test(errorText(error))
+      await refresh()
       setStatus('error')
       setMessage(stale
         ? 'This proposal is out of date and cannot replace newer profile data. Ask the agent to regenerate it.'
         : 'JobOS could not save that decision. Nothing was changed—try again.')
-      await refresh()
       return false
     }
   }, [bridge, history, onProfileChanged, online, refresh, status])
@@ -135,11 +141,11 @@ export function useCareerProfileCollaboration(
       return true
     } catch (error) {
       const stale = /revision|stale|changed|regenerat/i.test(errorText(error))
+      await refresh()
       setStatus('error')
       setMessage(stale
         ? 'Your Career Profile changed after this edit. Reloaded the latest version instead of overwriting it.'
         : 'JobOS could not undo that agent change. Nothing was changed—try again.')
-      await refresh()
       return false
     }
   }, [bridge, history, onProfileChanged, online, refresh, status])

--- a/apps/desktop/src/renderer/hooks/useCareerProfileProduct.ts
+++ b/apps/desktop/src/renderer/hooks/useCareerProfileProduct.ts
@@ -161,6 +161,15 @@ export function useCareerProfileProduct(bridge: CareerProfileBridge) {
   const cacheWriteSequence = useRef(0)
   const headCheckRunning = useRef(false)
 
+  useEffect(() => {
+    if (status !== 'saved' || !message) return undefined
+    const timeout = window.setTimeout(() => {
+      setMessage('')
+      setStatus(currentStatus => currentStatus === 'saved' ? 'ready' : currentStatus)
+    }, 5_000)
+    return () => { window.clearTimeout(timeout) }
+  }, [message, status])
+
   const persist = useCallback(async (profile: CareerProfileCurrent) => {
     const sequence = ++cacheWriteSequence.current
     try {


### PR DESCRIPTION
Closes #87

## User impact
Career Profile success feedback confirms an action for five seconds, then clears instead of looking like permanent profile state. Errors remain visible until the user retries or another action replaces them.

## Approach
- Auto-dismiss successful product mutations after five seconds and return status to ready.
- Auto-dismiss successful proposal/undo feedback after five seconds.
- Preserve collaboration errors after their recovery refresh so retry guidance remains actionable.

## Verification
- Success and error behavior covered through the real Career Profile UI.
- Proposal acceptance regression covered through the workspace UI.
- New tests fail against the previous persistent-message behavior.
- `pnpm check`
- `pnpm contracts:check`
- 526 desktop tests passed.
- 844 Python tests passed, 2 skipped.

## Scope
No profile data, proposal payload, API contract, or authorization behavior changed.