### PR TITLE
Organize My Career with search and collapsible groups

### DIFF
--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
@@ -209,6 +209,43 @@ test('renders list-valued career details as human-readable words', async () => {
   expect(detail.textContent).not.toMatch(/applied_ai_builder|internal_ai_enablement/)
 })
 
+test('organizes My Career into searchable collapsible type groups', async () => {
+  const experience: CareerProfileItemSnapshot = {
+    ...skill,
+    itemId: 'cpi_fakeproductexperience1234',
+    value: { kind: 'experience', organization: 'Acme', role: 'Product builder', summary: 'Shipped an internal platform.' }
+  }
+  const project: CareerProfileItemSnapshot = {
+    ...skill,
+    itemId: 'cpi_fakeproductproject123456',
+    value: { kind: 'project', name: 'Signal Desk', role: 'Lead', summary: 'Built a local-first workflow.' }
+  }
+  render(<CareerProfileWorkspace bridge={bridge({
+    getCareerProfile: vi.fn().mockResolvedValue(savedProfile({ items: [skill, experience, project] }))
+  })} hasActiveTurn={false} />)
+  await screen.findByRole('heading', { name: 'Work arrangement' })
+  fireEvent.click(screen.getByRole('button', { name: /My Career/i }))
+
+  const skillsGroup = await screen.findByRole('button', { name: 'Skills, 1 detail' })
+  expect(screen.getByRole('button', { name: 'Experience, 1 detail' })).not.toBeNull()
+  expect(screen.getByRole('button', { name: 'Projects, 1 detail' })).not.toBeNull()
+  expect(screen.getByRole('button', { name: /TypeScript details/i })).not.toBeNull()
+
+  fireEvent.click(skillsGroup)
+  expect(skillsGroup.getAttribute('aria-expanded')).toBe('false')
+  expect(screen.queryByRole('button', { name: /TypeScript details/i })).toBeNull()
+
+  fireEvent.change(screen.getByLabelText('Search career details'), { target: { value: 'type script' } })
+  expect(screen.getByRole('status').textContent).toMatch(/1 of 3 details/i)
+  expect(screen.getByRole('button', { name: /TypeScript details/i })).not.toBeNull()
+  expect(screen.queryByRole('button', { name: 'Experience, 1 detail' })).toBeNull()
+
+  fireEvent.change(screen.getByLabelText('Search career details'), { target: { value: 'no matching detail' } })
+  expect(screen.getByText('No career details match your search')).not.toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Clear search' }))
+  expect((screen.getByLabelText('Search career details') as HTMLInputElement).value).toBe('')
+})
+
 test('adds a typed career detail and dismisses its success feedback', async () => {
   const nextSkill = { ...skill, itemId: 'cpi_fakeproductskill5678', value: { kind: 'skill', name: 'React', level: 'expert' } }
   const createCareerProfileItem = vi.fn().mockResolvedValue({

--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.tsx
@@ -1,5 +1,6 @@
 import {
   ArchiveRestore,
+  ChevronDown,
   ChevronRight,
   Clock3,
   Download,
@@ -10,6 +11,7 @@ import {
   Link2,
   Plus,
   RefreshCw,
+  Search,
   ShieldCheck,
   Trash2,
   Upload,
@@ -18,6 +20,7 @@ import {
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ChangeEvent,
@@ -264,6 +267,32 @@ const areaLabels: Record<CareerProfileArea, string> = {
   my_career: 'My Career',
   what_im_looking_for: 'What I’m Looking For',
   my_evidence: 'My Evidence'
+}
+
+const careerGroupLabels: Partial<Record<EditableItemKind, string>> = {
+  identity: 'Identity',
+  education: 'Education',
+  skill: 'Skills',
+  positioning: 'Positioning',
+  experience: 'Experience',
+  project: 'Projects',
+  claim: 'Career claims',
+  custom: 'Other details'
+}
+
+function normalizeCareerSearch(value: string): string {
+  return value.toLocaleLowerCase().replaceAll(/[^a-z0-9]+/g, '')
+}
+
+function itemSearchText(item: CareerProfileItemSnapshot): string {
+  const kind = itemKind(item)
+  return normalizeCareerSearch([
+    kind ? specsByKind.get(kind)?.label ?? '' : '',
+    itemTitle(item),
+    itemSummary(item),
+    provenanceLabel(item),
+    ...Object.values(item.value).map(readableValue)
+  ].join(' '))
 }
 
 function requestId(prefix: string): string {
@@ -777,7 +806,21 @@ function ItemArea({ active, area, online, product }: {
 }) {
   const [detailItemId, setDetailItemId] = useState<string | null>(null)
   const [editorSession, setEditorSession] = useState<ItemEditorSession | null>(null)
+  const [query, setQuery] = useState('')
+  const [collapsedKinds, setCollapsedKinds] = useState<Set<EditableItemKind>>(() => new Set())
   const items = (product.current?.items ?? []).filter(item => item.area === area && itemKind(item) !== null)
+  const normalizedQuery = normalizeCareerSearch(query)
+  const filteredItems = area === 'my_career' && normalizedQuery
+    ? items.filter(item => itemSearchText(item).includes(normalizedQuery))
+    : items
+  const careerGroups = useMemo(() => itemSpecs
+    .filter(spec => spec.area === 'my_career')
+    .map(spec => ({
+      kind: spec.kind,
+      label: careerGroupLabels[spec.kind] ?? spec.label,
+      items: filteredItems.filter(item => itemKind(item) === spec.kind)
+    }))
+    .filter(group => group.items.length > 0), [filteredItems])
   const detailItem = detailItemId
     ? product.current?.items.find(item => item.itemId === detailItemId) ?? null
     : null
@@ -788,6 +831,24 @@ function ItemArea({ active, area, online, product }: {
     if (expectedProfileRevision === undefined) return
     setEditorSession({ expectedProfileRevision, item })
   }
+
+  const toggleGroup = (kind: EditableItemKind) => {
+    setCollapsedKinds(current => {
+      const next = new Set(current)
+      if (next.has(kind)) next.delete(kind)
+      else next.add(kind)
+      return next
+    })
+  }
+
+  const itemCard = (item: CareerProfileItemSnapshot) => (
+    <button aria-label={`${itemTitle(item)} details`} className="career-product-card" key={item.itemId} onClick={() => setDetailItemId(item.itemId)} type="button">
+      <div><span className="career-product-kind">{specsByKind.get(itemKind(item)!)?.label}</span><span className={`career-product-review ${item.reviewStatus}`}>{readableLabel(item.reviewStatus)}</span></div>
+      <strong>{itemTitle(item)}</strong>
+      <p>{itemSummary(item)}</p>
+      <footer><span>{provenanceLabel(item)}</span><span>{item.evidenceIds.length} Evidence</span><ChevronRight aria-hidden="true" size={16} /></footer>
+    </button>
+  )
 
   useEffect(() => {
     if (!active) {
@@ -806,22 +867,55 @@ function ItemArea({ active, area, online, product }: {
         </div>
         <button className="career-primary-button" disabled={!online || !product.current} onClick={() => openEditor(null)} type="button"><Plus aria-hidden="true" size={15} />Add {areaName}</button>
       </div>
+      {area === 'my_career' && items.length > 0 ? (
+        <div className="career-product-search">
+          <label>
+            <Search aria-hidden="true" size={16} />
+            <input aria-label="Search career details" onChange={event => setQuery(event.target.value)} placeholder="Search skills, roles, projects, or details" type="search" value={query} />
+          </label>
+          {query ? <button aria-label="Clear search field" onClick={() => setQuery('')} type="button"><X aria-hidden="true" size={15} /></button> : null}
+          <span role="status">{filteredItems.length} of {items.length} details</span>
+        </div>
+      ) : null}
       {items.length === 0 ? (
         <div className="career-product-empty">
           <FilePlus2 aria-hidden="true" size={22} />
           <strong>No {area === 'my_career' ? 'career details' : 'other preferences'} yet</strong>
           <p>Start with one useful fact. There is no completeness score to chase.</p>
         </div>
+      ) : area === 'my_career' && filteredItems.length === 0 ? (
+        <div className="career-product-empty">
+          <Search aria-hidden="true" size={22} />
+          <strong>No career details match your search</strong>
+          <p>Try a skill, role, company, project, or another word from the detail.</p>
+          <button className="career-secondary-button" onClick={() => setQuery('')} type="button">Clear search</button>
+        </div>
+      ) : area === 'my_career' ? (
+        <div className="career-product-groups">
+          {careerGroups.map(group => {
+            const expanded = normalizedQuery.length > 0 || !collapsedKinds.has(group.kind)
+            const groupId = `career-product-group-${group.kind}`
+            return (
+              <section className="career-product-group" key={group.kind}>
+                <button
+                  aria-controls={groupId}
+                  aria-expanded={expanded}
+                  aria-label={`${group.label}, ${group.items.length} ${group.items.length === 1 ? 'detail' : 'details'}`}
+                  className="career-product-group-toggle"
+                  onClick={() => toggleGroup(group.kind)}
+                  type="button"
+                >
+                  <span><strong>{group.label}</strong><small>{group.items.length}</small></span>
+                  <ChevronDown aria-hidden="true" size={18} />
+                </button>
+                {expanded ? <div className="career-product-card-grid" id={groupId}>{group.items.map(itemCard)}</div> : null}
+              </section>
+            )
+          })}
+        </div>
       ) : (
         <div className="career-product-card-grid">
-          {items.map(item => (
-            <button aria-label={`${itemTitle(item)} details`} className="career-product-card" key={item.itemId} onClick={() => setDetailItemId(item.itemId)} type="button">
-              <div><span className="career-product-kind">{specsByKind.get(itemKind(item)!)?.label}</span><span className={`career-product-review ${item.reviewStatus}`}>{readableLabel(item.reviewStatus)}</span></div>
-              <strong>{itemTitle(item)}</strong>
-              <p>{itemSummary(item)}</p>
-              <footer><span>{provenanceLabel(item)}</span><span>{item.evidenceIds.length} Evidence</span><ChevronRight aria-hidden="true" size={16} /></footer>
-            </button>
-          ))}
+          {items.map(itemCard)}
         </div>
       )}
       {detailItem ? <ItemDetails

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -1804,6 +1804,25 @@ button:focus-visible {
 .career-product-recover p { margin: 0; }
 .career-product-area-heading h3 { font-size: var(--text-xl); letter-spacing: -.025em; }
 .career-product-area-heading p { max-width: 650px; color: var(--muted); font-size: var(--text-sm); line-height: 1.55; }
+.career-product-search { display: flex; align-items: center; gap: 8px; }
+.career-product-search label { min-width: 180px; flex: 1; display: flex; align-items: center; gap: 9px; padding: 0 12px; border: 1px solid var(--border); border-radius: var(--radius-md); color: var(--muted); background: var(--surface-inset); }
+.career-product-search label:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-tint-strong); }
+.career-product-search input { min-width: 0; flex: 1; padding: 10px 0; border: 0; outline: 0; color: var(--text); background: transparent; font: inherit; font-size: var(--text-sm); }
+.career-product-search input::placeholder { color: var(--muted); }
+.career-product-search > button { width: 36px; height: 36px; display: grid; place-items: center; flex: 0 0 auto; border: 1px solid var(--border); border-radius: var(--radius-md); color: var(--muted); background: var(--surface-raised); cursor: pointer; }
+.career-product-search > button:hover { color: var(--text); background: var(--surface-hover); }
+.career-product-search > button:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-tint-strong); }
+.career-product-search > span { flex: 0 0 auto; color: var(--muted); font-size: var(--text-xs); }
+.career-product-groups { display: grid; gap: 14px; }
+.career-product-group { display: grid; gap: 10px; }
+.career-product-group-toggle { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 2px; border: 0; border-bottom: 1px solid var(--border-soft); color: var(--text); text-align: left; background: transparent; cursor: pointer; }
+.career-product-group-toggle > span { display: flex; align-items: center; gap: 8px; }
+.career-product-group-toggle strong { font-size: var(--text-base); }
+.career-product-group-toggle small { min-width: 24px; padding: 2px 7px; border-radius: 999px; color: var(--muted); text-align: center; background: var(--surface-inset); font-size: var(--text-xs); }
+.career-product-group-toggle svg { color: var(--muted); transition: transform var(--motion-fast); }
+.career-product-group-toggle[aria-expanded="false"] svg { transform: rotate(-90deg); }
+.career-product-group-toggle:hover { color: var(--accent-text); }
+.career-product-group-toggle:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 2px 0 var(--accent); }
 .career-product-card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 .career-product-card {
   min-width: 0;


### PR DESCRIPTION
Closes #88

## User impact
My Career is no longer one undifferentiated grid. Details are grouped by human-readable type, each group can collapse independently, and users can search across titles, summaries, field values, type labels, and provenance.

## Product behavior
- Groups start expanded so existing content is never unexpectedly hidden.
- Every group shows its item count.
- Search ignores spacing and punctuation, so `TypeScript` matches `type script`.
- Search temporarily reveals matching cards even if their group was collapsed.
- No-match state explains what to try and provides a clear recovery action.
- Other Career Profile areas keep their current layouts.

## Verification
- Regression test failed against the previous flat-grid implementation.
- Focused Career Profile suite: 30 tests passed.
- `pnpm check`
- `pnpm contracts:check`
- 527 desktop tests passed.
- 844 Python tests passed, 2 skipped.

## Scope
Renderer organization only. No schema, API, profile data, revision, evidence, or authorization changes.