### PR TITLE
Explain how JobOS uses My Career details

### DIFF
--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
@@ -229,6 +229,8 @@ test('organizes My Career into searchable collapsible type groups', async () => 
   const skillsGroup = await screen.findByRole('button', { name: 'Skills, 1 detail' })
   expect(screen.getByRole('button', { name: 'Experience, 1 detail' })).not.toBeNull()
   expect(screen.getByRole('button', { name: 'Projects, 1 detail' })).not.toBeNull()
+  expect(screen.getByText(/Capabilities JobOS can use to understand fit and keep drafts accurate/i)).not.toBeNull()
+  expect(screen.getByText(/Roles and work history JobOS can reference as career context/i)).not.toBeNull()
   expect(screen.getByRole('button', { name: /TypeScript details/i })).not.toBeNull()
 
   fireEvent.click(skillsGroup)
@@ -244,6 +246,20 @@ test('organizes My Career into searchable collapsible type groups', async () => 
   expect(screen.getByText('No career details match your search')).not.toBeNull()
   fireEvent.click(screen.getByRole('button', { name: 'Clear search' }))
   expect((screen.getByLabelText('Search career details') as HTMLInputElement).value).toBe('')
+})
+
+test('explains My Career usage even before the first detail is added', async () => {
+  render(<CareerProfileWorkspace bridge={bridge({
+    getCareerProfile: vi.fn().mockResolvedValue(savedProfile({ items: [] }))
+  })} hasActiveTurn={false} />)
+  await screen.findByRole('heading', { name: 'Work arrangement' })
+  fireEvent.click(screen.getByRole('button', { name: /My Career/i }))
+
+  const guidance = await screen.findByRole('region', { name: 'How JobOS uses My Career' })
+  expect(within(guidance).getByText('How JobOS uses this')).not.toBeNull()
+  expect(guidance.textContent).toMatch(/researching roles, comparing opportunities, and drafting documents/i)
+  expect(guidance.textContent).toMatch(/not a completeness score or automatic decision/i)
+  expect(screen.getByText('No career details yet')).not.toBeNull()
 })
 
 test('adds a typed career detail and dismisses its success feedback', async () => {

--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.tsx
@@ -280,6 +280,17 @@ const careerGroupLabels: Partial<Record<EditableItemKind, string>> = {
   custom: 'Other details'
 }
 
+const careerGroupDescriptions: Partial<Record<EditableItemKind, string>> = {
+  identity: 'The name and professional summary JobOS can use when representing you.',
+  education: 'Education and training JobOS can reference when they are relevant.',
+  skill: 'Capabilities JobOS can use to understand fit and keep drafts accurate.',
+  positioning: 'The headline and framing you want JobOS to use for your career story.',
+  experience: 'Roles and work history JobOS can reference as career context.',
+  project: 'Concrete examples of what you built, led, or contributed to.',
+  claim: 'Qualified statements JobOS can use only within the boundaries you saved.',
+  custom: 'Additional career context that does not fit another section.'
+}
+
 function normalizeCareerSearch(value: string): string {
   return value.toLocaleLowerCase().replaceAll(/[^a-z0-9]+/g, '')
 }
@@ -816,6 +827,7 @@ function ItemArea({ active, area, online, product }: {
   const careerGroups = useMemo(() => itemSpecs
     .filter(spec => spec.area === 'my_career')
     .map(spec => ({
+      description: careerGroupDescriptions[spec.kind] ?? '',
       kind: spec.kind,
       label: careerGroupLabels[spec.kind] ?? spec.label,
       items: filteredItems.filter(item => itemKind(item) === spec.kind)
@@ -867,6 +879,16 @@ function ItemArea({ active, area, online, product }: {
         </div>
         <button className="career-primary-button" disabled={!online || !product.current} onClick={() => openEditor(null)} type="button"><Plus aria-hidden="true" size={15} />Add {areaName}</button>
       </div>
+      {area === 'my_career' ? (
+        <aside aria-label="How JobOS uses My Career" className="career-product-usage-card" role="region">
+          <ShieldCheck aria-hidden="true" size={20} />
+          <div>
+            <span className="career-kicker">How JobOS uses this</span>
+            <strong>Accepted details become shared career context.</strong>
+            <p>They help JobOS when researching roles, comparing opportunities, and drafting documents. They inform the work—they are not a completeness score or automatic decision.</p>
+          </div>
+        </aside>
+      ) : null}
       {area === 'my_career' && items.length > 0 ? (
         <div className="career-product-search">
           <label>
@@ -905,7 +927,7 @@ function ItemArea({ active, area, online, product }: {
                   onClick={() => toggleGroup(group.kind)}
                   type="button"
                 >
-                  <span><strong>{group.label}</strong><small>{group.items.length}</small></span>
+                  <div><span><strong>{group.label}</strong><small>{group.items.length}</small></span><p>{group.description}</p></div>
                   <ChevronDown aria-hidden="true" size={18} />
                 </button>
                 {expanded ? <div className="career-product-card-grid" id={groupId}>{group.items.map(itemCard)}</div> : null}

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -1804,6 +1804,11 @@ button:focus-visible {
 .career-product-recover p { margin: 0; }
 .career-product-area-heading h3 { font-size: var(--text-xl); letter-spacing: -.025em; }
 .career-product-area-heading p { max-width: 650px; color: var(--muted); font-size: var(--text-sm); line-height: 1.55; }
+.career-product-usage-card { display: flex; align-items: start; gap: 12px; padding: 15px 16px; border: 1px solid var(--accent-border); border-radius: var(--radius-lg); background: color-mix(in srgb, var(--accent-tint) 66%, var(--surface-raised)); box-shadow: inset 0 1px 0 var(--highlight-inset); }
+.career-product-usage-card > svg { flex: 0 0 auto; margin-top: 2px; color: var(--accent-text); }
+.career-product-usage-card > div { display: grid; gap: 4px; }
+.career-product-usage-card strong { color: var(--text); font-size: var(--text-sm); }
+.career-product-usage-card p { max-width: 760px; margin: 0; color: var(--muted); font-size: var(--text-sm); line-height: 1.5; }
 .career-product-search { display: flex; align-items: center; gap: 8px; }
 .career-product-search label { min-width: 180px; flex: 1; display: flex; align-items: center; gap: 9px; padding: 0 12px; border: 1px solid var(--border); border-radius: var(--radius-md); color: var(--muted); background: var(--surface-inset); }
 .career-product-search label:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-tint-strong); }
@@ -1816,8 +1821,10 @@ button:focus-visible {
 .career-product-groups { display: grid; gap: 14px; }
 .career-product-group { display: grid; gap: 10px; }
 .career-product-group-toggle { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 2px; border: 0; border-bottom: 1px solid var(--border-soft); color: var(--text); text-align: left; background: transparent; cursor: pointer; }
-.career-product-group-toggle > span { display: flex; align-items: center; gap: 8px; }
+.career-product-group-toggle > div { min-width: 0; display: grid; gap: 3px; }
+.career-product-group-toggle > div > span { display: flex; align-items: center; gap: 8px; }
 .career-product-group-toggle strong { font-size: var(--text-base); }
+.career-product-group-toggle p { margin: 0; overflow: hidden; color: var(--muted); font-size: var(--text-xs); line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
 .career-product-group-toggle small { min-width: 24px; padding: 2px 7px; border-radius: 999px; color: var(--muted); text-align: center; background: var(--surface-inset); font-size: var(--text-xs); }
 .career-product-group-toggle svg { color: var(--muted); transition: transform var(--motion-fast); }
 .career-product-group-toggle[aria-expanded="false"] svg { transform: rotate(-90deg); }


### PR DESCRIPTION
Closes #89

## User impact
My Career now explains how accepted details support JobOS before or after the user adds anything. Each populated type group also states what that kind of information is for.

## Product behavior
- The usage card is visible in populated and empty-profile states.
- Copy names role research, opportunity comparison, and document drafting without claiming that details determine outcomes.
- The card explicitly says details are not a completeness score or automatic decision.
- Every supported My Career type has a concise purpose description under its group label.

## Verification
- Regression tests failed against the prior unexplained surface.
- Focused Career Profile suite: 31 tests passed.
- `pnpm check`
- `pnpm contracts:check`
- 528 desktop tests passed.
- 844 Python tests passed, 2 skipped.

## Scope
Renderer copy and presentation only. No ranking, matching, schema, API, profile data, or agent-access behavior changed.