### PR TITLE
Present Career Profile claims as professional statements

### DIFF
--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
@@ -262,6 +262,37 @@ test('explains My Career usage even before the first detail is added', async () 
   expect(screen.getByText('No career details yet')).not.toBeNull()
 })
 
+test('presents claim records as bounded professional statements', async () => {
+  const statement: CareerProfileItemSnapshot = {
+    ...skill,
+    itemId: 'cpi_fakeproductstatement1234',
+    value: {
+      kind: 'claim',
+      statement: 'I build trustworthy AI workflows.',
+      qualifiers: ['For product and engineering roles'],
+      forbidden_uses: ['Do not describe this as model research']
+    }
+  }
+  render(<CareerProfileWorkspace bridge={bridge({
+    getCareerProfile: vi.fn().mockResolvedValue(savedProfile({ items: [statement] }))
+  })} hasActiveTurn={false} />)
+  await screen.findByRole('heading', { name: 'Work arrangement' })
+  fireEvent.click(screen.getByRole('button', { name: /My Career/i }))
+
+  expect(await screen.findByRole('button', { name: 'Professional statements, 1 detail' })).not.toBeNull()
+  expect(screen.getByText(/Statements you approved, with saved context and limits/i)).not.toBeNull()
+  expect(screen.getByText('Professional statement')).not.toBeNull()
+  expect(screen.queryByText(/Career claims?/i)).toBeNull()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Add career detail' }))
+  const editor = screen.getByRole('dialog', { name: 'Add career detail' })
+  fireEvent.change(within(editor).getByLabelText('Detail type'), { target: { value: 'claim' } })
+  expect(within(editor).getByRole('option', { name: 'Professional statement' })).not.toBeNull()
+  expect(within(editor).getByLabelText('What JobOS should know')).not.toBeNull()
+  expect(within(editor).getByLabelText('Context and qualifiers')).not.toBeNull()
+  expect(within(editor).getByLabelText('Do not use this for')).not.toBeNull()
+})
+
 test('adds a typed career detail and dismisses its success feedback', async () => {
   const nextSkill = { ...skill, itemId: 'cpi_fakeproductskill5678', value: { kind: 'skill', name: 'React', level: 'expert' } }
   const createCareerProfileItem = vi.fn().mockResolvedValue({

--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.tsx
@@ -178,12 +178,12 @@ const itemSpecs: ItemSpec[] = [
     ]
   },
   {
-    area: 'my_career', kind: 'claim', label: 'Career claim',
+    area: 'my_career', kind: 'claim', label: 'Professional statement',
     requiredAny: ['statement', 'qualifiers', 'forbidden_uses'],
     fields: [
-      { key: 'statement', kind: 'textarea', label: 'Statement' },
-      { key: 'qualifiers', kind: 'list', label: 'Qualifiers', placeholder: 'One qualifier per line' },
-      { key: 'forbidden_uses', kind: 'list', label: 'Do not use this claim for', placeholder: 'One restriction per line' }
+      { key: 'statement', kind: 'textarea', label: 'What JobOS should know' },
+      { key: 'qualifiers', kind: 'list', label: 'Context and qualifiers', placeholder: 'One piece of context per line' },
+      { key: 'forbidden_uses', kind: 'list', label: 'Do not use this for', placeholder: 'One restriction per line' }
     ]
   },
   {
@@ -276,7 +276,7 @@ const careerGroupLabels: Partial<Record<EditableItemKind, string>> = {
   positioning: 'Positioning',
   experience: 'Experience',
   project: 'Projects',
-  claim: 'Career claims',
+  claim: 'Professional statements',
   custom: 'Other details'
 }
 
@@ -287,7 +287,7 @@ const careerGroupDescriptions: Partial<Record<EditableItemKind, string>> = {
   positioning: 'The headline and framing you want JobOS to use for your career story.',
   experience: 'Roles and work history JobOS can reference as career context.',
   project: 'Concrete examples of what you built, led, or contributed to.',
-  claim: 'Qualified statements JobOS can use only within the boundaries you saved.',
+  claim: 'Statements you approved, with saved context and limits on how JobOS may use them.',
   custom: 'Additional career context that does not fit another section.'
 }
 


### PR DESCRIPTION
Closes #90

## Product decision
Use **Professional statement** as the user-facing name for internal `claim` records.

This is more understandable than “Career claim” while remaining neutral: it does not imply that a statement is proven, unusually important, or automatically suitable for a résumé. It also fits the existing saved qualifiers and usage restrictions.

## User impact
- Existing records appear under **Professional statements** without migration or rewriting.
- Cards and editor options use **Professional statement**.
- Editor fields use `What JobOS should know`, `Context and qualifiers`, and `Do not use this for`.
- Group guidance emphasizes user approval, context, and usage limits.

## Verification
- Regression test failed against the previous Career claim labels.
- Focused Career Profile suite: 32 tests passed.
- `pnpm check`
- `pnpm contracts:check`
- 529 desktop tests passed.
- 844 Python tests passed, 2 skipped.

## Scope
Presentation only. Internal `kind: claim` contracts, saved records, authorship policy, evidence semantics, exports, APIs, and migrations are unchanged.