### PR TITLE
Phase 2: add provider-neutral Connected Agent routing

### DIFF
--- a/packages/contracts/openapi.json
+++ b/packages/contracts/openapi.json
@@ -8432,6 +8432,22 @@
             }
           },
           {
+            "in": "query",
+            "name": "turn_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Turn Id"
+            }
+          },
+          {
             "in": "header",
             "name": "X-JobOS-MCP-Token",
             "required": false,

--- a/packages/contracts/openapi.json
+++ b/packages/contracts/openapi.json
@@ -8416,6 +8416,22 @@
         "operationId": "browser_command_v1_browser_commands_post",
         "parameters": [
           {
+            "in": "query",
+            "name": "conversation_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Conversation Id"
+            }
+          },
+          {
             "in": "header",
             "name": "X-JobOS-MCP-Token",
             "required": false,

--- a/packages/contracts/src/generated/types.gen.ts
+++ b/packages/contracts/src/generated/types.gen.ts
@@ -4328,7 +4328,12 @@ export type BrowserCommandV1BrowserCommandsPostData = {
         'X-JobOS-MCP-Token'?: string | null;
     };
     path?: never;
-    query?: never;
+    query?: {
+        /**
+         * Conversation Id
+         */
+        conversation_id?: string | null;
+    };
     url: '/v1/browser/commands';
 };
 

--- a/packages/contracts/src/generated/types.gen.ts
+++ b/packages/contracts/src/generated/types.gen.ts
@@ -4333,6 +4333,10 @@ export type BrowserCommandV1BrowserCommandsPostData = {
          * Conversation Id
          */
         conversation_id?: string | null;
+        /**
+         * Turn Id
+         */
+        turn_id?: string | null;
     };
     url: '/v1/browser/commands';
 };

--- a/services/api/jobos_api/agent_gateway.py
+++ b/services/api/jobos_api/agent_gateway.py
@@ -1,8 +1,31 @@
+import asyncio
+import hashlib
+import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from typing import Literal, Protocol
+from datetime import UTC, datetime
+from typing import Literal, Protocol, cast
 
 ConnectionState = Literal["online", "connecting", "offline"]
+ConnectedAgentProvider = Literal["hermes", "codex"]
+NormalizedEventKind = Literal[
+    "turn_started",
+    "assistant_text_delta",
+    "reasoning_activity",
+    "tool_started",
+    "tool_progress",
+    "tool_review_required",
+    "tool_completed",
+    "turn_completed",
+    "turn_cancelled",
+    "turn_failed",
+    "connection_changed",
+    "recovery_required",
+]
+
+
+class AmbiguousDeliveryError(RuntimeError):
+    """The provider may have accepted an operation whose result was not observed."""
 
 
 @dataclass(frozen=True)
@@ -14,6 +37,12 @@ class AgentContext:
     selected_job: dict[str, str] | None = None
     career_profile: dict[str, object] | None = None
     career_profile_context: dict[str, object] | None = None
+    profile_id: str | None = None
+    connected_agent_id: str | None = None
+    provider: ConnectedAgentProvider | None = None
+    model_id: str | None = None
+    reasoning_effort: str | None = None
+    permission_state: dict[str, object] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -25,6 +54,65 @@ class GatewayEvent:
     turn_id: str | None = None
     source_event_id: str | None = None
     activity_id: str | None = None
+    normalized_kind: NormalizedEventKind | None = None
+    profile_id: str | None = None
+    conversation_id: str | None = None
+    sequence: int | None = None
+    timestamp: str | None = None
+
+
+@dataclass(frozen=True)
+class RuntimeBinding:
+    connected_agent_id: str | None
+    provider: ConnectedAgentProvider | None
+    model_id: str | None
+    reasoning_effort: str | None
+    binding_state: str | None
+    creation_state: str
+    lock_reason: str | None
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, object]) -> "RuntimeBinding":
+        provider_value = value.get("provider")
+        if provider_value not in {None, "hermes", "codex"}:
+            raise ValueError("Connected Agent provider is invalid")
+        provider = cast(ConnectedAgentProvider | None, provider_value)
+        binding = cls(
+            connected_agent_id=(
+                str(value["connected_agent_id"])
+                if value.get("connected_agent_id") is not None
+                else None
+            ),
+            provider=provider,
+            model_id=str(value["model_id"]) if value.get("model_id") is not None else None,
+            reasoning_effort=(
+                str(value["reasoning_effort"])
+                if value.get("reasoning_effort") is not None
+                else None
+            ),
+            binding_state=(
+                str(value["binding_state"]) if value.get("binding_state") is not None else None
+            ),
+            creation_state=str(value.get("creation_state") or "locked"),
+            lock_reason=(
+                str(value["lock_reason"]) if value.get("lock_reason") is not None else None
+            ),
+        )
+        supplied = (
+            binding.connected_agent_id,
+            binding.provider,
+            binding.model_id,
+            binding.reasoning_effort,
+        )
+        if binding.connected_agent_id is None:
+            if any(item is not None for item in supplied[1:]):
+                raise ValueError("Conversation binding is incomplete")
+            return binding
+        if binding.binding_state == "sealed" and any(item is None for item in supplied):
+            raise ValueError("Sealed conversation binding is incomplete")
+        if binding.provider is None:
+            raise ValueError("Conversation binding has no provider")
+        return binding
 
 
 class AgentGateway(Protocol):
@@ -54,6 +142,329 @@ class AgentGatewayFactory(Protocol):
     """Creates one isolated gateway connection per active JobOS conversation."""
 
     def create(self, conversation_id: str) -> AgentGateway: ...
+
+
+class AgentRuntimeRouter:
+    """Resolve an immutable chat binding to one isolated provider gateway."""
+
+    def __init__(
+        self,
+        adapters: dict[
+            ConnectedAgentProvider | tuple[ConnectedAgentProvider, str], AgentGatewayFactory
+        ],
+        *,
+        profile_id: str,
+        compatibility_provider: ConnectedAgentProvider = "hermes",
+    ) -> None:
+        self._adapters = dict(adapters)
+        self._profile_id = profile_id
+        self._compatibility_provider = compatibility_provider
+        self._session_owners: dict[tuple[ConnectedAgentProvider, str, str], str] = {}
+        self._session_lock = asyncio.Lock()
+
+    def create(self, conversation_id: str, binding_value: dict[str, object]) -> AgentGateway:
+        binding = RuntimeBinding.from_mapping(binding_value)
+        raw_sequences = binding_value.get("_normalized_event_sequences", {})
+        initial_sequences = (
+            {
+                str(turn_id): int(sequence)
+                for turn_id, sequence in raw_sequences.items()
+                if isinstance(turn_id, str) and isinstance(sequence, int) and sequence >= 0
+            }
+            if isinstance(raw_sequences, dict)
+            else {}
+        )
+        provider = binding.provider or self._compatibility_provider
+        factory = (
+            self._adapters.get((provider, binding.connected_agent_id))
+            if binding.connected_agent_id is not None
+            else self._adapters.get(provider)
+        )
+        if factory is None:
+            raise ConnectionError("Connected Agent provider is unavailable")
+        return _RoutedAgentGateway(
+            router=self,
+            gateway=factory.create(conversation_id),
+            profile_id=self._profile_id,
+            conversation_id=conversation_id,
+            binding=binding,
+            provider=provider,
+            initial_sequences=initial_sequences,
+        )
+
+    async def claim_sessions(
+        self,
+        provider: ConnectedAgentProvider,
+        identity: str,
+        session_ids: tuple[str, ...],
+        conversation_id: str,
+    ) -> None:
+        async with self._session_lock:
+            keys = tuple(
+                (provider, identity, session_id)
+                for session_id in dict.fromkeys(session_ids)
+            )
+            if any(
+                (owner := self._session_owners.get(key)) is not None
+                and owner != conversation_id
+                for key in keys
+            ):
+                raise RuntimeError("Provider session is already owned by another conversation")
+            for key in keys:
+                self._session_owners[key] = conversation_id
+
+
+class _RoutedAgentGateway:
+    """Seal scope, session ownership, cancellation, and normalized event ordering."""
+
+    def __init__(
+        self,
+        *,
+        router: AgentRuntimeRouter,
+        gateway: AgentGateway,
+        profile_id: str,
+        conversation_id: str,
+        binding: RuntimeBinding,
+        provider: ConnectedAgentProvider,
+        initial_sequences: dict[str, int],
+    ) -> None:
+        self._router = router
+        self._gateway = gateway
+        self._profile_id = profile_id
+        self._conversation_id = conversation_id
+        self._binding = binding
+        self._provider: ConnectedAgentProvider = provider
+        self._session_identity = binding.connected_agent_id or f"compatibility:{provider}"
+        self._active_turn_id: str | None = None
+        self._sequences = dict(initial_sequences)
+        self._terminal_turns: set[str] = set()
+        self._source_event_ids: set[tuple[str, str]] = set()
+        self._events: asyncio.Queue[GatewayEvent | None] = asyncio.Queue()
+        self._event_task: asyncio.Task[None] | None = None
+
+    @property
+    def connection_state(self) -> ConnectionState:
+        return self._gateway.connection_state
+
+    async def start(self) -> None:
+        await self._gateway.start()
+        if self._event_task is None or self._event_task.done():
+            self._event_task = asyncio.create_task(self._pump_events())
+
+    async def create_or_resume_conversation(self, stored_session_id: str | None) -> tuple[str, str]:
+        if stored_session_id is not None:
+            await self._router.claim_sessions(
+                self._provider,
+                self._session_identity,
+                (stored_session_id,),
+                self._conversation_id,
+            )
+        stored, live = await self._gateway.create_or_resume_conversation(stored_session_id)
+        try:
+            await self._router.claim_sessions(
+                self._provider,
+                self._session_identity,
+                (stored, live),
+                self._conversation_id,
+            )
+        except BaseException:
+            await self._gateway.detach_conversation()
+            raise
+        return stored, live
+
+    async def detach_conversation(self) -> None:
+        self._active_turn_id = None
+        await self._gateway.detach_conversation()
+
+    def _validate_turn(self, context: AgentContext) -> None:
+        if (
+            context.profile_id != self._profile_id
+            or context.conversation_id != self._conversation_id
+        ):
+            raise ValueError("Trusted turn scope does not match the routed conversation")
+        expected = (
+            self._binding.connected_agent_id,
+            self._binding.provider or self._provider,
+            self._binding.model_id,
+            self._binding.reasoning_effort,
+        )
+        actual = (
+            context.connected_agent_id,
+            context.provider,
+            context.model_id,
+            context.reasoning_effort,
+        )
+        if self._binding.connected_agent_id is not None and actual != expected:
+            raise ValueError("Trusted turn binding does not match the routed conversation")
+        if self._active_turn_id is not None and self._active_turn_id != context.turn_id:
+            raise RuntimeError("A provider turn is already active for this conversation")
+
+    async def submit_turn(self, text: str, context: AgentContext) -> None:
+        self._validate_turn(context)
+        self._active_turn_id = context.turn_id
+        self._sequences.setdefault(context.turn_id, 0)
+        self._terminal_turns.discard(context.turn_id)
+        await self._events.put(
+            self._normalized(
+                GatewayEvent("status", "working", "", turn_id=context.turn_id),
+                forced_kind="turn_started",
+            )
+        )
+        try:
+            await self._gateway.submit_turn(text, context)
+        except BaseException:
+            self._active_turn_id = None
+            raise
+
+    def stream_events(self) -> AsyncIterator[GatewayEvent]:
+        return self._stream_events()
+
+    async def _stream_events(self) -> AsyncIterator[GatewayEvent]:
+        while True:
+            event = await self._events.get()
+            if event is None:
+                return
+            yield event
+
+    async def interrupt_turn(self, turn_id: str) -> None:
+        if self._active_turn_id != turn_id:
+            return
+        try:
+            await self._gateway.interrupt_turn(turn_id)
+        finally:
+            if self._active_turn_id == turn_id:
+                self._active_turn_id = None
+
+    async def recover_active_turn(self, stored_session_id: str, turn_id: str) -> None:
+        await self._router.claim_sessions(
+            self._provider,
+            self._session_identity,
+            (stored_session_id,),
+            self._conversation_id,
+        )
+        self._active_turn_id = turn_id
+        try:
+            await self._gateway.recover_active_turn(stored_session_id, turn_id)
+        finally:
+            if self._active_turn_id == turn_id:
+                self._active_turn_id = None
+
+    async def _pump_events(self) -> None:
+        try:
+            async for event in self._gateway.stream_events():
+                if event.event_type == "reconciliation":
+                    session_id = event.detail.get("stored_session_id")
+                    if isinstance(session_id, str):
+                        try:
+                            await self._router.claim_sessions(
+                                self._provider,
+                                self._session_identity,
+                                (session_id,),
+                                self._conversation_id,
+                            )
+                        except RuntimeError:
+                            await self._gateway.detach_conversation()
+                            continue
+                normalized = self._normalized(event)
+                if normalized is not None:
+                    await self._events.put(normalized)
+        finally:
+            await self._events.put(None)
+
+    @staticmethod
+    def _kind(event: GatewayEvent) -> NormalizedEventKind:
+        if event.event_type == "connection":
+            return "connection_changed"
+        if event.event_type == "reconciliation":
+            return "connection_changed"
+        if event.event_type == "error":
+            return (
+                "recovery_required"
+                if event.detail.get("reason") == "transport_lost"
+                else "turn_failed"
+            )
+        if event.event_type == "assistant_message":
+            if event.state == "completed":
+                return "turn_completed"
+            if event.state == "interrupted":
+                return "turn_cancelled"
+            if event.state == "failed":
+                return "turn_failed"
+            return "assistant_text_delta"
+        if event.event_type == "activity":
+            return "tool_completed" if event.state == "completed" else "tool_progress"
+        if event.event_type == "status" and event.state == "waiting":
+            return "tool_review_required"
+        return "reasoning_activity"
+
+    def _normalized(
+        self,
+        event: GatewayEvent,
+        *,
+        forced_kind: NormalizedEventKind | None = None,
+    ) -> GatewayEvent | None:
+        kind = forced_kind or self._kind(event)
+        turn_id = event.turn_id or self._active_turn_id
+        if kind == "connection_changed" or event.event_type == "reconciliation":
+            if turn_id is None:
+                # Keep lifecycle updates internal rather than emitting a malformed
+                # normalized event without a trusted turn scope.
+                return GatewayEvent(**{**event.__dict__, "normalized_kind": None})
+            sequence = self._sequences.get(turn_id, 0) + 1
+            self._sequences[turn_id] = sequence
+            return GatewayEvent(
+                **{
+                    **event.__dict__,
+                    "turn_id": turn_id,
+                    "normalized_kind": kind,
+                    "profile_id": self._profile_id,
+                    "conversation_id": self._conversation_id,
+                    "sequence": sequence,
+                    "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+                }
+            )
+        if turn_id is None or turn_id != self._active_turn_id:
+            return None
+        source_event_id = event.source_event_id
+        if source_event_id is not None:
+            source_key = (turn_id, source_event_id)
+            if source_key in self._source_event_ids:
+                return None
+            self._source_event_ids.add(source_key)
+        if turn_id in self._terminal_turns:
+            return None
+        sequence = self._sequences.get(turn_id, 0) + 1
+        self._sequences[turn_id] = sequence
+        if source_event_id is None:
+            material = json.dumps(
+                [self._conversation_id, turn_id, kind, sequence, event.event_type, event.state],
+                separators=(",", ":"),
+            )
+            source_event_id = f"jobos:{hashlib.sha256(material.encode()).hexdigest()}"
+        if kind in {"turn_completed", "turn_cancelled", "turn_failed", "recovery_required"}:
+            self._terminal_turns.add(turn_id)
+            self._active_turn_id = None
+        return GatewayEvent(
+            event_type=event.event_type,
+            state=event.state,
+            summary=event.summary,
+            detail=event.detail,
+            turn_id=turn_id,
+            source_event_id=source_event_id,
+            activity_id=event.activity_id,
+            normalized_kind=kind,
+            profile_id=self._profile_id,
+            conversation_id=self._conversation_id,
+            sequence=sequence,
+            timestamp=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        )
+
+    async def close(self) -> None:
+        if self._event_task is not None:
+            self._event_task.cancel()
+            await asyncio.gather(self._event_task, return_exceptions=True)
+        await self._gateway.close()
+        await self._events.put(None)
 
 
 class OfflineAgentGatewayFactory:

--- a/services/api/jobos_api/agent_gateway.py
+++ b/services/api/jobos_api/agent_gateway.py
@@ -343,11 +343,9 @@ class _RoutedAgentGateway:
             self._conversation_id,
         )
         self._active_turn_id = turn_id
-        try:
-            await self._gateway.recover_active_turn(stored_session_id, turn_id)
-        finally:
-            if self._active_turn_id == turn_id:
-                self._active_turn_id = None
+        await self._gateway.recover_active_turn(stored_session_id, turn_id)
+        if self._active_turn_id == turn_id:
+            self._active_turn_id = None
 
     async def _pump_events(self) -> None:
         try:

--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -39,6 +39,7 @@ from jobos_api.activity import ActivityReportRequest, ActivityReportResponse
 from jobos_api.agent_gateway import (
     AgentGateway,
     AgentGatewayFactory,
+    AgentRuntimeRouter,
     OfflineAgentGateway,
     OfflineAgentGatewayFactory,
 )
@@ -584,6 +585,7 @@ def create_app(
     )
     installation_profiles = InstallationProfileRegistry(settings.installation_registry_path)
     profile_fence_enabled = settings.installation_registry_path.is_file()
+    hermes_agent_ids: set[str] = set()
     if profile_fence_enabled:
         migration_runtime = {
             "job_provider": settings.job_provider,
@@ -596,6 +598,9 @@ def create_app(
             "facade_source_path": None,
         }
         registry_data = installation_profiles.load_or_bootstrap(migration_runtime)
+        hermes_agent_ids = {
+            agent.id for agent in registry_data.connected_agents if agent.provider == "hermes"
+        }
         if (
             registry_data.connected_agent_migration is not None
             and any(
@@ -656,9 +661,21 @@ def create_app(
             request_timeout=settings.hermes_request_timeout,
         )
         configured_gateway = True
+    selected_gateway_factory = gateway_factory or OfflineAgentGatewayFactory()
+    runtime_router = AgentRuntimeRouter(
+        {
+            "hermes": selected_gateway_factory,
+            **{
+                ("hermes", agent_id): selected_gateway_factory
+                for agent_id in hermes_agent_ids
+            },
+        },
+        profile_id=settings.installation_profile_id,
+    )
     conversation_manager = ConversationManager(
         state_store,
-        gateway_factory or OfflineAgentGatewayFactory(),
+        runtime_router,
+        profile_id=settings.installation_profile_id,
         career_profile_principal=(
             principal_for_device(settings.device_id) if settings.career_profile_enabled else None
         ),
@@ -1245,40 +1262,50 @@ def create_app(
     async def enforce_mcp_conversation_job_scope(
         request: Request, call_next: Callable[[Request], Any]
     ) -> Response:
-        """Fence conversation-scoped MCP job/document calls at the API boundary."""
+        """Fence every valid MCP credential to one exact active turn."""
         supplied_mcp_token = request.headers.get("x-jobos-mcp-token")
-        conversation_id = request.query_params.get("conversation_id")
         if (
             supplied_mcp_token is None
             or not hmac.compare_digest(supplied_mcp_token, settings.mcp_token)
-            or conversation_id is None
         ):
             return await call_next(request)
 
-        job_id: str | None = None
-        job_match = re.match(
-            r"^/v1/jobs/([^/]+)/(?:status|description|artifacts(?:/|$)|"
-            r"editable-documents(?:/|$)|editable-document-outlines(?:/|$))",
-            request.url.path,
+        path = request.url.path
+        is_mcp_capability = (
+            path == "/v1/activity"
+            or path == "/v1/browser/commands"
+            or path == "/v1/jobs"
+            or path.startswith("/v1/jobs/")
+            or path == "/v1/workspace"
+            or path == "/v1/workspace/jobs"
+            or path.startswith("/v1/editable-documents/")
+            or bool(re.match(r"^/v1/conversations/[^/]+/workspace/(?:job|document)$", path))
+            or path == "/v1/career-profile/consumer-projection"
+            or path.startswith("/v1/career-profile/agent-")
         )
-        if job_match is not None:
-            job_id = unquote(job_match.group(1))
-        else:
-            editable_match = re.match(r"^/v1/editable-documents/([^/]+)", request.url.path)
-            if editable_match is not None:
-                document = state_store.get_editable_document(unquote(editable_match.group(1)))
-                if document is not None and isinstance(document.get("job_id"), str):
-                    job_id = cast(str, document["job_id"])
-            else:
-                artifact_match = re.match(r"^/v1/artifacts/([^/]+)", request.url.path)
-                if artifact_match is not None:
-                    artifact = state_store.get_document_artifact(unquote(artifact_match.group(1)))
-                    if artifact is not None and isinstance(artifact.get("job_id"), str):
-                        job_id = cast(str, artifact["job_id"])
-
-        if job_id is None:
+        if not is_mcp_capability:
             return await call_next(request)
 
+        conversation_id = request.query_params.get("conversation_id")
+        turn_id = request.query_params.get("turn_id")
+        if conversation_id is None and turn_id is None:
+            if path != "/v1/browser/commands":
+                return await call_next(request)
+            return error_response(
+                request,
+                status_code=422,
+                code="mcp_turn_required",
+                message="MCP operations require trusted conversation and turn correlation",
+                retryable=False,
+            )
+        if conversation_id is None or turn_id is None:
+            return error_response(
+                request,
+                status_code=422,
+                code="mcp_turn_required",
+                message="MCP operations require trusted conversation and turn correlation",
+                retryable=False,
+            )
         authorization = request.headers.get("authorization", "")
         scheme, _, token = authorization.partition(" ")
         identity = device_authenticator.authenticate(
@@ -1293,7 +1320,7 @@ def create_app(
                 retryable=False,
             )
         try:
-            context = conversation_manager.get(conversation_id).store.snapshot()["job_context"]
+            scoped_service = conversation_manager.get(conversation_id)
         except ConversationNotFound:
             return error_response(
                 request,
@@ -1302,16 +1329,62 @@ def create_app(
                 message="Conversation not found",
                 retryable=False,
             )
-        assert isinstance(context, dict)
-        if context.get("selected_job_id") != job_id:
-            return error_response(
-                request,
-                status_code=409,
-                code="conversation_job_mismatch",
-                message="This agent session is attached to a different job",
-                retryable=False,
+
+        async with scoped_service.turn_scope_lease():
+            turn = scoped_service.store.turn_record(turn_id)
+            active = scoped_service.store.conversation_snapshot().get("active_turn")
+            if (
+                turn is None
+                or not isinstance(active, dict)
+                or active.get("turn_id") != turn_id
+                or turn.get("status") not in {"queued", "running", "waiting"}
+                or turn.get("cancel_requested") is True
+            ):
+                return error_response(
+                    request,
+                    status_code=409,
+                    code="mcp_turn_mismatch",
+                    message="This MCP operation is not correlated to the active JobOS turn",
+                    retryable=False,
+                )
+
+            job_id: str | None = None
+            job_match = re.match(
+                r"^/v1/jobs/([^/]+)/(?:status|description|artifacts(?:/|$)|"
+                r"editable-documents(?:/|$)|editable-document-outlines(?:/|$))",
+                request.url.path,
             )
-        return await call_next(request)
+            if job_match is not None:
+                job_id = unquote(job_match.group(1))
+            else:
+                editable_match = re.match(r"^/v1/editable-documents/([^/]+)", request.url.path)
+                if editable_match is not None:
+                    document = state_store.get_editable_document(
+                        unquote(editable_match.group(1))
+                    )
+                    if document is not None and isinstance(document.get("job_id"), str):
+                        job_id = cast(str, document["job_id"])
+                else:
+                    artifact_match = re.match(r"^/v1/artifacts/([^/]+)", request.url.path)
+                    if artifact_match is not None:
+                        artifact = state_store.get_document_artifact(
+                            unquote(artifact_match.group(1))
+                        )
+                        if artifact is not None and isinstance(artifact.get("job_id"), str):
+                            job_id = cast(str, artifact["job_id"])
+
+            if job_id is not None:
+                context = scoped_service.store.snapshot()["job_context"]
+                assert isinstance(context, dict)
+                if context.get("selected_job_id") != job_id:
+                    return error_response(
+                        request,
+                        status_code=409,
+                        code="conversation_job_mismatch",
+                        message="This agent session is attached to a different job",
+                        retryable=False,
+                    )
+            return await call_next(request)
 
     def mutation_hash(command_name: str, payload: dict[str, object]) -> str:
         return hashlib.sha256(
@@ -1493,11 +1566,18 @@ def create_app(
         command: BrowserCommandRequest,
         identity: Annotated[DeviceIdentity, Depends(authenticated_device)],
         mcp_token: Annotated[str | None, Header(alias="X-JobOS-MCP-Token")] = None,
+        correlated_conversation_id: Annotated[
+            str | None, Query(alias="conversation_id")
+        ] = None,
     ) -> BrowserCommandResponse:
         require_trusted_mcp(identity, command.origin, mcp_token)
-        if command.origin == "mcp" and command.conversation_id is None:
+        if command.origin == "mcp" and (
+            command.conversation_id is None
+            or command.conversation_id != correlated_conversation_id
+        ):
             raise HTTPException(
-                status_code=422, detail="MCP browser commands require a conversation ID"
+                status_code=422,
+                detail="MCP browser commands require matching query and body correlation",
             )
         try:
             arguments = command.validated_arguments()

--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -1569,6 +1569,7 @@ def create_app(
         correlated_conversation_id: Annotated[
             str | None, Query(alias="conversation_id")
         ] = None,
+        correlated_turn_id: Annotated[str | None, Query(alias="turn_id")] = None,
     ) -> BrowserCommandResponse:
         require_trusted_mcp(identity, command.origin, mcp_token)
         if command.origin == "mcp" and (

--- a/services/api/jobos_api/conversation_manager.py
+++ b/services/api/jobos_api/conversation_manager.py
@@ -3,7 +3,7 @@ from typing import Literal
 
 from pydantic import Field
 
-from .agent_gateway import AgentGatewayFactory
+from .agent_gateway import AgentGatewayFactory, AgentRuntimeRouter
 from .career_profile_context import CareerProfileContextStore
 from .conversations import (
     ConnectionResponse,
@@ -35,14 +35,16 @@ class ConversationManager:
     def __init__(
         self,
         store: JobOsStateStore,
-        gateway_factory: AgentGatewayFactory,
+        gateway_factory: AgentGatewayFactory | AgentRuntimeRouter,
         *,
+        profile_id: str | None = None,
         career_profile_principal: str | None = None,
         career_profile_context: CareerProfileContextStore | None = None,
         career_profile_agent_id: str | None = None,
     ) -> None:
         self.store = store
         self.gateway_factory = gateway_factory
+        self.profile_id = profile_id
         self.career_profile_principal = career_profile_principal
         self.career_profile_context = career_profile_context
         self.career_profile_agent_id = career_profile_agent_id
@@ -85,10 +87,19 @@ class ConversationManager:
                     raise result
 
     def _make_service(self, conversation_id: str) -> ConversationService:
+        scoped_store = self.store.conversation_store(conversation_id)
+        binding = scoped_store.binding()
+        binding["_normalized_event_sequences"] = scoped_store.normalized_event_sequences()
+        gateway = (
+            self.gateway_factory.create(conversation_id, binding)
+            if isinstance(self.gateway_factory, AgentRuntimeRouter)
+            else self.gateway_factory.create(conversation_id)
+        )
         return ConversationService(
-            self.store.conversation_store(conversation_id),
-            self.gateway_factory.create(conversation_id),
+            scoped_store,
+            gateway,
             conversation_id,
+            profile_id=self.profile_id,
             career_profile_principal=self.career_profile_principal,
             career_profile_context=self.career_profile_context,
             career_profile_agent_id=self.career_profile_agent_id,

--- a/services/api/jobos_api/conversation_store.py
+++ b/services/api/jobos_api/conversation_store.py
@@ -47,6 +47,15 @@ def event_row(row: sqlite3.Row) -> dict[str, object]:
             context=detail.get("context", {}),
             source_turn_id=detail.get("source_turn_id"),
         )
+    for key in (
+        "normalized_kind",
+        "profile_id",
+        "conversation_id",
+        "sequence",
+        "timestamp",
+    ):
+        if key in detail:
+            entry[key] = detail[key]
     return entry
 
 
@@ -87,6 +96,24 @@ class ConversationStore:
             "creation_state": row["creation_state"],
             "lock_reason": row["lock_reason"],
         }
+
+    def normalized_event_sequences(self) -> dict[str, int]:
+        """Return the durable high-water mark for each normalized turn trace."""
+        with connect_sqlite(f"file:{self._path}?mode=ro", uri=True) as connection:
+            rows = connection.execute(
+                "SELECT turn_id, detail_json FROM conversation_events "
+                "WHERE conversation_id = ? AND turn_id IS NOT NULL ORDER BY event_id",
+                (self.conversation_id,),
+            ).fetchall()
+        sequences: dict[str, int] = {}
+        for turn_id, detail_json in rows:
+            try:
+                sequence = json.loads(str(detail_json)).get("sequence")
+            except (AttributeError, TypeError, json.JSONDecodeError):
+                continue
+            if isinstance(turn_id, str) and isinstance(sequence, int) and sequence >= 0:
+                sequences[turn_id] = max(sequences.get(turn_id, 0), sequence)
+        return sequences
 
     def seal_legacy_binding(
         self,

--- a/services/api/jobos_api/conversations.py
+++ b/services/api/jobos_api/conversations.py
@@ -453,6 +453,7 @@ class ConversationService:
                 type(error).__name__,
                 getattr(error, "code", None),
             )
+            self._restore_session_after_isolated_turn(turn_id)
             self._recovery_turn_id = turn_id
             self.store.mark_recovery_turn(turn_id)
             self.store.append_conversation_event(

--- a/services/api/jobos_api/conversations.py
+++ b/services/api/jobos_api/conversations.py
@@ -4,12 +4,18 @@ import logging
 import re
 import time
 from collections.abc import AsyncIterator
-from contextlib import suppress
-from typing import Literal, Protocol
+from contextlib import asynccontextmanager, suppress
+from typing import Literal, Protocol, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from .agent_gateway import AgentContext, AgentGateway
+from .agent_gateway import (
+    AgentContext,
+    AgentGateway,
+    AmbiguousDeliveryError,
+    ConnectedAgentProvider,
+    GatewayEvent,
+)
 from .career_profile_context import CareerProfileContextStore
 from .conversation_store import ConversationStore
 from .redaction import safe_error_summary, sanitize_user_text
@@ -96,6 +102,7 @@ class ConversationService:
         store: ConversationStore | JobOsStateStore,
         gateway: AgentGateway,
         conversation_id: str | None = None,
+        profile_id: str | None = None,
         career_profile_principal: str | None = None,
         career_profile_context: CareerProfileContextStore | None = None,
         career_profile_agent_id: str | None = None,
@@ -104,6 +111,7 @@ class ConversationService:
             conversation_id = conversation_id or store.first_active_conversation_id()
             store = store.conversation_store(conversation_id)
         self.conversation_id = conversation_id or store.conversation_id
+        self.profile_id = profile_id
         self.store = store
         self.gateway = gateway
         self.career_profile_principal = career_profile_principal
@@ -114,7 +122,14 @@ class ConversationService:
         self._recovery_turn_id: str | None = None
         self._isolated_session_ids: set[str] = set()
         self._submission_lock = asyncio.Lock()
+        self._turn_scope_lock = asyncio.Lock()
         self._event_consumer_restart_delay = 1.0
+
+    @asynccontextmanager
+    async def turn_scope_lease(self) -> AsyncIterator[None]:
+        """Keep cancellation settlement outside an authorized MCP operation."""
+        async with self._turn_scope_lock:
+            yield
 
     def _restore_session_after_isolated_turn(self, turn_id: str) -> None:
         self.store.restore_isolated_agent_session(turn_id)
@@ -323,6 +338,10 @@ class ConversationService:
         return TurnMutationResponse(**created)
 
     async def cancel(self, turn_id: str) -> TurnMutationResponse | None:
+        async with self._turn_scope_lock:
+            return await self._cancel_under_lease(turn_id)
+
+    async def _cancel_under_lease(self, turn_id: str) -> TurnMutationResponse | None:
         initial = self.store.turn_record(turn_id)
         if initial is None:
             return None
@@ -428,6 +447,26 @@ class ConversationService:
             if context.get(FRESH_AGENT_SESSION_CONTEXT_KEY) is True:
                 self._isolated_session_ids.add(stored_id)
                 self.store.record_isolated_agent_session(turn_id, stored_id)
+        except AmbiguousDeliveryError as error:
+            logger.warning(
+                "Agent conversation attachment is ambiguous (%s, code=%s)",
+                type(error).__name__,
+                getattr(error, "code", None),
+            )
+            self._recovery_turn_id = turn_id
+            self.store.mark_recovery_turn(turn_id)
+            self.store.append_conversation_event(
+                turn_id=turn_id,
+                event_type="status",
+                state="waiting",
+                summary="Agent attachment outcome must be confirmed before retrying",
+                detail={"actionable": True, "recovery_pending": True, "retry": False},
+                source_event_id=f"ambiguous-attachment:{turn_id}",
+            )
+            self.store.transition_active_turn_status(
+                turn_id, "waiting", expected=("queued", "running", "waiting")
+            )
+            return
         except Exception as error:
             logger.warning(
                 "Agent conversation attachment failed (%s, code=%s)",
@@ -457,6 +496,7 @@ class ConversationService:
                 ):
                     return
                 selected_job = context.get("selected_job")
+                binding = self.store.binding()
                 await self.gateway.submit_turn(
                     str(turn["text"]),
                     AgentContext(
@@ -471,6 +511,28 @@ class ConversationService:
                         ),
                         career_profile=career_profile,
                         career_profile_context=career_profile_context,
+                        profile_id=self.profile_id,
+                        connected_agent_id=(
+                            str(binding["connected_agent_id"])
+                            if binding.get("connected_agent_id") is not None
+                            else None
+                        ),
+                        provider=(
+                            cast(ConnectedAgentProvider, binding["provider"])
+                            if binding.get("provider") in {"hermes", "codex"}
+                            else None
+                        ),
+                        model_id=(
+                            str(binding["model_id"])
+                            if binding.get("model_id") is not None
+                            else None
+                        ),
+                        reasoning_effort=(
+                            str(binding["reasoning_effort"])
+                            if binding.get("reasoning_effort") is not None
+                            else None
+                        ),
+                        permission_state={"scope": "global"},
                     ),
                 )
         except Exception as error:
@@ -498,11 +560,12 @@ class ConversationService:
                 state = event.detail.get("agent_connection")
                 if state in {"online", "connecting", "offline"}:
                     self.store.append_conversation_event(
-                        turn_id=None,
+                        turn_id=event.turn_id,
                         event_type="status",
                         state="working",
                         summary=f"Agent {state}",
-                        detail={"agent_connection": state},
+                        detail=self._event_detail(event, {"agent_connection": state}),
+                        source_event_id=event.source_event_id,
                     )
                 continue
             if event.event_type == "reconciliation":
@@ -515,6 +578,14 @@ class ConversationService:
                     continue
                 if isinstance(stored_session_id, str) and 0 < len(stored_session_id) <= 256:
                     self.store.save_stored_session_id(stored_session_id)
+                self.store.append_conversation_event(
+                    turn_id=event.turn_id,
+                    event_type="status",
+                    state="working",
+                    summary="Agent session reconciled",
+                    detail=self._event_detail(event, {}),
+                    source_event_id=event.source_event_id,
+                )
                 continue
             turn_id = event.turn_id
             if turn_id and self.store.turn_record(turn_id) is None:
@@ -528,7 +599,7 @@ class ConversationService:
                         status=event.state,
                         event_type=event.event_type,
                         summary=event.summary,
-                        detail={**event.detail, "activity_id": event.activity_id},
+                        detail=self._event_detail(event),
                         source_event_id=event.source_event_id,
                         career_profile_principal=self.career_profile_principal,
                         career_profile_context=self.career_profile_context,
@@ -546,7 +617,7 @@ class ConversationService:
                     event.state,
                     event_type=event.event_type,
                     summary=event.summary,
-                    detail={**event.detail, "activity_id": event.activity_id},
+                    detail=self._event_detail(event),
                     source_event_id=event.source_event_id,
                     quarantine=event.detail.get("reason") == "transport_lost",
                 )
@@ -563,7 +634,7 @@ class ConversationService:
                 event_type=event.event_type,
                 state=event.state,
                 summary=event.summary,
-                detail={**event.detail, "activity_id": event.activity_id},
+                detail=self._event_detail(event),
                 source_event_id=event.source_event_id,
                 continuation_ids=continuation_ids,
             )
@@ -583,6 +654,24 @@ class ConversationService:
                 and event.state == "working"
             ):
                 self.store.transition_active_turn_status(turn_id, "running", expected=("waiting",))
+
+    @staticmethod
+    def _event_detail(
+        event: GatewayEvent, detail: dict[str, object] | None = None
+    ) -> dict[str, object]:
+        safe = dict(event.detail if detail is None else detail)
+        if event.activity_id is not None:
+            safe["activity_id"] = event.activity_id
+        for key, value in (
+            ("normalized_kind", event.normalized_kind),
+            ("profile_id", event.profile_id),
+            ("conversation_id", event.conversation_id),
+            ("sequence", event.sequence),
+            ("timestamp", event.timestamp),
+        ):
+            if value is not None:
+                safe[key] = value
+        return safe
 
     async def _supervise_gateway_events(self) -> None:
         while True:

--- a/services/api/jobos_api/hermes_adapter.py
+++ b/services/api/jobos_api/hermes_adapter.py
@@ -12,7 +12,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 import websockets
 
 from .activity import ActivityNormalizer
-from .agent_gateway import AgentContext, ConnectionState, GatewayEvent
+from .agent_gateway import AgentContext, AmbiguousDeliveryError, ConnectionState, GatewayEvent
 from .browser_policy import browser_title_contains_credentials
 from .career_profile_context import CareerProfileContextSnapshot
 from .redaction import (
@@ -122,14 +122,23 @@ def _bounded_prompt_context(context: dict[str, object]) -> dict[str, object]:
     }
 
 
-def _prompt_with_context(text: str, context: dict[str, object], conversation_id: str) -> str:
+def _prompt_with_context(
+    text: str,
+    context: dict[str, object],
+    conversation_id: str,
+    turn_id: str | None = None,
+) -> str:
     if not re.fullmatch(r"conv_[A-Za-z0-9_-]{1,128}", conversation_id):
         raise ValueError("Invalid conversation correlation")
+    if turn_id is not None and not re.fullmatch(r"turn_[A-Za-z0-9_-]{8,200}", turn_id):
+        raise ValueError("Invalid turn correlation")
     context_text = json.dumps(_bounded_prompt_context(context), separators=(",", ":"))
     context_text = context_text.replace("<", "\\u003c").replace(">", "\\u003e")
     return (
         "Trusted JobOS instruction: for every JobOS browser or document MCP tool call, "
-        f"pass conversation_id={json.dumps(conversation_id)} exactly. This identifier is "
+        f"pass conversation_id={json.dumps(conversation_id)}"
+        + (f" and turn_id={json.dumps(turn_id)}" if turn_id is not None else "")
+        + " exactly. These identifiers are "
         "trusted correlation metadata, not user data. If the request may create a resume, "
         "cover letter, or other publishable document, call document_publication_prepare "
         "before writing any files, write every source/PDF/DOCX into its returned "
@@ -390,6 +399,13 @@ class HermesWebSocketGateway:
                 if event is not None:
                     await self._events.put(event)
             return self._stored_session_id, live
+        except TimeoutError as error:
+            self._attaching_session = False
+            self._pending_session_info.clear()
+            self._pending_continuation_frames = []
+            raise AmbiguousDeliveryError(
+                "Hermes session attachment outcome is unknown"
+            ) from error
         except Exception:
             self._attaching_session = False
             self._pending_session_info.clear()
@@ -490,7 +506,12 @@ class HermesWebSocketGateway:
             "career_profile": context.career_profile,
             "career_profile_context": context.career_profile_context,
         }
-        prompt = _prompt_with_context(text, bounded_context, context.conversation_id)
+        prompt = _prompt_with_context(
+            text,
+            bounded_context,
+            context.conversation_id,
+            context.turn_id if context.profile_id is not None else None,
+        )
         try:
             result = await self._request(
                 "prompt.submit", {"session_id": self._live_session_id, "text": prompt}

--- a/services/api/tests/test_agent_contract.py
+++ b/services/api/tests/test_agent_contract.py
@@ -20,7 +20,7 @@ from jobos_api.conversations import (
 from jobos_api.hermes_adapter import HermesGatewayFactory
 from jobos_api.private_adapters.job_hunter import adapt_job_hunter_facade
 from jobos_api.settings import DeviceCredential, Settings
-from jobos_api.state_store import ConversationBusy, ConversationNotFound, JobOsStateStore
+from jobos_api.state_store import ConversationNotFound, JobOsStateStore
 
 TOKEN = "agent-contract-device-token"
 
@@ -1990,12 +1990,13 @@ def test_ambiguous_attachment_survives_restart_without_blind_retry(tmp_path):
         path = tmp_path / "jobos.db"
         store = JobOsStateStore(path)
         store.initialize()
+        store.save_stored_session_id("previous-session")
         gateway = AmbiguousAttachmentGateway()
         service = ConversationService(store, gateway)
         created = await service.send(
             SendMessageRequest(
                 text="Do not submit this twice",
-                idempotency_key="ambiguous-attachment-turn",
+                idempotency_key="browser-save-ambiguous-attachment-turn",
             ),
             actor_id="device-a",
             context={"selected_job_id": None, "workspace": {}},
@@ -2005,19 +2006,18 @@ def test_ambiguous_attachment_survives_restart_without_blind_retry(tmp_path):
         assert turn is not None
         assert turn["status"] == "waiting"
         assert store.recovery_turn_id() == created.turn_id
+        assert store.stored_session_id() == "previous-session"
         assert gateway.submissions == []
 
         restarted_store = JobOsStateStore(path)
         restarted_store.initialize()
         restarted_gateway = FakeGateway()
         restarted = ConversationService(restarted_store, restarted_gateway)
-        with pytest.raises(ConversationBusy, match="cleanup must be confirmed"):
-            await restarted.retry(
-                created.turn_id,
-                RetryTurnRequest(idempotency_key="ambiguous-attachment-retry"),
-                actor_id="device-a",
-            )
+        cancelled = await restarted.cancel(created.turn_id)
+        assert cancelled is not None
+        assert cancelled.status == "interrupted"
         assert restarted_gateway.submissions == []
+        assert restarted_gateway.interruptions == [created.turn_id]
         entries = restarted_store.conversation_snapshot()["entries"]
         assert sum(entry["type"] == "turn" for entry in entries) == 1
 

--- a/services/api/tests/test_agent_contract.py
+++ b/services/api/tests/test_agent_contract.py
@@ -4,7 +4,11 @@ import time
 
 import pytest
 from fastapi.testclient import TestClient
-from jobos_api.agent_gateway import AgentContext, GatewayEvent
+from jobos_api.agent_gateway import (
+    AgentContext,
+    AmbiguousDeliveryError,
+    GatewayEvent,
+)
 from jobos_api.app import create_app
 from jobos_api.conversation_manager import ConversationManager
 from jobos_api.conversations import (
@@ -16,7 +20,7 @@ from jobos_api.conversations import (
 from jobos_api.hermes_adapter import HermesGatewayFactory
 from jobos_api.private_adapters.job_hunter import adapt_job_hunter_facade
 from jobos_api.settings import DeviceCredential, Settings
-from jobos_api.state_store import ConversationNotFound, JobOsStateStore
+from jobos_api.state_store import ConversationBusy, ConversationNotFound, JobOsStateStore
 
 TOKEN = "agent-contract-device-token"
 
@@ -52,8 +56,9 @@ class FakeJobFacade:
 
 
 class FakeGateway:
-    def __init__(self, *, online=True) -> None:
+    def __init__(self, *, online=True, session_scope="") -> None:
         self.online = online
+        self.session_scope = session_scope
         self.submissions: list[tuple[str, AgentContext]] = []
         self.session_requests: list[str | None] = []
         self.interruptions: list[str] = []
@@ -72,8 +77,8 @@ class FakeGateway:
     async def create_or_resume_conversation(self, stored_session_id):
         self.session_requests.append(stored_session_id)
         if not self.online:
-            raise ConnectionError("dashboard unavailable with Authorization: secret-value")
-        return "stored-session", "live-session"
+            raise ConnectionError("dashboard unavailable with Authorization: ***")
+        return f"stored-session{self.session_scope}", f"live-session{self.session_scope}"
 
     async def submit_turn(self, text, context):
         if not self.online:
@@ -146,6 +151,12 @@ class InterruptFailureGateway(FakeGateway):
     async def interrupt_turn(self, turn_id):
         self.interruptions.append(turn_id)
         raise ConnectionError("Authorization: Bearer cancellation-secret")
+
+
+class AmbiguousAttachmentGateway(FakeGateway):
+    async def create_or_resume_conversation(self, stored_session_id):
+        self.session_requests.append(stored_session_id)
+        raise AmbiguousDeliveryError("Provider attachment outcome is unknown")
 
 
 class RotatingSessionGateway(FakeGateway):
@@ -1028,7 +1039,8 @@ def test_rotated_durable_id_reconciles_without_transcript_or_raw_metadata(tmp_pa
 
     assert store.stored_session_id() == "stored-rotated"
     snapshot = store.conversation_snapshot()
-    assert snapshot["entries"] == []
+    assert len(snapshot["entries"]) == 1
+    assert snapshot["entries"][0]["summary"] == "Agent session reconciled"
     serialized = json.dumps(snapshot)
     assert "stored-rotated" not in serialized
     assert "running" not in serialized
@@ -1461,7 +1473,7 @@ class RecordingGatewayFactory:
         self.gateways = {}
 
     def create(self, conversation_id):
-        gateway = FakeGateway()
+        gateway = FakeGateway(session_scope=f"-{conversation_id}")
         self.gateways[conversation_id] = gateway
         return gateway
 
@@ -1971,3 +1983,142 @@ def test_conversation_routes_share_profile_authority_across_authenticated_device
     assert [item["title"] for item in primary_list] == [f"Session {value}" for value in range(1, 6)]
     assert primary_cap.status_code == remote_cap.status_code == 409
     assert f'"conversation_id":"{primary_id}"' in stream.text
+
+
+def test_ambiguous_attachment_survives_restart_without_blind_retry(tmp_path):
+    async def scenario():
+        path = tmp_path / "jobos.db"
+        store = JobOsStateStore(path)
+        store.initialize()
+        gateway = AmbiguousAttachmentGateway()
+        service = ConversationService(store, gateway)
+        created = await service.send(
+            SendMessageRequest(
+                text="Do not submit this twice",
+                idempotency_key="ambiguous-attachment-turn",
+            ),
+            actor_id="device-a",
+            context={"selected_job_id": None, "workspace": {}},
+        )
+
+        turn = store.turn_record(created.turn_id)
+        assert turn is not None
+        assert turn["status"] == "waiting"
+        assert store.recovery_turn_id() == created.turn_id
+        assert gateway.submissions == []
+
+        restarted_store = JobOsStateStore(path)
+        restarted_store.initialize()
+        restarted_gateway = FakeGateway()
+        restarted = ConversationService(restarted_store, restarted_gateway)
+        with pytest.raises(ConversationBusy, match="cleanup must be confirmed"):
+            await restarted.retry(
+                created.turn_id,
+                RetryTurnRequest(idempotency_key="ambiguous-attachment-retry"),
+                actor_id="device-a",
+            )
+        assert restarted_gateway.submissions == []
+        entries = restarted_store.conversation_snapshot()["entries"]
+        assert sum(entry["type"] == "turn" for entry in entries) == 1
+
+    asyncio.run(scenario())
+
+
+def test_authorized_turn_scope_finishes_before_cancellation_settles(tmp_path):
+    async def scenario():
+        store = JobOsStateStore(tmp_path / "jobos.db")
+        store.initialize()
+        gateway = FakeGateway()
+        service = ConversationService(store, gateway)
+        created = await service.send(
+            SendMessageRequest(
+                text="Run one scoped operation",
+                idempotency_key="turn-scope-cancellation",
+            ),
+            actor_id="device-a",
+            context={"selected_job_id": None, "workspace": {}},
+        )
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def authorized_operation():
+            async with service.turn_scope_lease():
+                entered.set()
+                await release.wait()
+
+        operation = asyncio.create_task(authorized_operation())
+        await entered.wait()
+        cancellation = asyncio.create_task(service.cancel(created.turn_id))
+        await asyncio.sleep(0)
+        assert not cancellation.done()
+        release.set()
+        await operation
+        cancelled = await cancellation
+        assert cancelled is not None
+        assert cancelled.status == "interrupted"
+
+    asyncio.run(scenario())
+
+
+def test_normalized_event_envelope_is_durable_across_store_restart(tmp_path):
+    async def scenario():
+        path = tmp_path / "jobos.db"
+        store = JobOsStateStore(path)
+        store.initialize()
+        gateway = FakeGateway()
+        service = ConversationService(store, gateway, profile_id="jprof_test")
+        created = await service.send(
+            SendMessageRequest(
+                text="Persist normalized events",
+                idempotency_key="normalized-event-replay",
+            ),
+            actor_id="device-a",
+            context={"selected_job_id": None, "workspace": {}},
+        )
+        gateway._events = [
+            GatewayEvent(
+                event_type="status",
+                state="working",
+                summary="Agent turn started",
+                turn_id=created.turn_id,
+                source_event_id="normalized-start",
+                normalized_kind="turn_started",
+                profile_id="jprof_test",
+                conversation_id=service.conversation_id,
+                sequence=1,
+                timestamp="2026-08-24T20:00:00Z",
+            ),
+            GatewayEvent(
+                event_type="assistant_message",
+                state="completed",
+                summary="Done",
+                turn_id=created.turn_id,
+                source_event_id="normalized-complete",
+                normalized_kind="turn_completed",
+                profile_id="jprof_test",
+                conversation_id=service.conversation_id,
+                sequence=2,
+                timestamp="2026-08-24T20:00:01Z",
+            ),
+        ]
+        await service._consume_gateway_events()
+
+        restarted = JobOsStateStore(path)
+        restarted.initialize()
+        entries = restarted.conversation_snapshot()["entries"]
+        normalized = [entry for entry in entries if entry.get("normalized_kind")]
+        assert [entry["normalized_kind"] for entry in normalized] == [
+            "turn_started",
+            "turn_completed",
+        ]
+        assert [entry["sequence"] for entry in normalized] == [1, 2]
+        assert all(entry["profile_id"] == "jprof_test" for entry in normalized)
+        assert all(
+            entry["conversation_id"] == service.conversation_id for entry in normalized
+        )
+        assert [entry["timestamp"] for entry in normalized] == [
+            "2026-08-24T20:00:00Z",
+            "2026-08-24T20:00:01Z",
+        ]
+
+    asyncio.run(scenario())

--- a/services/api/tests/test_agent_runtime_router.py
+++ b/services/api/tests/test_agent_runtime_router.py
@@ -1,0 +1,254 @@
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+from jobos_api.agent_gateway import (
+    AgentContext,
+    AgentRuntimeRouter,
+    GatewayEvent,
+)
+
+PROFILE_ID = "jprof_11111111111111111111111111111111"
+AGENT_ID = "jagent_22222222222222222222222222222222"
+
+
+def sealed_binding(*, provider: str = "hermes") -> dict[str, object]:
+    return {
+        "connected_agent_id": AGENT_ID,
+        "provider": provider,
+        "model_id": "(FAKE)-model-stable",
+        "reasoning_effort": "medium",
+        "binding_state": "sealed",
+        "provider_session_id": None,
+        "connection_account_fingerprint": None,
+        "creation_state": "ready",
+        "lock_reason": None,
+    }
+
+
+def trusted_context(conversation_id: str, turn_id: str) -> AgentContext:
+    return AgentContext(
+        turn_id=turn_id,
+        selected_job_id=None,
+        workspace={},
+        conversation_id=conversation_id,
+        profile_id=PROFILE_ID,
+        connected_agent_id=AGENT_ID,
+        provider="hermes",
+        model_id="(FAKE)-model-stable",
+        reasoning_effort="medium",
+        permission_state={"scope": "global"},
+    )
+
+
+class QueueGateway:
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        self.events: asyncio.Queue[GatewayEvent | None] = asyncio.Queue()
+        self.submissions: list[tuple[str, AgentContext]] = []
+        self.interruptions: list[str] = []
+        self.detaches = 0
+        self.closed = False
+
+    @property
+    def connection_state(self):
+        return "online"
+
+    async def start(self) -> None:
+        return None
+
+    async def create_or_resume_conversation(self, stored_session_id: str | None):
+        return stored_session_id or self.session_id, f"live-{self.session_id}"
+
+    async def detach_conversation(self) -> None:
+        self.detaches += 1
+
+    async def submit_turn(self, text: str, context: AgentContext) -> None:
+        self.submissions.append((text, context))
+
+    async def stream_events(self) -> AsyncIterator[GatewayEvent]:
+        while True:
+            event = await self.events.get()
+            if event is None:
+                return
+            yield event
+
+    async def interrupt_turn(self, turn_id: str) -> None:
+        self.interruptions.append(turn_id)
+
+    async def recover_active_turn(self, stored_session_id: str, turn_id: str) -> None:
+        self.interruptions.append(turn_id)
+
+    async def close(self) -> None:
+        self.closed = True
+        await self.events.put(None)
+
+
+class QueueFactory:
+    def __init__(self, *, shared_session: str | None = None) -> None:
+        self.shared_session = shared_session
+        self.gateways: dict[str, QueueGateway] = {}
+
+    def create(self, conversation_id: str) -> QueueGateway:
+        gateway = QueueGateway(self.shared_session or f"session-{conversation_id}")
+        self.gateways[conversation_id] = gateway
+        return gateway
+
+
+def test_router_fails_closed_for_unregistered_provider_and_incomplete_binding():
+    router = AgentRuntimeRouter(
+        {("hermes", AGENT_ID): QueueFactory()}, profile_id=PROFILE_ID
+    )
+
+    with pytest.raises(ConnectionError, match="provider is unavailable"):
+        router.create("conv_codex", sealed_binding(provider="codex"))
+    with pytest.raises(ValueError, match="incomplete"):
+        router.create(
+            "conv_incomplete",
+            {**sealed_binding(), "model_id": None},
+        )
+
+
+def test_router_rejects_cross_chat_session_reuse_and_wrong_turn_envelope():
+    async def scenario() -> None:
+        factory = QueueFactory(shared_session="(FAKE)-shared-session")
+        router = AgentRuntimeRouter({("hermes", AGENT_ID): factory}, profile_id=PROFILE_ID)
+        first = router.create("conv_first", sealed_binding())
+        second = router.create("conv_second", sealed_binding())
+        await first.start()
+        await second.start()
+        await first.create_or_resume_conversation(None)
+        with pytest.raises(RuntimeError, match="already owned"):
+            await second.create_or_resume_conversation(None)
+        assert factory.gateways["conv_second"].detaches == 1
+        with pytest.raises(ValueError, match="scope"):
+            await first.submit_turn("wrong chat", trusted_context("conv_second", "turn_wrong_1234"))
+        with pytest.raises(ValueError, match="binding"):
+            wrong = trusted_context("conv_first", "turn_wrong_5678")
+            object.__setattr__(wrong, "model_id", "(FAKE)-other-model")
+            await first.submit_turn("wrong binding", wrong)
+        await first.close()
+        await second.close()
+
+    asyncio.run(scenario())
+
+
+def test_router_normalizes_orders_deduplicates_and_seals_terminal_outcome():
+    async def scenario() -> None:
+        factory = QueueFactory()
+        router = AgentRuntimeRouter({("hermes", AGENT_ID): factory}, profile_id=PROFILE_ID)
+        routed = router.create("conv_events", sealed_binding())
+        await routed.start()
+        await routed.create_or_resume_conversation(None)
+        context = trusted_context("conv_events", "turn_events_1234")
+        await routed.submit_turn("safe", context)
+        provider = factory.gateways["conv_events"]
+        duplicate = GatewayEvent(
+            event_type="activity",
+            state="working",
+            summary="(FAKE) tool running",
+            turn_id=context.turn_id,
+            source_event_id="(FAKE)-source-tool",
+            activity_id="(FAKE)-activity",
+        )
+        await provider.events.put(duplicate)
+        await provider.events.put(duplicate)
+        await provider.events.put(
+            GatewayEvent(
+                event_type="assistant_message",
+                state="completed",
+                summary="(FAKE) done",
+                turn_id=context.turn_id,
+                source_event_id="(FAKE)-source-terminal",
+            )
+        )
+        await provider.events.put(
+            GatewayEvent(
+                event_type="error",
+                state="failed",
+                summary="(FAKE) late",
+                turn_id=context.turn_id,
+                source_event_id="(FAKE)-source-late",
+            )
+        )
+
+        stream = routed.stream_events()
+        observed = [await asyncio.wait_for(anext(stream), 1) for _ in range(3)]
+        assert [event.normalized_kind for event in observed] == [
+            "turn_started",
+            "tool_progress",
+            "turn_completed",
+        ]
+        assert [event.sequence for event in observed] == [1, 2, 3]
+        assert all(event.profile_id == PROFILE_ID for event in observed)
+        assert all(event.conversation_id == "conv_events" for event in observed)
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(anext(stream), 0.05)
+        await routed.close()
+
+    asyncio.run(scenario())
+
+
+def test_router_resumes_durable_turn_sequence_and_normalizes_reconciliation():
+    async def scenario() -> None:
+        factory = QueueFactory()
+        router = AgentRuntimeRouter({("hermes", AGENT_ID): factory}, profile_id=PROFILE_ID)
+        binding = {
+            **sealed_binding(),
+            "_normalized_event_sequences": {"turn_restart_1234": 2},
+        }
+        routed = router.create("conv_restart", binding)
+        await routed.start()
+        await routed.create_or_resume_conversation("stored-conv-restart")
+        context = trusted_context("conv_restart", "turn_restart_1234")
+        await routed.submit_turn("resume safely", context)
+        await factory.gateways["conv_restart"].events.put(
+            GatewayEvent(
+                event_type="reconciliation",
+                state="idle",
+                summary="",
+                detail={"stored_session_id": "stored-conv-restart"},
+            )
+        )
+
+        stream = routed.stream_events()
+        started = await asyncio.wait_for(anext(stream), 1)
+        reconciled = await asyncio.wait_for(anext(stream), 1)
+
+        assert started.sequence == 3
+        assert reconciled.sequence == 4
+        assert reconciled.normalized_kind == "connection_changed"
+        assert reconciled.turn_id == context.turn_id
+        await routed.close()
+
+    asyncio.run(scenario())
+
+
+def test_cancellation_is_scoped_to_the_current_chat_and_turn():
+    async def scenario() -> None:
+        factory = QueueFactory()
+        router = AgentRuntimeRouter({("hermes", AGENT_ID): factory}, profile_id=PROFILE_ID)
+        first = router.create("conv_cancel_a", sealed_binding())
+        second = router.create("conv_cancel_b", sealed_binding())
+        await first.start()
+        await second.start()
+        await first.create_or_resume_conversation(None)
+        await second.create_or_resume_conversation(None)
+        first_context = trusted_context("conv_cancel_a", "turn_cancel_a_1234")
+        second_context = trusted_context("conv_cancel_b", "turn_cancel_b_1234")
+        await first.submit_turn("first", first_context)
+        await second.submit_turn("second", second_context)
+
+        await first.interrupt_turn(second_context.turn_id)
+        await first.interrupt_turn(first_context.turn_id)
+
+        assert factory.gateways["conv_cancel_a"].interruptions == [first_context.turn_id]
+        assert factory.gateways["conv_cancel_b"].interruptions == []
+        await first.submit_turn(
+            "next",
+            trusted_context("conv_cancel_a", "turn_cancel_a_next_1234"),
+        )
+        await first.close()
+        await second.close()
+
+    asyncio.run(scenario())

--- a/services/api/tests/test_browser_capability.py
+++ b/services/api/tests/test_browser_capability.py
@@ -100,6 +100,13 @@ def begin_active_conversation(client, *, token=TOKEN, key="browser-active-turn-1
     return conversation_id
 
 
+def active_correlation(client, conversation_id):
+    active = client.get(
+        f"/v1/conversations/{conversation_id}", headers=auth()
+    ).json()["active_turn"]
+    return {"conversation_id": conversation_id, "turn_id": active["turn_id"]}
+
+
 def test_tab_association_requires_a_bounded_job_id():
     request = BrowserCommandRequest(
         command="tab.associate",
@@ -187,10 +194,15 @@ def test_tab_association_rejects_unknown_jobs_before_desktop_dispatch(tmp_path):
     }
     with TestClient(app) as client:
         body["conversation_id"] = begin_active_conversation(client)
-        missing = client.post("/v1/browser/commands", headers=mcp_auth(), json=body)
+        params = active_correlation(client, body["conversation_id"])
+        missing = client.post(
+            "/v1/browser/commands", headers=mcp_auth(), params=params, json=body
+        )
         body["arguments"]["job_id"] = "job-known"
         body["idempotency_key"] = "associate-known-1"
-        known = client.post("/v1/browser/commands", headers=mcp_auth(), json=body)
+        known = client.post(
+            "/v1/browser/commands", headers=mcp_auth(), params=params, json=body
+        )
 
     assert missing.status_code == 422
     assert missing.json()["detail"] == "Cannot associate a browser tab with an unknown job"
@@ -323,6 +335,10 @@ def test_mcp_browser_command_targets_the_desktop_that_started_the_turn(tmp_path)
         result = client.post(
             "/v1/browser/commands",
             headers=mcp_auth(),
+            params={
+                "conversation_id": conversation_id,
+                "turn_id": turn.json()["turn_id"],
+            },
             json={
                 "command": "page.snapshot",
                 "arguments": {"tab_id": "macbook-tab"},
@@ -341,11 +357,15 @@ def test_mcp_browser_commands_are_correlated_to_one_active_conversation(tmp_path
     class Gateway:
         connection_state = "online"
 
+        def __init__(self, conversation_id):
+            self.conversation_id = conversation_id
+
         async def start(self):
             return None
 
         async def create_or_resume_conversation(self, stored_session_id):
-            return "stored-session", "live-session"
+            session_id = stored_session_id or f"stored-{self.conversation_id}"
+            return session_id, f"live-{self.conversation_id}"
 
         async def submit_turn(self, text, context):
             return None
@@ -368,7 +388,7 @@ def test_mcp_browser_commands_are_correlated_to_one_active_conversation(tmp_path
 
     class Factory:
         def create(self, conversation_id):
-            return Gateway()
+            return Gateway(conversation_id)
 
     class CapturingBroker:
         def __init__(self):
@@ -400,24 +420,22 @@ def test_mcp_browser_commands_are_correlated_to_one_active_conversation(tmp_path
             "/v1/conversations", headers={"Authorization": f"Bearer {REMOTE_TOKEN}"}
         ).json()["conversation_id"]
         idle_id = client.post("/v1/conversations", headers=auth()).json()["conversation_id"]
-        assert (
-            client.post(
-                f"/v1/conversations/{first_id}/messages",
-                headers=auth(),
-                json={"text": "First", "idempotency_key": "correlation-first-1"},
-            ).status_code
-            == 201
+        first_turn = client.post(
+            f"/v1/conversations/{first_id}/messages",
+            headers=auth(),
+            json={"text": "First", "idempotency_key": "correlation-first-1"},
         )
-        assert (
-            client.post(
-                f"/v1/conversations/{second_id}/messages",
-                headers={"Authorization": f"Bearer {REMOTE_TOKEN}"},
-                json={"text": "Second", "idempotency_key": "correlation-second-1"},
-            ).status_code
-            == 201
+        second_turn = client.post(
+            f"/v1/conversations/{second_id}/messages",
+            headers={"Authorization": f"Bearer {REMOTE_TOKEN}"},
+            json={"text": "Second", "idempotency_key": "correlation-second-1"},
         )
+        assert first_turn.status_code == 201
+        assert second_turn.status_code == 201
+        first_turn_id = first_turn.json()["turn_id"]
+        second_turn_id = second_turn.json()["turn_id"]
 
-        def command(conversation_id=None, key="correlation-command-1"):
+        def command(conversation_id=None, turn_id=None, key="correlation-command-1"):
             body = {
                 "command": "tabs.inspect",
                 "arguments": {},
@@ -426,15 +444,29 @@ def test_mcp_browser_commands_are_correlated_to_one_active_conversation(tmp_path
             }
             if conversation_id is not None:
                 body["conversation_id"] = conversation_id
-            return client.post("/v1/browser/commands", headers=mcp_auth(), json=body)
+            params = {}
+            if conversation_id is not None:
+                params["conversation_id"] = conversation_id
+            if turn_id is not None:
+                params["turn_id"] = turn_id
+            return client.post("/v1/browser/commands", headers=mcp_auth(), params=params, json=body)
 
-        assert command(second_id, "correlation-second-command").status_code == 200
-        assert command(first_id, "correlation-first-command").status_code == 200
-        assert command(None, "correlation-missing-command").status_code == 422
-        assert command("conv_unknown", "correlation-wrong-command").status_code == 404
-        assert command(idle_id, "correlation-idle-command").status_code == 409
+        assert command(second_id, second_turn_id, "correlation-second-command").status_code == 200
+        assert command(first_id, first_turn_id, "correlation-first-command").status_code == 200
+        assert command(first_id, None, "correlation-missing-turn").status_code == 422
+        cross_chat = command(first_id, second_turn_id, "correlation-cross-chat")
+        assert cross_chat.status_code == 409
+        assert cross_chat.json()["code"] == "mcp_turn_mismatch"
+        stale_turn = command(first_id, "turn_stale_00000001", "correlation-stale-turn")
+        assert stale_turn.status_code == 409
+        assert stale_turn.json()["code"] == "mcp_turn_mismatch"
+        assert command(None, None, "correlation-missing-command").status_code == 422
+        assert (
+            command("conv_unknown", first_turn_id, "correlation-wrong-command").status_code == 404
+        )
+        assert command(idle_id, first_turn_id, "correlation-idle-command").status_code == 409
         assert client.delete(f"/v1/conversations/{idle_id}", headers=auth()).status_code == 204
-        assert command(idle_id, "correlation-archived-command").status_code == 404
+        assert command(idle_id, first_turn_id, "correlation-archived-command").status_code == 404
 
     assert broker.device_ids == ["example-macbook", "primary-device"]
 
@@ -506,6 +538,7 @@ def test_browser_command_fails_immediately_without_a_desktop(tmp_path):
         response = client.post(
             "/v1/browser/commands",
             headers=mcp_auth(),
+            params=active_correlation(client, conversation_id),
             json={
                 "command": "tabs.inspect",
                 "arguments": {},
@@ -541,6 +574,7 @@ def test_authenticated_desktop_receives_correlated_command_and_replay_is_idempot
         assert presence["available"] is True
         assert 0 < presence["lease_remaining_ms"] <= 15_000
         conversation_id = begin_active_conversation(client)
+        params = active_correlation(client, conversation_id)
         chronology_before = client.get("/v1/conversations/current", headers=auth()).json()[
             "entries"
         ]
@@ -550,6 +584,7 @@ def test_authenticated_desktop_receives_correlated_command_and_replay_is_idempot
                 client.post,
                 "/v1/browser/commands",
                 headers=mcp_auth(),
+                params=params,
                 json={
                     "command": "tab.navigate",
                     "arguments": {"tab_id": "tab-1", "url": "https://example.com/jobs/1"},
@@ -584,6 +619,7 @@ def test_authenticated_desktop_receives_correlated_command_and_replay_is_idempot
             replay = client.post(
                 "/v1/browser/commands",
                 headers=mcp_auth(),
+                params=params,
                 json={
                     "command": "tab.navigate",
                     "arguments": {"tab_id": "tab-1", "url": "https://example.com/jobs/1"},
@@ -631,8 +667,15 @@ def test_concurrent_durable_browser_retries_execute_the_desktop_once(tmp_path):
         ThreadPoolExecutor(max_workers=2) as executor,
     ):
         body["conversation_id"] = begin_active_conversation(client)
+        params = active_correlation(client, body["conversation_id"])
         futures = [
-            executor.submit(client.post, "/v1/browser/commands", headers=mcp_auth(), json=body)
+            executor.submit(
+                client.post,
+                "/v1/browser/commands",
+                headers=mcp_auth(),
+                params=params,
+                json=body,
+            )
             for _ in range(2)
         ]
         responses = [future.result(timeout=2) for future in futures]
@@ -659,14 +702,19 @@ def test_browser_replay_does_not_inject_activity_into_agent_chat(tmp_path):
     database = tmp_path / "jobos.db"
     with TestClient(make_app(tmp_path, broker=Broker())) as client:
         body["conversation_id"] = begin_active_conversation(client)
+        params = active_correlation(client, body["conversation_id"])
         entries_before = client.get("/v1/conversations/current", headers=auth()).json()["entries"]
-        first = client.post("/v1/browser/commands", headers=mcp_auth(), json=body)
+        first = client.post(
+            "/v1/browser/commands", headers=mcp_auth(), params=params, json=body
+        )
         with sqlite3.connect(database) as connection:
             connection.execute(
                 "DELETE FROM conversation_events WHERE summary = ?",
                 ("Browser: tab select",),
             )
-        replay = client.post("/v1/browser/commands", headers=mcp_auth(), json=body)
+        replay = client.post(
+            "/v1/browser/commands", headers=mcp_auth(), params=params, json=body
+        )
         entries = client.get("/v1/conversations/current", headers=auth()).json()["entries"]
 
     assert replay.json() == first.json()
@@ -689,10 +737,12 @@ def test_distinct_browser_actions_may_reuse_a_key_without_injecting_chat_activit
 
     with TestClient(make_app(tmp_path, broker=Broker())) as client:
         conversation_id = begin_active_conversation(client)
+        params = active_correlation(client, conversation_id)
         entries_before = client.get("/v1/conversations/current", headers=auth()).json()["entries"]
         inspect = client.post(
             "/v1/browser/commands",
             headers=mcp_auth(),
+            params=params,
             json={
                 "command": "tabs.inspect",
                 "arguments": {},
@@ -705,6 +755,7 @@ def test_distinct_browser_actions_may_reuse_a_key_without_injecting_chat_activit
         select = client.post(
             "/v1/browser/commands",
             headers=mcp_auth(),
+            params=params,
             json={
                 "command": "tab.select",
                 "arguments": {"tab_id": "tab-1"},
@@ -738,13 +789,18 @@ def test_activity_report_is_idempotent_without_injecting_agent_chat_activity(tmp
         "idempotency_key": "activity-repair-1",
     }
     with TestClient(make_app(tmp_path)) as client:
-        first = client.post("/v1/activity", headers=mcp_auth(), json=body)
-        replay = client.post("/v1/activity", headers=mcp_auth(), json=body)
+        conversation_id = begin_active_conversation(client)
+        params = active_correlation(client, conversation_id)
+        entries_before = client.get(
+            "/v1/conversations/current", headers=auth()
+        ).json()["entries"]
+        first = client.post("/v1/activity", headers=mcp_auth(), params=params, json=body)
+        replay = client.post("/v1/activity", headers=mcp_auth(), params=params, json=body)
         entries = client.get("/v1/conversations/current", headers=auth()).json()["entries"]
 
     assert first.status_code == 200
     assert replay.json() == first.json()
-    assert entries == []
+    assert entries == entries_before
     with sqlite3.connect(tmp_path / "jobos.db") as connection:
         detail = json.loads(
             connection.execute(
@@ -778,7 +834,12 @@ def test_browser_command_validation_rejects_scripts_and_selector_like_targets(
     }
     with TestClient(make_app(tmp_path)) as client:
         body["conversation_id"] = begin_active_conversation(client)
-        response = client.post("/v1/browser/commands", headers=mcp_auth(), json=body)
+        response = client.post(
+            "/v1/browser/commands",
+            headers=mcp_auth(),
+            params=active_correlation(client, body["conversation_id"]),
+            json=body,
+        )
     assert response.status_code == 422
     assert message in str(response.json())
 

--- a/services/api/tests/test_document_files.py
+++ b/services/api/tests/test_document_files.py
@@ -230,11 +230,15 @@ def test_mcp_document_commands_require_an_explicit_active_conversation(tmp_path)
         accepted = client.post(
             "/v1/browser/commands",
             headers=mcp_headers(),
+            params={
+                "conversation_id": conversation_id,
+                "turn_id": started.json()["turn_id"],
+            },
             json={**command, "conversation_id": conversation_id},
         )
 
     assert missing.status_code == 422
-    assert missing.json()["detail"] == "MCP browser commands require a conversation ID"
+    assert missing.json()["code"] == "mcp_turn_required"
     assert started.status_code == 201
     assert accepted.status_code == 200
     assert len(broker.commands) == 1

--- a/services/api/tests/test_hermes_adapter.py
+++ b/services/api/tests/test_hermes_adapter.py
@@ -3,7 +3,7 @@ import json
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
-from jobos_api.agent_gateway import AgentContext, GatewayEvent
+from jobos_api.agent_gateway import AgentContext, AmbiguousDeliveryError, GatewayEvent
 from jobos_api.career_profile import (
     CareerProfileStore,
     WorkArrangementMutation,
@@ -124,6 +124,25 @@ async def next_non_connection(stream):
         item = await asyncio.wait_for(anext(stream), 1)
         if item.event_type != "connection":
             return item
+
+
+def test_session_attachment_timeout_is_ambiguous_delivery(tmp_path):
+    async def scenario():
+        socket = FakeWebSocket(lambda request: [])
+        gateway = HermesWebSocketGateway(
+            url="ws://127.0.0.1:9119/api/ws",
+            token=TOKEN,
+            cwd=tmp_path,
+            request_timeout=0.01,
+            connector=FakeConnector(socket),
+        )
+        await gateway.start()
+        with pytest.raises(AmbiguousDeliveryError):
+            await gateway.create_or_resume_conversation(None)
+        assert [request["method"] for request in socket.requests] == ["session.create"]
+        await gateway.close()
+
+    asyncio.run(scenario())
 
 
 def test_adapter_scopes_create_submit_events_and_interrupt_to_job_hunter(tmp_path):
@@ -296,8 +315,11 @@ def test_prompt_contract_preserves_user_agency_and_typed_reuse_boundaries():
         "Use my explicit claim in a hypothetical resume example",
         {},
         "conv_prompt_contract",
+        "turn_prompt_contract_0001",
     )
 
+    assert 'conversation_id="conv_prompt_contract"' in prompt
+    assert 'turn_id="turn_prompt_contract_0001"' in prompt
     assert "Never silently invent or infer career claims" in prompt
     assert (
         "User-authored or user-approved claims may be used without supporting Evidence or proof"
@@ -1597,12 +1619,9 @@ def test_adapter_timeout_is_safe_and_does_not_disclose_credentials(tmp_path):
             connector=FakeConnector(socket),
         )
         await gateway.start()
-        try:
+        with pytest.raises(AmbiguousDeliveryError) as caught:
             await gateway.create_or_resume_conversation(None)
-        except TimeoutError as error:
-            assert TOKEN not in str(error)
-        else:
-            raise AssertionError("expected timeout")
+        assert TOKEN not in str(caught.value)
         await gateway.close()
 
     asyncio.run(scenario())

--- a/services/api/tests/test_jobs_contract.py
+++ b/services/api/tests/test_jobs_contract.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 import sqlite3
@@ -258,7 +259,59 @@ class FailOnceStatusSettlementStore(JobOsStateStore):
         return super().record_mutation_result(**kwargs)
 
 
-def make_client(tmp_path, facade=None, state_store=None):
+class PendingGateway:
+    connection_state = "online"
+
+    def __init__(self, conversation_id):
+        self.conversation_id = conversation_id
+        self.events = asyncio.Queue()
+
+    async def start(self):
+        return None
+
+    async def create_or_resume_conversation(self, stored_session_id):
+        stored = stored_session_id or f"stored-{self.conversation_id}"
+        return stored, f"live-{self.conversation_id}"
+
+    async def submit_turn(self, text, context):
+        return None
+
+    async def detach_conversation(self):
+        return None
+
+    async def stream_events(self):
+        while True:
+            event = await self.events.get()
+            if event is None:
+                return
+            yield event
+
+    async def interrupt_turn(self, turn_id):
+        return None
+
+    async def recover_active_turn(self, stored_session_id, turn_id):
+        return None
+
+    async def close(self):
+        await self.events.put(None)
+
+
+class PendingGatewayFactory:
+    def create(self, conversation_id):
+        return PendingGateway(conversation_id)
+
+
+def start_active_turn(client, conversation_id, *, headers=None, key="mcp-scope-active-turn"):
+    response = client.post(
+        f"/v1/conversations/{conversation_id}/messages",
+        headers=headers or auth_headers(),
+        json={"text": "Keep MCP scope active", "idempotency_key": key},
+    )
+    assert response.status_code == 201
+    return response.json()["turn_id"]
+
+
+def make_client(tmp_path, facade=None, state_store=None, gateway_factory=None):
     repository, artifact_gateway = adapt_job_hunter_facade(
         facade or FakeJobHunterFacade()
     )
@@ -273,8 +326,24 @@ def make_client(tmp_path, facade=None, state_store=None):
         job_repository=repository,
         artifact_gateway=artifact_gateway,
         state_store=state_store,
+        agent_gateway_factory=gateway_factory or PendingGatewayFactory(),
     )
     return TestClient(app)
+
+
+def current_mcp_scope(client, *, key="mcp-current-scope-turn", job_id=None):
+    conversation_id = client.get(
+        "/v1/conversations/current", headers=auth_headers()
+    ).json()["conversation_id"]
+    if job_id is not None:
+        selected = client.put(
+            f"/v1/conversations/{conversation_id}/workspace/job",
+            headers=auth_headers(),
+            json={"job_id": job_id, "origin": "user"},
+        )
+        assert selected.status_code == 200
+    turn_id = start_active_turn(client, conversation_id, key=key)
+    return {"conversation_id": conversation_id, "turn_id": turn_id}
 
 
 def test_record_application_advances_through_required_internal_states(tmp_path):
@@ -462,9 +531,11 @@ def test_agent_job_create_stays_in_audit_without_injecting_ownerless_chat_activi
     facade = FakeJobHunterFacade()
 
     with make_client(tmp_path, facade) as client:
+        params = current_mcp_scope(client, key="agent-save-scope-turn")
         response = client.post(
             "/v1/jobs",
             headers=mcp_auth_headers(),
+            params=params,
             json=browser_job_payload(origin="mcp", idempotency_key="agent-save-1"),
         )
         conversation = client.get("/v1/conversations/current", headers=auth_headers())
@@ -476,10 +547,12 @@ def test_agent_job_create_stays_in_audit_without_injecting_ownerless_chat_activi
 
 def test_agent_read_stays_in_audit_without_injecting_ownerless_chat_activity(tmp_path):
     with make_client(tmp_path) as client:
+        params = current_mcp_scope(client, key="agent-read-scope-turn")
+        params.update(origin="mcp", idempotency_key="agent-read-audit-1")
         response = client.get(
             "/v1/jobs",
             headers=mcp_auth_headers(),
-            params={"origin": "mcp", "idempotency_key": "agent-read-audit-1"},
+            params=params,
         )
         conversation = client.get("/v1/conversations/current", headers=auth_headers())
 
@@ -506,11 +579,20 @@ def test_agent_updates_full_description_with_idempotent_recorded_mutation(tmp_pa
     }
 
     with make_client(tmp_path, facade) as client:
+        params = current_mcp_scope(
+            client, key="description-update-scope-turn", job_id="job-0"
+        )
         first = client.put(
-            "/v1/jobs/job-0/description", headers=mcp_auth_headers(), json=payload
+            "/v1/jobs/job-0/description",
+            headers=mcp_auth_headers(),
+            params=params,
+            json=payload,
         )
         replay = client.put(
-            "/v1/jobs/job-0/description", headers=mcp_auth_headers(), json=payload
+            "/v1/jobs/job-0/description",
+            headers=mcp_auth_headers(),
+            params=params,
+            json=payload,
         )
         inspected = client.get("/v1/jobs/job-0", headers=auth_headers())
         events = client.get("/v1/events?after=0", headers=auth_headers())
@@ -552,22 +634,30 @@ def test_description_update_requires_trusted_mcp_credential_and_valid_job(tmp_pa
         "idempotency_key": "description-update-2",
     }
     with make_client(tmp_path) as client:
+        params = current_mcp_scope(
+            client, key="description-validation-scope-turn", job_id="job-0"
+        )
         forbidden = client.put(
             "/v1/jobs/job-0/description",
             headers={"Authorization": "Bearer test-device-token"},
             json=payload,
         )
         missing = client.put(
-            "/v1/jobs/missing/description", headers=mcp_auth_headers(), json=payload
+            "/v1/jobs/missing/description",
+            headers=mcp_auth_headers(),
+            params=params,
+            json=payload,
         )
         invalid = client.put(
             "/v1/jobs/job-0/description",
             headers=mcp_auth_headers(),
+            params=params,
             json={**payload, "description_text": "   "},
         )
 
     assert forbidden.status_code == 403
-    assert missing.status_code == 404
+    assert missing.status_code == 409
+    assert missing.json()["code"] == "conversation_job_mismatch"
     assert invalid.status_code == 422
 
 
@@ -730,9 +820,13 @@ def test_user_and_mcp_status_changes_share_one_command_and_event_path(tmp_path):
             json={"target_status": "reviewed", "origin": "user", "reason": "Worth review"},
         )
         visible_to_mcp = client.get("/v1/jobs/job-0", headers=auth_headers())
+        params = current_mcp_scope(
+            client, key="status-change-scope-turn", job_id="job-0"
+        )
         mcp_change = client.put(
             "/v1/jobs/job-0/status",
             headers=mcp_auth_headers(),
+            params=params,
             json={"target_status": "shortlisted", "origin": "mcp"},
         )
         events = client.get("/v1/events?after=0", headers=auth_headers())
@@ -785,9 +879,13 @@ def test_selection_is_durable_and_uses_the_same_conversation_path_for_user_and_m
         state = client.get(
             f"/v1/workspace/jobs?conversation_id={conversation_id}", headers=auth_headers()
         )
+        turn_id = start_active_turn(
+            client, conversation_id, key="job-selection-scope-turn"
+        )
         mcp_selection = client.put(
             f"/v1/conversations/{conversation_id}/workspace/job",
             headers=mcp_auth_headers(),
+            params={"conversation_id": conversation_id, "turn_id": turn_id},
             json={"job_id": "job-0", "origin": "mcp"},
         )
         restored = client.get(
@@ -806,7 +904,9 @@ def test_mcp_job_and_artifact_calls_fail_closed_when_the_conversation_owns_anoth
     facade = FakeJobHunterFacade()
     facade.jobs = facade.jobs[:2]
 
-    with make_client(tmp_path, facade) as client:
+    with make_client(
+        tmp_path, facade, gateway_factory=PendingGatewayFactory()
+    ) as client:
         conversation_id = client.get(
             "/v1/conversations/current", headers=auth_headers()
         ).json()["conversation_id"]
@@ -815,12 +915,14 @@ def test_mcp_job_and_artifact_calls_fail_closed_when_the_conversation_owns_anoth
             headers=auth_headers(),
             json={"job_id": "job-0", "origin": "user"},
         )
+        turn_id = start_active_turn(client, conversation_id)
+        scope = f"conversation_id={conversation_id}&turn_id={turn_id}"
         mismatched_read = client.get(
-            f"/v1/jobs/job-1/artifacts?conversation_id={conversation_id}",
+            f"/v1/jobs/job-1/artifacts?{scope}",
             headers=mcp_auth_headers(),
         )
         mismatched_mutation = client.put(
-            f"/v1/jobs/job-1/status?conversation_id={conversation_id}",
+            f"/v1/jobs/job-1/status?{scope}",
             headers=mcp_auth_headers(),
             json={
                 "target_status": "reviewed",
@@ -829,7 +931,7 @@ def test_mcp_job_and_artifact_calls_fail_closed_when_the_conversation_owns_anoth
             },
         )
         owned_read = client.get(
-            f"/v1/jobs/job-0/artifacts?conversation_id={conversation_id}",
+            f"/v1/jobs/job-0/artifacts?{scope}",
             headers=mcp_auth_headers(),
         )
 
@@ -863,6 +965,7 @@ def test_trusted_local_mcp_scopes_publication_to_a_remote_device_conversation(
         ),
         job_repository=repository,
         artifact_gateway=artifact_gateway,
+        agent_gateway_factory=PendingGatewayFactory(),
     )
     remote_headers = {"Authorization": "Bearer remote-device-token"}
     source = b"# Remote-device resume"
@@ -885,21 +988,28 @@ def test_trusted_local_mcp_scopes_publication_to_a_remote_device_conversation(
             headers=remote_headers,
             json={"job_id": "job-0", "origin": "user"},
         )
+        turn_id = start_active_turn(
+            client,
+            conversation_id,
+            headers=remote_headers,
+            key="remote-mcp-scope-active-turn",
+        )
+        scope = f"conversation_id={conversation_id}&turn_id={turn_id}"
         published = client.post(
-            f"/v1/jobs/job-0/artifacts/publish?conversation_id={conversation_id}",
+            f"/v1/jobs/job-0/artifacts/publish?{scope}",
             headers=mcp_auth_headers(),
             json=payload,
         )
         listed = client.get(
-            f"/v1/jobs/job-0/artifacts?conversation_id={conversation_id}",
+            f"/v1/jobs/job-0/artifacts?{scope}",
             headers=mcp_auth_headers(),
         )
         missing = client.get(
-            "/v1/jobs/job-0/artifacts?conversation_id=conv_missing",
+            f"/v1/jobs/job-0/artifacts?conversation_id=conv_missing&turn_id={turn_id}",
             headers=mcp_auth_headers(),
         )
         remote_mcp_attempt = client.get(
-            f"/v1/jobs/job-0/artifacts?conversation_id={conversation_id}",
+            f"/v1/jobs/job-0/artifacts?{scope}",
             headers={**remote_headers, "X-JobOS-MCP-Token": "test-mcp-trusted-token"},
         )
 
@@ -944,9 +1054,13 @@ def test_event_stream_emits_ordered_resumable_status_events(tmp_path):
     facade.jobs = facade.jobs[:1]
 
     with make_client(tmp_path, facade) as client:
+        params = current_mcp_scope(
+            client, key="event-stream-scope-turn", job_id="job-0"
+        )
         changed = client.put(
             "/v1/jobs/job-0/status",
             headers=mcp_auth_headers(),
+            params=params,
             json={"target_status": "reviewed", "origin": "mcp"},
         )
         streamed = client.get(
@@ -1041,12 +1155,14 @@ def test_workspace_snapshot_round_trip_and_revision_conflict(tmp_path):
 
 
 def test_scoped_mcp_workspace_uses_conversation_owner_state(tmp_path):
-    with make_client(tmp_path) as client:
+    with make_client(tmp_path, gateway_factory=PendingGatewayFactory()) as client:
         conversation = client.post("/v1/conversations", headers=auth_headers()).json()
         conversation_id = conversation["conversation_id"]
+        turn_id = start_active_turn(client, conversation_id)
         selected = client.put(
             f"/v1/conversations/{conversation_id}/workspace/job",
             headers=mcp_auth_headers(),
+            params={"conversation_id": conversation_id, "turn_id": turn_id},
             json={
                 "job_id": "job-0",
                 "origin": "mcp",
@@ -1058,6 +1174,7 @@ def test_scoped_mcp_workspace_uses_conversation_owner_state(tmp_path):
         params = {
             "origin": "mcp",
             "conversation_id": conversation_id,
+            "turn_id": turn_id,
             "idempotency_key": "scoped-workspace-read",
         }
         inspected = client.get("/v1/workspace", headers=mcp_auth_headers(), params=params)
@@ -1075,7 +1192,7 @@ def test_scoped_mcp_workspace_uses_conversation_owner_state(tmp_path):
         updated = client.put(
             "/v1/workspace",
             headers=mcp_auth_headers(),
-            params={"conversation_id": conversation_id},
+            params={"conversation_id": conversation_id, "turn_id": turn_id},
             json=snapshot,
         )
         assert updated.status_code == 200
@@ -1484,9 +1601,13 @@ def test_layout_save_cannot_overwrite_a_newer_user_or_mcp_selection(tmp_path):
         stale_layout.pop("repaired_browser")
         stale_layout.pop("browser_repair_reasons")
         stale_layout.update({"origin": "user", "idempotency_key": "workspace-selection-race-1"})
+        turn_id = start_active_turn(
+            client, conversation_id, key="workspace-selection-race-turn"
+        )
         client.put(
             f"/v1/conversations/{conversation_id}/workspace/job",
             headers=mcp_auth_headers(),
+            params={"conversation_id": conversation_id, "turn_id": turn_id},
             json={"job_id": "job-1", "origin": "mcp"},
         )
         stale_layout["selected_preset"] = "research"
@@ -1600,9 +1721,13 @@ def test_trusted_mcp_can_publish_paired_pdf_and_docx_into_one_logical_revision(
         }
 
     with make_client(tmp_path, facade) as client:
+        params = current_mcp_scope(
+            client, key="paired-publication-scope-turn", job_id="job-0"
+        )
         pdf = client.post(
             "/v1/jobs/job-0/artifacts/publish",
             headers=mcp_auth_headers(),
+            params=params,
             json=payload(
                 "cover-letter.pdf",
                 build_minimal_pdf("(FAKE) letter"),
@@ -1615,11 +1740,13 @@ def test_trusted_mcp_can_publish_paired_pdf_and_docx_into_one_logical_revision(
         docx = client.post(
             "/v1/jobs/job-0/artifacts/publish",
             headers=mcp_auth_headers(),
+            params=params,
             json=docx_payload,
         )
         replay = client.post(
             "/v1/jobs/job-0/artifacts/publish",
             headers=mcp_auth_headers(),
+            params=params,
             json=docx_payload,
         )
         untrusted = client.post(
@@ -2090,9 +2217,13 @@ def test_failed_render_stays_in_audit_without_injecting_chat_activity(tmp_path):
             }
 
     with make_client(tmp_path, FailedRenderFacade()) as client:
+        params = current_mcp_scope(
+            client, key="failed-render-scope-turn", job_id="job-0"
+        )
         response = client.post(
             "/v1/jobs/job-0/artifacts/render",
             headers=mcp_auth_headers(),
+            params=params,
             json={
                 "source_id": "job-0-tailored",
                 "output_format": "pdf",
@@ -2159,7 +2290,14 @@ def test_gateway_artifact_storage_races_are_stable_503(tmp_path, route, damage):
         }
 
     with make_client(tmp_path, facade) as client:
-        response = client.post(endpoint, headers=mcp_auth_headers(), json=payload)
+        params = current_mcp_scope(
+            client,
+            key=f"storage-race-scope-{route}-{damage}",
+            job_id="job-0",
+        )
+        response = client.post(
+            endpoint, headers=mcp_auth_headers(), params=params, json=payload
+        )
         listed = client.get("/v1/jobs/job-0/artifacts", headers=auth_headers())
 
     assert (response.status_code, response.json()["detail"]) == (
@@ -2205,7 +2343,12 @@ def test_gateway_artifact_trust_validation_remains_422(tmp_path, route):
         }
 
     with make_client(tmp_path, InvalidMetadataFacade()) as client:
-        response = client.post(endpoint, headers=mcp_auth_headers(), json=payload)
+        params = current_mcp_scope(
+            client, key=f"trust-validation-scope-{route}", job_id="job-0"
+        )
+        response = client.post(
+            endpoint, headers=mcp_auth_headers(), params=params, json=payload
+        )
 
     assert response.status_code == 422
 
@@ -2642,13 +2785,18 @@ def test_mutation_replay_does_not_recreate_agent_chat_activity(
     with make_client(tmp_path, facade) as client:
         request = getattr(client, method)
         request_headers = mcp_auth_headers() if payload.get("origin") == "mcp" else auth_headers()
-        first = request(endpoint, headers=request_headers, json=payload)
+        params = current_mcp_scope(
+            client,
+            key=f"mutation-replay-scope-{method}",
+            job_id="job-0",
+        )
+        first = request(endpoint, headers=request_headers, params=params, json=payload)
         with sqlite3.connect(tmp_path / "jobos.db") as connection:
             connection.execute(
                 "DELETE FROM conversation_events WHERE source_event_id = ?",
                 (source_event_id,),
             )
-        replay = request(endpoint, headers=request_headers, json=payload)
+        replay = request(endpoint, headers=request_headers, params=params, json=payload)
 
     assert first.status_code == 200
     assert replay.status_code == 200
@@ -2667,14 +2815,19 @@ def test_workspace_save_replay_does_not_recreate_agent_chat_activity(tmp_path):
         for key in ("repaired_presets", "repaired_browser", "browser_repair_reasons"):
             body.pop(key)
         body.update({"origin": "mcp", "idempotency_key": "repair-workspace"})
-        first = client.put("/v1/workspace", headers=mcp_auth_headers(), json=body)
+        params = current_mcp_scope(client, key="workspace-replay-scope-turn")
+        first = client.put(
+            "/v1/workspace", headers=mcp_auth_headers(), params=params, json=body
+        )
         source_event_id = "workspace:primary-device:repair-workspace"
         with sqlite3.connect(tmp_path / "jobos.db") as connection:
             connection.execute(
                 "DELETE FROM conversation_events WHERE source_event_id = ?",
                 (source_event_id,),
             )
-        replay = client.put("/v1/workspace", headers=mcp_auth_headers(), json=body)
+        replay = client.put(
+            "/v1/workspace", headers=mcp_auth_headers(), params=params, json=body
+        )
 
     assert replay.json() == first.json()
     with sqlite3.connect(tmp_path / "jobos.db") as connection:
@@ -2770,10 +2923,13 @@ def test_editable_document_routes_cover_crud_conflict_snapshots_operations_and_s
         listing = client.get(
             "/v1/jobs/job-0/editable-documents", headers=auth_headers()
         )
+        scope = current_mcp_scope(
+            client, key="editable-document-scope-turn", job_id="job-0"
+        )
         outline = client.get(
             "/v1/jobs/job-0/editable-document-outlines/references",
             headers=mcp_auth_headers(),
-            params={"origin": "mcp", "idempotency_key": "draft-read-1"},
+            params={**scope, "origin": "mcp", "idempotency_key": "draft-read-1"},
         )
         assert listing.status_code == outline.status_code == 200
         assert "content" not in listing.json()["documents"][0]
@@ -2810,6 +2966,7 @@ def test_editable_document_routes_cover_crud_conflict_snapshots_operations_and_s
         snapshot = client.post(
             f"/v1/editable-documents/{document_id}/snapshots",
             headers=mcp_auth_headers(),
+            params=scope,
             json={
                 "base_revision": 2,
                 "reason": "manual",
@@ -2825,6 +2982,7 @@ def test_editable_document_routes_cover_crud_conflict_snapshots_operations_and_s
         applied = client.post(
             f"/v1/editable-documents/{document_id}/operations",
             headers=mcp_auth_headers(),
+            params=scope,
             json={
                 "base_revision": 2,
                 "origin": "mcp",

--- a/services/mcp/jobos_mcp/jobs.py
+++ b/services/mcp/jobos_mcp/jobs.py
@@ -131,6 +131,9 @@ class JobOsMcpClient:
         self._conversation_scope: ContextVar[str | None] = ContextVar(
             "jobos_mcp_conversation_id", default=None
         )
+        self._turn_scope: ContextVar[str | None] = ContextVar(
+            "jobos_mcp_turn_id", default=None
+        )
         self._career_profile_agent_headers = {
             "X-JobOS-Agent-Id": agent_id,
             "X-JobOS-Agent-Token": agent_token or mcp_token,
@@ -151,6 +154,14 @@ class JobOsMcpClient:
         if not re.fullmatch(r"conv_[A-Za-z0-9_-]{1,128}", conversation_id):
             raise ValueError("Invalid conversation ID")
         self._conversation_scope.set(conversation_id)
+
+    def scope_turn(self, conversation_id: str, turn_id: str) -> None:
+        if not re.fullmatch(r"conv_[A-Za-z0-9_-]{1,128}", conversation_id):
+            raise ValueError("Invalid conversation ID")
+        if not re.fullmatch(r"turn_[A-Za-z0-9_-]{8,200}", turn_id):
+            raise ValueError("Invalid turn ID")
+        self._conversation_scope.set(conversation_id)
+        self._turn_scope.set(turn_id)
 
     async def list_jobs(
         self,
@@ -743,9 +754,13 @@ class JobOsMcpClient:
 
     async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         conversation_id = self._conversation_scope.get()
-        if conversation_id is not None:
+        turn_id = self._turn_scope.get()
+        if conversation_id is not None or turn_id is not None:
+            if conversation_id is None or turn_id is None:
+                raise ValueError("Conversation and turn correlation must be supplied together")
             params = dict(kwargs.pop("params", {}) or {})
             params["conversation_id"] = conversation_id
+            params["turn_id"] = turn_id
             kwargs["params"] = params
         try:
             response = await self._client.request(method, path, **kwargs)

--- a/services/mcp/jobos_mcp/server.py
+++ b/services/mcp/jobos_mcp/server.py
@@ -728,6 +728,7 @@ def create_server(client: JobOsMcpClient, *, artifact_root: Path | None = None) 
         workspace, repository, temporary folder, or agent-profile cache for publication.
         """
         client.scope_turn(conversation_id, turn_id)
+        await client.inspect_job(job_id)
         workspace = _prepare_document_publication_workspace(
             conversation_id, job_id, artifact_root=artifact_root
         )

--- a/services/mcp/jobos_mcp/server.py
+++ b/services/mcp/jobos_mcp/server.py
@@ -15,9 +15,8 @@ from pydantic import Field
 
 from jobos_mcp.jobs import JobOsMcpClient
 
-ConversationId = Annotated[
-    str, Field(pattern=r"^conv_[A-Za-z0-9_-]{1,128}$", max_length=133)
-]
+ConversationId = Annotated[str, Field(pattern=r"^conv_[A-Za-z0-9_-]{1,128}$", max_length=133)]
+TurnId = Annotated[str, Field(pattern=r"^turn_[A-Za-z0-9_-]{8,200}$", max_length=205)]
 
 
 def local_mcp_token() -> str:
@@ -78,9 +77,7 @@ def _document_artifact_root() -> Path:
         ValueError,
         json.JSONDecodeError,
     ) as error:
-        raise RuntimeError(
-            "Document publication requires a valid JobOS local config"
-        ) from error
+        raise RuntimeError("Document publication requires a valid JobOS local config") from error
 
     artifact_root = Path(raw_artifacts).expanduser()
     root = artifact_root if artifact_root.is_absolute() else path.parent / artifact_root
@@ -153,9 +150,7 @@ def _prepare_document_publication_workspace(
     if not resolved_root.is_dir():
         raise RuntimeError("The JobOS artifact root must be a directory")
     workspace = _publication_workspace_path(conversation_id, job_id, resolved_root)
-    _prepare_private_directory_chain(
-        resolved_root, workspace.relative_to(resolved_root).parts
-    )
+    _prepare_private_directory_chain(resolved_root, workspace.relative_to(resolved_root).parts)
     return workspace
 
 
@@ -171,9 +166,7 @@ def _existing_document_publication_workspace(
     for part in workspace.relative_to(resolved_root).parts:
         current = current / part
         if current.is_symlink():
-            raise RuntimeError(
-                "JobOS publication inbox directories must not use symbolic links"
-            )
+            raise RuntimeError("JobOS publication inbox directories must not use symbolic links")
         try:
             metadata = os.stat(current, follow_symlinks=False)
         except OSError as error:
@@ -325,9 +318,7 @@ def _read_publication_input(
     )
 
 
-def create_server(
-    client: JobOsMcpClient, *, artifact_root: Path | None = None
-) -> FastMCP:
+def create_server(client: JobOsMcpClient, *, artifact_root: Path | None = None) -> FastMCP:
     server = FastMCP(
         "JobOS Jobs",
         instructions=(
@@ -361,12 +352,15 @@ def create_server(
 
     @server.tool(name="job_list", structured_output=True)
     async def job_list(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
         sort: str = "manual",
         query: str | None = None,
         status_group: str | None = None,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """List jobs using JobOS filtering and ordering."""
+        client.scope_turn(conversation_id, turn_id)
         return await client.list_jobs(
             sort=sort,
             query=query,
@@ -375,12 +369,20 @@ def create_server(
         )
 
     @server.tool(name="job_inspect", structured_output=True)
-    async def job_inspect(job_id: str, idempotency_key: str | None = None) -> dict[str, Any]:
+    async def job_inspect(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        job_id: str,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
         """Inspect one normalized JobOS job record."""
+        client.scope_turn(conversation_id, turn_id)
         return await client.inspect_job(job_id, idempotency_key=idempotency_key)
 
     @server.tool(name="job_create_from_browser", structured_output=True)
     async def job_create_from_browser(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
         company_name: str,
         title: str,
         canonical_url: str,
@@ -390,6 +392,7 @@ def create_server(
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Save one listing inspected from the live JobOS browser through canonical ingest."""
+        client.scope_turn(conversation_id, turn_id)
         return await client.create_job(
             company_name=company_name,
             title=title,
@@ -402,27 +405,37 @@ def create_server(
 
     @server.tool(name="job_select", structured_output=True)
     async def job_select(
-        conversation_id: ConversationId, job_id: str, idempotency_key: str | None = None
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        job_id: str,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Select this conversation's active JobOS job context."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.select_job(job_id, idempotency_key=idempotency_key)
 
     @server.tool(name="job_reorder", structured_output=True)
-    async def job_reorder(job_ids: list[str], idempotency_key: str | None = None) -> dict[str, Any]:
+    async def job_reorder(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        job_ids: list[str],
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
         """Replace the complete manual JobOS job order."""
+        client.scope_turn(conversation_id, turn_id)
         return await client.reorder_jobs(job_ids, idempotency_key=idempotency_key)
 
     @server.tool(name="job_update_status", structured_output=True)
     async def job_update_status(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
         target_status: str,
         reason: str | None = None,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Change a job status through the shared JobOS transition command."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.update_status(
             job_id, target_status, reason=reason, idempotency_key=idempotency_key
         )
@@ -430,13 +443,14 @@ def create_server(
     @server.tool(name="job_update_description", structured_output=True)
     async def job_update_description(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
         description_text: str,
         source_note: str | None = None,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Replace a saved job's canonical full listing and refresh its durable packet."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.update_description(
             job_id,
             description_text,
@@ -446,6 +460,8 @@ def create_server(
 
     @server.tool(name="career_profile_edit", structured_output=True)
     async def career_profile_edit(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
         expected_profile_revision: int,
         operation: Literal["item.create", "item.update", "item.remove"],
         reason: str,
@@ -460,6 +476,7 @@ def create_server(
         edits, identity changes, removals, Evidence removal, and loosened claim boundaries
         become proposals for the user. Evidence is optional.
         """
+        client.scope_turn(conversation_id, turn_id)
         return await client.edit_career_profile(
             expected_profile_revision=expected_profile_revision,
             operation=operation,
@@ -471,12 +488,17 @@ def create_server(
         )
 
     @server.tool(name="career_profile_get", structured_output=True)
-    async def career_profile_get() -> dict[str, Any]:
+    async def career_profile_get(
+        conversation_id: ConversationId, turn_id: TurnId
+    ) -> dict[str, Any]:
         """Read the exact user-authorized post-cutover Career Profile projection."""
+        client.scope_turn(conversation_id, turn_id)
         return await client.get_career_profile_projection()
 
     @server.tool(name="career_profile_search", structured_output=True)
     async def career_profile_search(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
         query: str,
         kinds: list[str] | None = None,
         areas: list[str] | None = None,
@@ -485,6 +507,7 @@ def create_server(
         limit: int = 25,
     ) -> dict[str, Any]:
         """Search only the Career Profile items and Evidence authorized for this agent."""
+        client.scope_turn(conversation_id, turn_id)
         return await client.search_career_profile(
             query=query,
             kinds=kinds,
@@ -496,6 +519,8 @@ def create_server(
 
     @server.tool(name="career_profile_edit_batch", structured_output=True)
     async def career_profile_edit_batch(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
         expected_profile_revision: int,
         edits: list[dict[str, Any]],
         idempotency_key: str | None = None,
@@ -506,6 +531,7 @@ def create_server(
         career_profile_edit. Evidence IDs remain optional. If any edit is invalid,
         none of the batch is saved.
         """
+        client.scope_turn(conversation_id, turn_id)
         return await client.edit_career_profile_batch(
             expected_profile_revision=expected_profile_revision,
             edits=edits,
@@ -514,14 +540,19 @@ def create_server(
 
     @server.tool(name="career_profile_changes_list", structured_output=True)
     async def career_profile_changes_list(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
         status: Literal["pending", "accepted", "rejected", "all"] = "pending",
         limit: int = 25,
     ) -> dict[str, Any]:
         """List this agent's proposals and directly applied Career Profile revisions."""
+        client.scope_turn(conversation_id, turn_id)
         return await client.list_career_profile_changes(status=status, limit=limit)
 
     @server.tool(name="career_profile_evidence_import", structured_output=True)
     async def career_profile_evidence_import(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
         expected_profile_revision: int,
         original_filename: str,
         media_type: str,
@@ -537,6 +568,7 @@ def create_server(
         Evidence is never required to create or edit profile items. Any supplied
         extractions remain subject to JobOS review and truthfulness rules.
         """
+        client.scope_turn(conversation_id, turn_id)
         return await client.import_career_profile_evidence(
             expected_profile_revision=expected_profile_revision,
             original_filename=original_filename,
@@ -551,11 +583,14 @@ def create_server(
 
     @server.tool(name="career_profile_evidence_inspect", structured_output=True)
     async def career_profile_evidence_inspect(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
         evidence_id: str,
         byte_start: int = 0,
         byte_length: int = 65_536,
     ) -> dict[str, Any]:
         """Read a bounded segment of Evidence already authorized for this agent."""
+        client.scope_turn(conversation_id, turn_id)
         return await client.inspect_career_profile_evidence(
             evidence_id,
             byte_start=byte_start,
@@ -564,45 +599,54 @@ def create_server(
 
     @server.tool(name="workspace_inspect", structured_output=True)
     async def workspace_inspect(
-        conversation_id: ConversationId, idempotency_key: str | None = None
+        conversation_id: ConversationId, turn_id: TurnId, idempotency_key: str | None = None
     ) -> dict[str, Any]:
         """Inspect global layout merged with this conversation's job context."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.inspect_workspace(idempotency_key=idempotency_key)
 
     @server.tool(name="workspace_update", structured_output=True)
     async def workspace_update(
         conversation_id: ConversationId,
-        snapshot: dict[str, Any], idempotency_key: str | None = None
+        turn_id: TurnId,
+        snapshot: dict[str, Any],
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Update global layout and this conversation's document projection."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.update_workspace(snapshot, idempotency_key=idempotency_key)
 
     @server.tool(name="document_list", structured_output=True)
     async def document_list(
-        conversation_id: ConversationId, job_id: str, idempotency_key: str | None = None
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        job_id: str,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """List trusted registered artifacts for a job."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.list_documents(job_id, idempotency_key=idempotency_key)
 
     @server.tool(name="document_draft_get", structured_output=True)
     async def document_draft_get(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
         document_key: str,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Read a bounded semantic outline for one editable job document."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.get_document_draft(
-            job_id, document_key, idempotency_key=idempotency_key  # gitleaks:allow
+            job_id,
+            document_key,
+            idempotency_key=idempotency_key,  # gitleaks:allow
         )
 
     @server.tool(name="document_draft_apply", structured_output=True)
     async def document_draft_apply(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
         document_id: str,
         base_revision: int,
@@ -610,7 +654,7 @@ def create_server(
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Atomically apply only the five allowlisted editable-document operations."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.apply_document_draft(
             job_id,
             document_id,
@@ -622,45 +666,51 @@ def create_server(
     @server.tool(name="document_draft_snapshot", structured_output=True)
     async def document_draft_snapshot(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
         document_id: str,
         label: str,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Create a durable manual checkpoint for one job-owned editable document."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.snapshot_document_draft(
             job_id, document_id, label, idempotency_key=idempotency_key
         )
 
     @server.tool(name="document_refresh", structured_output=True)
     async def document_refresh(
-        conversation_id: ConversationId, job_id: str, idempotency_key: str | None = None
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        job_id: str,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Refresh a job's trusted artifact manifest."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.refresh_documents(job_id, idempotency_key=idempotency_key)
 
     @server.tool(name="document_render", structured_output=True)
     async def document_render(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
         source_id: str,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Start the fixed PDF resume render command for a job source."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.render_document(job_id, source_id, idempotency_key=idempotency_key)
 
     @server.tool(name="document_register", structured_output=True)
     async def document_register(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
         artifact_reference: str,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Register an opaque facade artifact reference through JobOS."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.register_document(
             job_id, artifact_reference, idempotency_key=idempotency_key
         )
@@ -668,6 +718,7 @@ def create_server(
     @server.tool(name="document_publication_prepare", structured_output=True)
     async def document_publication_prepare(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
     ) -> dict[str, Any]:
         """Prepare JobOS's only supported publication inbox for this session and job.
@@ -676,7 +727,7 @@ def create_server(
         every promised PDF/DOCX directly into publication_directory. Do not use a
         workspace, repository, temporary folder, or agent-profile cache for publication.
         """
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         workspace = _prepare_document_publication_workspace(
             conversation_id, job_id, artifact_root=artifact_root
         )
@@ -696,6 +747,7 @@ def create_server(
     @server.tool(name="document_publish", structured_output=True)
     async def document_publish(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
         document_key: str,
         document_label: str,
@@ -709,7 +761,7 @@ def create_server(
         use the same source file for paired PDF/DOCX, then confirm every format with
         document_list before claiming completion. Other filesystem paths are never read.
         """
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         resolved_artifact_root = artifact_root or _document_artifact_root()
         try:
             source_filename, source_bytes = _read_publication_input(
@@ -749,23 +801,25 @@ def create_server(
     @server.tool(name="document_select", structured_output=True)
     async def document_select(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         artifact_id: str,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Select a registered artifact in the shared document workspace."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.select_document(artifact_id, idempotency_key=idempotency_key)
 
     @server.tool(name="document_file_inspect", structured_output=True)
     async def document_file_inspect(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
         document_key: str,
         timeout_ms: int = 10_000,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Inspect the current canonical DOCX hash, capabilities, and bounded block context."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.inspect_document_file(
             conversation_id,
             job_id,
@@ -777,6 +831,7 @@ def create_server(
     @server.tool(name="document_file_apply", structured_output=True)
     async def document_file_apply(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         job_id: str,
         document_key: str,
         expected_sha256: str,
@@ -785,7 +840,7 @@ def create_server(
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Apply typed operations to the canonical DOCX with an expected-hash conflict check."""
-        client.scope_conversation(conversation_id)
+        client.scope_turn(conversation_id, turn_id)
         return await client.apply_document_file_operations(
             conversation_id,
             job_id,
@@ -809,20 +864,23 @@ def create_server(
 
     @server.tool(name="browser_tabs_inspect", structured_output=True)
     async def browser_tabs_inspect(
-        conversation_id: ConversationId, timeout_ms: int = 5_000
+        conversation_id: ConversationId, turn_id: TurnId, timeout_ms: int = 5_000
     ) -> dict[str, Any]:
         """Inspect bounded metadata for live desktop browser tabs."""
+        client.scope_turn(conversation_id, turn_id)
         return await browser(conversation_id, "tabs.inspect", {}, None, timeout_ms)
 
     @server.tool(name="browser_tab_create", structured_output=True)
     async def browser_tab_create(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         url: str,
         associated_job_id: str | None = None,
         activate: bool = True,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Create a live browser tab for an ordinary HTTP(S) URL."""
+        client.scope_turn(conversation_id, turn_id)
         return await browser(
             conversation_id,
             "tab.create",
@@ -832,90 +890,116 @@ def create_server(
 
     @server.tool(name="browser_tab_select", structured_output=True)
     async def browser_tab_select(
-        conversation_id: ConversationId, tab_id: str, idempotency_key: str | None = None
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        tab_id: str,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Select a live browser tab."""
+        client.scope_turn(conversation_id, turn_id)
         return await browser(conversation_id, "tab.select", {"tab_id": tab_id}, idempotency_key)
 
     @server.tool(name="browser_tab_associate", structured_output=True)
     async def browser_tab_associate(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         tab_id: str,
         job_id: str,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Link a live browser tab to the canonical JobOS job created from it."""
+        client.scope_turn(conversation_id, turn_id)
         return await browser(
-            conversation_id,
-            "tab.associate", {"tab_id": tab_id, "job_id": job_id}, idempotency_key
+            conversation_id, "tab.associate", {"tab_id": tab_id, "job_id": job_id}, idempotency_key
         )
 
     @server.tool(name="browser_tab_close", structured_output=True)
     async def browser_tab_close(
-        conversation_id: ConversationId, tab_id: str, idempotency_key: str | None = None
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        tab_id: str,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Close a live browser tab."""
+        client.scope_turn(conversation_id, turn_id)
         return await browser(conversation_id, "tab.close", {"tab_id": tab_id}, idempotency_key)
 
     @server.tool(name="browser_tabs_reorder", structured_output=True)
     async def browser_tabs_reorder(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         tab_ids: list[str],
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Replace the complete live browser tab order."""
-        return await browser(
-            conversation_id, "tabs.reorder", {"tab_ids": tab_ids}, idempotency_key
-        )
+        client.scope_turn(conversation_id, turn_id)
+        return await browser(conversation_id, "tabs.reorder", {"tab_ids": tab_ids}, idempotency_key)
 
-    async def tab_command(
-        conversation_id: str, name: str, tab_id: str, key: str | None = None
-    ):
+    async def tab_command(conversation_id: str, name: str, tab_id: str, key: str | None = None):
         return await browser(conversation_id, name, {"tab_id": tab_id}, key)
 
     @server.tool(name="browser_navigate", structured_output=True)
     async def browser_navigate(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         tab_id: str,
         url: str,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Navigate a live tab to an ordinary HTTP(S) URL."""
+        client.scope_turn(conversation_id, turn_id)
         return await browser(
             conversation_id, "tab.navigate", {"tab_id": tab_id, "url": url}, idempotency_key
         )
 
     @server.tool(name="browser_back", structured_output=True)
     async def browser_back(
-        conversation_id: ConversationId, tab_id: str, idempotency_key: str | None = None
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        tab_id: str,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Go back in a live tab."""
+        client.scope_turn(conversation_id, turn_id)
         return await tab_command(conversation_id, "tab.back", tab_id, idempotency_key)
 
     @server.tool(name="browser_forward", structured_output=True)
     async def browser_forward(
-        conversation_id: ConversationId, tab_id: str, idempotency_key: str | None = None
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        tab_id: str,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Go forward in a live tab."""
+        client.scope_turn(conversation_id, turn_id)
         return await tab_command(conversation_id, "tab.forward", tab_id, idempotency_key)
 
     @server.tool(name="browser_reload", structured_output=True)
     async def browser_reload(
-        conversation_id: ConversationId, tab_id: str, idempotency_key: str | None = None
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        tab_id: str,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Reload a live tab."""
+        client.scope_turn(conversation_id, turn_id)
         return await tab_command(conversation_id, "tab.reload", tab_id, idempotency_key)
 
     @server.tool(name="browser_stop", structured_output=True)
     async def browser_stop(
-        conversation_id: ConversationId, tab_id: str, idempotency_key: str | None = None
+        conversation_id: ConversationId,
+        turn_id: TurnId,
+        tab_id: str,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Stop loading a live tab."""
+        client.scope_turn(conversation_id, turn_id)
         return await tab_command(conversation_id, "tab.stop", tab_id, idempotency_key)
 
     @server.tool(name="browser_snapshot", structured_output=True)
     async def browser_snapshot(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         tab_id: str,
         text_start: int = 0,
         text_length: int = 12_000,
@@ -928,6 +1012,7 @@ def create_server(
         For later segments, pass every pagination argument and use the returned
         next_text_start.
         """
+        client.scope_turn(conversation_id, turn_id)
         return await browser(
             conversation_id,
             "page.snapshot",
@@ -943,19 +1028,24 @@ def create_server(
     @server.tool(name="browser_click", structured_output=True)
     async def browser_click(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         tab_id: str,
         target_id: str,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Click an opaque target from the latest semantic snapshot."""
+        client.scope_turn(conversation_id, turn_id)
         return await browser(
             conversation_id,
-            "element.click", {"tab_id": tab_id, "target_id": target_id}, idempotency_key
+            "element.click",
+            {"tab_id": tab_id, "target_id": target_id},
+            idempotency_key,
         )
 
     @server.tool(name="browser_type", structured_output=True)
     async def browser_type(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         tab_id: str,
         target_id: str,
         text: str,
@@ -963,6 +1053,7 @@ def create_server(
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Type bounded text into an opaque snapshot target."""
+        client.scope_turn(conversation_id, turn_id)
         return await browser(
             conversation_id,
             "element.type",
@@ -973,12 +1064,14 @@ def create_server(
     @server.tool(name="browser_scroll", structured_output=True)
     async def browser_scroll(
         conversation_id: ConversationId,
+        turn_id: TurnId,
         tab_id: str,
         direction: str,
         amount: int = 600,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Scroll a live tab by a bounded amount."""
+        client.scope_turn(conversation_id, turn_id)
         return await browser(
             conversation_id,
             "page.scroll",
@@ -988,12 +1081,15 @@ def create_server(
 
     @server.tool(name="activity_report", structured_output=True)
     async def activity_report(
+        conversation_id: ConversationId,
+        turn_id: TurnId,
         label: str,
         state: str,
         detail: dict[str, Any] | None = None,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Append one concise agent-origin action to JobOS chronology."""
+        client.scope_turn(conversation_id, turn_id)
         return await client.report_activity(
             label, state, detail=detail, idempotency_key=idempotency_key
         )

--- a/services/mcp/tests/test_career_profile_tools.py
+++ b/services/mcp/tests/test_career_profile_tools.py
@@ -121,10 +121,15 @@ async def test_career_profile_mcp_tools_keep_review_decisions_user_owned():
         transport=httpx.MockTransport(handler),
     )
     server = create_server(client)
+    scope = {
+        "conversation_id": "conv_career_profile_tools",
+        "turn_id": "turn_career_profile_tools_0001",
+    }
 
     _, edit = await server.call_tool(
         "career_profile_edit",
-        {
+        scope
+        | {
             "expected_profile_revision": 0,
             "operation": "item.create",
             "reason": "Remember a user-authored skill",
@@ -188,10 +193,15 @@ async def test_career_profile_agent_operating_tools_map_to_scoped_api_contracts(
         transport=httpx.MockTransport(handler),
     )
     server = create_server(client)
+    scope = {
+        "conversation_id": "conv_career_profile_operating",
+        "turn_id": "turn_career_profile_operating_0001",
+    }
 
     await server.call_tool(
         "career_profile_search",
-        {
+        scope
+        | {
             "query": "Python",
             "kinds": ["skill"],
             "areas": ["my_career"],
@@ -202,7 +212,8 @@ async def test_career_profile_agent_operating_tools_map_to_scoped_api_contracts(
     )
     await server.call_tool(
         "career_profile_edit_batch",
-        {
+        scope
+        | {
             "expected_profile_revision": 4,
             "edits": [
                 {
@@ -217,11 +228,12 @@ async def test_career_profile_agent_operating_tools_map_to_scoped_api_contracts(
     )
     await server.call_tool(
         "career_profile_changes_list",
-        {"status": "all", "limit": 20},
+        scope | {"status": "all", "limit": 20},
     )
     await server.call_tool(
         "career_profile_evidence_import",
-        {
+        scope
+        | {
             "expected_profile_revision": 6,
             "original_filename": "synthetic.txt",
             "media_type": "text/plain",
@@ -234,7 +246,8 @@ async def test_career_profile_agent_operating_tools_map_to_scoped_api_contracts(
     )
     await server.call_tool(
         "career_profile_evidence_inspect",
-        {
+        scope
+        | {
             "evidence_id": "cpe_fixturefixture1234",
             "byte_start": 0,
             "byte_length": 1000,

--- a/services/mcp/tests/test_jobs_tools.py
+++ b/services/mcp/tests/test_jobs_tools.py
@@ -575,6 +575,10 @@ async def test_publication_prepare_and_publish_use_only_the_app_owned_inbox(tmp_
         },
     )
     assert isinstance(prepared, dict)
+    assert len(requests) == 1
+    assert requests[0].url.path == "/v1/jobs/job-1"
+    assert requests[0].url.params["conversation_id"] == "conv_alpha"
+    assert requests[0].url.params["turn_id"] == "turn_publication_test_0001"
     workspace = Path(prepared["publication_directory"])
     source = workspace / "resume.md"
     artifact = workspace / "resume.docx"
@@ -595,7 +599,7 @@ async def test_publication_prepare_and_publish_use_only_the_app_owned_inbox(tmp_
         },
     )
     assert isinstance(published, dict)
-    assert len(requests) == 1
+    assert len(requests) == 2
 
     outside = tmp_path / "outside.docx"
     outside.write_bytes(b"PK\x03\x04private")
@@ -612,7 +616,7 @@ async def test_publication_prepare_and_publish_use_only_the_app_owned_inbox(tmp_
                 "artifact_path": str(outside),
             },
         )
-    assert len(requests) == 1
+    assert len(requests) == 2
     await client.aclose()
 
 

--- a/services/mcp/tests/test_jobs_tools.py
+++ b/services/mcp/tests/test_jobs_tools.py
@@ -204,9 +204,7 @@ def test_mcp_error_sanitizer_preserves_urls_prose_and_ordinary_identifiers():
         ),
     ],
 )
-def test_mcp_error_sanitizer_has_api_parity_for_every_sensitive_category(
-    category, raw, expected
-):
+def test_mcp_error_sanitizer_has_api_parity_for_every_sensitive_category(category, raw, expected):
     assert _safe_error_message(raw) == expected, category
     assert sanitize_text(raw) == expected, category
 
@@ -229,7 +227,7 @@ async def test_job_tools_use_only_the_authenticated_jobos_http_contract():
         mcp_token="test-mcp-trusted-token",
         transport=httpx.MockTransport(handler),
     )
-    client.scope_conversation("conv_test")
+    client.scope_turn("conv_test", "turn_contract_test_0001")
 
     await client.list_jobs(sort="status", query="builder")
     await client.inspect_job("job-1")
@@ -265,8 +263,7 @@ async def test_job_tools_use_only_the_authenticated_jobos_http_contract():
         ("PUT", "/v1/jobs/job-1/description"),
     ]
     assert all(
-        request.headers["authorization"] == "Bearer test-mcp-trusted-token"
-        for request in requests
+        request.headers["authorization"] == "Bearer test-mcp-trusted-token" for request in requests
     )
     assert json.loads(requests[2].content) == {
         "company_name": "Northstar Labs",
@@ -437,9 +434,7 @@ def test_document_input_rejects_same_inode_same_size_in_place_mutation(tmp_path,
     assert changed.st_size == identity.st_size
 
 
-def test_document_artifact_root_uses_local_config_and_never_cwd_or_hermes(
-    tmp_path, monkeypatch
-):
+def test_document_artifact_root_uses_local_config_and_never_cwd_or_hermes(tmp_path, monkeypatch):
     working = tmp_path / "working"
     working.mkdir()
     hermes = tmp_path / ".hermes/profiles/job-hunter/cache/documents"
@@ -500,9 +495,7 @@ def test_publication_workspace_rejects_symlinked_inbox(tmp_path):
     (artifact_root / "publication-inbox").symlink_to(outside, target_is_directory=True)
 
     with pytest.raises(RuntimeError, match="symbolic links"):
-        _prepare_document_publication_workspace(
-            "conv_alpha", "job-1", artifact_root=artifact_root
-        )
+        _prepare_document_publication_workspace("conv_alpha", "job-1", artifact_root=artifact_root)
 
 
 def test_publication_workspace_rejects_parent_replaced_by_symlink(tmp_path):
@@ -520,14 +513,10 @@ def test_publication_workspace_rejects_parent_replaced_by_symlink(tmp_path):
     conversation_directory.symlink_to(outside, target_is_directory=True)
 
     with pytest.raises(RuntimeError, match="symbolic links"):
-        _existing_document_publication_workspace(
-            "conv_alpha", "job-1", artifact_root=artifact_root
-        )
+        _existing_document_publication_workspace("conv_alpha", "job-1", artifact_root=artifact_root)
 
 
-def test_publication_read_cannot_follow_parent_swapped_after_workspace_check(
-    tmp_path, monkeypatch
-):
+def test_publication_read_cannot_follow_parent_swapped_after_workspace_check(tmp_path, monkeypatch):
     artifact_root = tmp_path / "artifacts"
     artifact_root.mkdir()
     workspace = _prepare_document_publication_workspace(
@@ -547,9 +536,7 @@ def test_publication_read_cannot_follow_parent_swapped_after_workspace_check(
         checked.parent.symlink_to(outside, target_is_directory=True)
         return checked
 
-    monkeypatch.setattr(
-        server_module, "_existing_document_publication_workspace", check_then_swap
-    )
+    monkeypatch.setattr(server_module, "_existing_document_publication_workspace", check_then_swap)
     with pytest.raises(ValueError, match="symbolic link|inaccessible component"):
         _read_publication_input(
             str(target),
@@ -581,7 +568,11 @@ async def test_publication_prepare_and_publish_use_only_the_app_owned_inbox(tmp_
 
     _, prepared = await server.call_tool(
         "document_publication_prepare",
-        {"conversation_id": "conv_alpha", "job_id": "job-1"},
+        {
+            "conversation_id": "conv_alpha",
+            "turn_id": "turn_publication_test_0001",
+            "job_id": "job-1",
+        },
     )
     assert isinstance(prepared, dict)
     workspace = Path(prepared["publication_directory"])
@@ -594,6 +585,7 @@ async def test_publication_prepare_and_publish_use_only_the_app_owned_inbox(tmp_
         "document_publish",
         {
             "conversation_id": "conv_alpha",
+            "turn_id": "turn_publication_test_0001",
             "job_id": "job-1",
             "document_key": "resume",
             "document_label": "Resume",
@@ -612,6 +604,7 @@ async def test_publication_prepare_and_publish_use_only_the_app_owned_inbox(tmp_
             "document_publish",
             {
                 "conversation_id": "conv_alpha",
+                "turn_id": "turn_publication_test_0001",
                 "job_id": "job-1",
                 "document_key": "resume",
                 "document_label": "Resume",
@@ -689,25 +682,15 @@ async def test_mcp_server_exposes_public_v1_parity_tools_while_retaining_job_too
     assert "Other filesystem paths are never read" in (
         tools_by_name["document_publish"].description or ""
     )
-    correlated = [
-        tool
-        for tool in tools
-        if tool.name.startswith("browser_")
-        or tool.name.startswith("document_")
-        or tool.name
-        in {
-            "job_select",
-            "job_update_status",
-            "job_update_description",
-            "workspace_inspect",
-            "workspace_update",
-        }
-    ]
-    for tool in correlated:
+    for tool in tools:
         conversation = tool.inputSchema["properties"]["conversation_id"]
+        turn = tool.inputSchema["properties"]["turn_id"]
         assert "conversation_id" in tool.inputSchema["required"]
+        assert "turn_id" in tool.inputSchema["required"]
         assert conversation["maxLength"] == 133
         assert conversation["pattern"] == "^conv_[A-Za-z0-9_-]{1,128}$"
+        assert turn["maxLength"] == 205
+        assert turn["pattern"] == "^turn_[A-Za-z0-9_-]{8,200}$"
     snapshot_schema = tools_by_name["browser_snapshot"].inputSchema
     assert "text_start" not in snapshot_schema["required"]
     assert "text_length" not in snapshot_schema["required"]
@@ -764,28 +747,29 @@ async def test_save_current_tab_contract_pages_oversized_listing_then_creates_an
             start = body["arguments"]["text_start"]
             length = body["arguments"]["text_length"]
             text = listing_text[start : start + length]
-            return httpx.Response(200, json={
-                "state": "completed",
-                "outcome": "page.snapshot",
-                "data": {
-                    "tab_id": "live-applied-systems-tab",
-                    "url": "https://www.linkedin.com/jobs/view/4431837844/",
-                    "title": "AI Product Manager",
-                    "text": text,
-                    "requested_text_start": start,
-                    "text_start": start,
-                    "text_length": len(text),
-                    "next_text_start": (
-                        start + len(text)
-                        if start + len(text) < len(listing_text)
-                        else None
-                    ),
-                    "total_text_length": len(listing_text),
-                    "has_more": start + len(text) < len(listing_text),
-                    "page_revision": revision,
-                    "targets": [],
+            return httpx.Response(
+                200,
+                json={
+                    "state": "completed",
+                    "outcome": "page.snapshot",
+                    "data": {
+                        "tab_id": "live-applied-systems-tab",
+                        "url": "https://www.linkedin.com/jobs/view/4431837844/",
+                        "title": "AI Product Manager",
+                        "text": text,
+                        "requested_text_start": start,
+                        "text_start": start,
+                        "text_length": len(text),
+                        "next_text_start": (
+                            start + len(text) if start + len(text) < len(listing_text) else None
+                        ),
+                        "total_text_length": len(listing_text),
+                        "has_more": start + len(text) < len(listing_text),
+                        "page_revision": revision,
+                        "targets": [],
+                    },
                 },
-            })
+            )
         if request.url.path == "/v1/jobs":
             return httpx.Response(200, json={"job_id": "job-applied-systems", "created": True})
         return httpx.Response(200, json={"state": "completed", "outcome": "tab.associate"})
@@ -800,13 +784,17 @@ async def test_save_current_tab_contract_pages_oversized_listing_then_creates_an
     captured = []
     start = 0
     while True:
-        content, snapshot = await server.call_tool("browser_snapshot", {
-            "conversation_id": "conv_save_current_tab",
-            "tab_id": "live-applied-systems-tab",
-            "text_start": start,
-            "text_length": 12_000,
-            "include_targets": False,
-        })
+        content, snapshot = await server.call_tool(
+            "browser_snapshot",
+            {
+                "conversation_id": "conv_save_current_tab",
+                "turn_id": "turn_save_current_tab_0001",
+                "tab_id": "live-applied-systems-tab",
+                "text_start": start,
+                "text_length": 12_000,
+                "include_targets": False,
+            },
+        )
         assert sum(len(item.text) for item in content if hasattr(item, "text")) < 25_000
         assert snapshot["data"]["page_revision"] == revision
         captured.append(snapshot["data"]["text"])
@@ -814,19 +802,28 @@ async def test_save_current_tab_contract_pages_oversized_listing_then_creates_an
             break
         start = snapshot["data"]["next_text_start"]
 
-    _, created = await server.call_tool("job_create_from_browser", {
-        "company_name": "Applied Systems",
-        "title": "AI Product Manager",
-        "canonical_url": "https://www.linkedin.com/jobs/view/4431837844/",
-        "location_text": "Not specified",
-        "description_text": "".join(captured),
-        "application_url": "https://www.linkedin.com/jobs/view/4431837844/",
-    })
-    await server.call_tool("browser_tab_associate", {
-        "conversation_id": "conv_save_current_tab",
-        "tab_id": "live-applied-systems-tab",
-        "job_id": created["job_id"],
-    })
+    _, created = await server.call_tool(
+        "job_create_from_browser",
+        {
+            "conversation_id": "conv_save_current_tab",
+            "turn_id": "turn_save_current_tab_0001",
+            "company_name": "Applied Systems",
+            "title": "AI Product Manager",
+            "canonical_url": "https://www.linkedin.com/jobs/view/4431837844/",
+            "location_text": "Not specified",
+            "description_text": "".join(captured),
+            "application_url": "https://www.linkedin.com/jobs/view/4431837844/",
+        },
+    )
+    await server.call_tool(
+        "browser_tab_associate",
+        {
+            "conversation_id": "conv_save_current_tab",
+            "turn_id": "turn_save_current_tab_0001",
+            "tab_id": "live-applied-systems-tab",
+            "job_id": created["job_id"],
+        },
+    )
     await client.aclose()
 
     assert "".join(captured) == listing_text
@@ -836,7 +833,8 @@ async def test_save_current_tab_contract_pages_oversized_listing_then_creates_an
     assert create_body["company_name"] == "Applied Systems"
     assert create_body["title"] == "AI Product Manager"
     assert associate_body["arguments"] == {
-        "tab_id": "live-applied-systems-tab", "job_id": "job-applied-systems"
+        "tab_id": "live-applied-systems-tab",
+        "job_id": "job-applied-systems",
     }
 
 
@@ -919,7 +917,7 @@ async def test_document_select_reads_workspace_silently_then_emits_one_shared_mu
         mcp_token="test-mcp-trusted-token",
         transport=httpx.MockTransport(handler),
     )
-    client.scope_conversation("conv_test")
+    client.scope_turn("conv_test", "turn_document_test_0001")
     await client.select_document("art_1234567890abcdef", idempotency_key="select-document-1")
     await client.aclose()
 

--- a/tests/public-release/test_clean_clone.py
+++ b/tests/public-release/test_clean_clone.py
@@ -5,6 +5,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import sqlite3
 import stat
 import subprocess
 import xml.etree.ElementTree as ElementTree
@@ -291,6 +292,53 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
                 "conv_current",
                 conversation_id,
             ]
+            turn = assert_response(
+                client.post(
+                    f"/v1/conversations/{conversation_id}/messages",
+                    json={
+                        "text": "Run the clean-clone acceptance workflow",
+                        "idempotency_key": "clean-turn-1",
+                    },
+                ),
+                201,
+            )
+            turn_id = turn["turn_id"]
+
+        # The clean-clone runtime intentionally has no agent provider. Let that
+        # dispatch settle, then retain its legitimate turn as the trusted MCP
+        # scope used by this synthetic acceptance workflow.
+        await anyio.sleep(0.1)
+        with sqlite3.connect(profile / "state/jobos.db") as connection:
+            connection.execute(
+                "UPDATE conversation_turns SET status = 'running', cancel_requested = 0 "
+                "WHERE turn_id = ?",
+                (turn_id,),
+            )
+
+        async def correlated_call(
+            session: ClientSession, name: str, arguments: dict[str, Any]
+        ) -> dict[str, Any]:
+            return await call(
+                session,
+                name,
+                {**arguments, "conversation_id": conversation_id, "turn_id": turn_id},
+            )
+
+        async def correlated_optional_error(
+            session: ClientSession,
+            name: str,
+            arguments: dict[str, Any],
+            code: str,
+            *,
+            retryable: bool = True,
+        ) -> None:
+            await assert_optional_error(
+                session,
+                name,
+                {**arguments, "conversation_id": conversation_id, "turn_id": turn_id},
+                code,
+                retryable=retryable,
+            )
 
         async with mcp_session(
             root,
@@ -300,17 +348,19 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
             mcp_token=mcp_token,
             label="first",
         ) as mcp:
-            jobs = (await call(mcp, "job_list", {"idempotency_key": "clean-list-1"}))["jobs"]
+            jobs = (
+                await correlated_call(mcp, "job_list", {"idempotency_key": "clean-list-1"})
+            )["jobs"]
             assert len(jobs) == 1
             demo = jobs[0]
             assert demo["synthetic_demo"] is True
             assert demo["dataset_version"] == "jobos-demo-v1"
             job_id = demo["job_id"]
-            inspected = await call(
+            inspected = await correlated_call(
                 mcp, "job_inspect", {"job_id": job_id, "idempotency_key": "clean-inspect-1"}
             )
             assert inspected["job_id"] == job_id
-            selected = await call(
+            selected = await correlated_call(
                 mcp,
                 "job_select",
                 {
@@ -320,7 +370,7 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
                 },
             )
             assert selected["job_context"]["selected_job_id"] == job_id
-            updated_status = await call(
+            updated_status = await correlated_call(
                 mcp,
                 "job_update_status",
                 {
@@ -332,7 +382,7 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
                 },
             )
             assert updated_status["job"]["status"] == "reviewed"
-            updated_description = await call(
+            updated_description = await correlated_call(
                 mcp,
                 "job_update_description",
                 {
@@ -344,7 +394,7 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
                 },
             )
             assert updated_description["job"]["description"] == values["description"]
-            workspace = await call(
+            workspace = await correlated_call(
                 mcp,
                 "workspace_inspect",
                 {
@@ -355,7 +405,7 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
             for response_only in ("repaired_presets", "repaired_browser", "browser_repair_reasons"):
                 workspace.pop(response_only, None)
             workspace["browse_query"] = values["workspaceQuery"]
-            persisted_workspace = await call(
+            persisted_workspace = await correlated_call(
                 mcp,
                 "workspace_update",
                 {
@@ -396,7 +446,7 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
                         },
                     )
                 )
-            draft = await call(
+            draft = await correlated_call(
                 mcp,
                 "document_draft_get",
                 {
@@ -407,7 +457,7 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
                 },
             )
             assert any(block["text"] == values["documentText"] for block in draft["outline"])
-            snapshot = await call(
+            snapshot = await correlated_call(
                 mcp,
                 "document_draft_snapshot",
                 {
@@ -459,14 +509,13 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
                         assert downloaded.content == expected
                         artifact_bytes[artifact["artifact_id"]] = expected
 
-            await assert_optional_error(
+            await correlated_optional_error(
                 mcp,
                 "browser_tabs_inspect",
                 {"conversation_id": conversation_id, "timeout_ms": 500},
-                "http_409",
-                retryable=False,
+                "desktop_unavailable",
             )
-            await assert_optional_error(
+            await correlated_optional_error(
                 mcp,
                 "document_refresh",
                 {
@@ -476,7 +525,7 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
                 },
                 "artifact_provider_unavailable",
             )
-            await assert_optional_error(
+            await correlated_optional_error(
                 mcp,
                 "document_render",
                 {
@@ -516,6 +565,13 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
 
     try:
         api.start("restart")
+        await anyio.sleep(0.1)
+        with sqlite3.connect(profile / "state/jobos.db") as connection:
+            connection.execute(
+                "UPDATE conversation_turns SET status = 'running', cancel_requested = 0 "
+                "WHERE turn_id = ?",
+                (turn_id,),
+            )
         async with mcp_session(
             root,
             environment,
@@ -524,15 +580,17 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
             mcp_token=mcp_token,
             label="restart",
         ) as mcp:
-            jobs = (await call(mcp, "job_list", {"idempotency_key": "clean-list-2"}))["jobs"]
+            jobs = (
+                await correlated_call(mcp, "job_list", {"idempotency_key": "clean-list-2"})
+            )["jobs"]
             assert len(jobs) == 1
             assert jobs[0]["job_id"] == job_id
             assert jobs[0]["status"] == "reviewed"
-            inspected = await call(
+            inspected = await correlated_call(
                 mcp, "job_inspect", {"job_id": job_id, "idempotency_key": "clean-inspect-2"}
             )
             assert inspected["description"] == values["description"]
-            workspace = await call(
+            workspace = await correlated_call(
                 mcp,
                 "workspace_inspect",
                 {

--- a/tests/public-release/test_clean_clone.py
+++ b/tests/public-release/test_clean_clone.py
@@ -304,10 +304,22 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
             )
             turn_id = turn["turn_id"]
 
+        async def wait_for_agentless_turn_to_settle() -> None:
+            with anyio.fail_after(5):
+                while True:
+                    with sqlite3.connect(profile / "state/jobos.db") as connection:
+                        row = connection.execute(
+                            "SELECT status FROM conversation_turns WHERE turn_id = ?",
+                            (turn_id,),
+                        ).fetchone()
+                    if row is not None and row[0] not in {"queued", "running", "waiting"}:
+                        return
+                    await anyio.sleep(0.05)
+
         # The clean-clone runtime intentionally has no agent provider. Let that
         # dispatch settle, then retain its legitimate turn as the trusted MCP
         # scope used by this synthetic acceptance workflow.
-        await anyio.sleep(0.1)
+        await wait_for_agentless_turn_to_settle()
         with sqlite3.connect(profile / "state/jobos.db") as connection:
             connection.execute(
                 "UPDATE conversation_turns SET status = 'running', cancel_requested = 0 "
@@ -565,7 +577,7 @@ async def test_clean_home_golden_path(clean_runtime) -> None:
 
     try:
         api.start("restart")
-        await anyio.sleep(0.1)
+        await wait_for_agentless_turn_to_settle()
         with sqlite3.connect(profile / "state/jobos.db") as connection:
             connection.execute(
                 "UPDATE conversation_turns SET status = 'running', cancel_requested = 0 "


### PR DESCRIPTION
## What changed

- added an API-owned provider-neutral Connected Agent runtime router
- route conversations from their persisted immutable agent/provider/model binding
- carry trusted `conversation_id` and `turn_id` correlation through Hermes, MCP, and privileged API requests
- normalize and persist ordered runtime events with source-event deduplication and terminal sealing
- scope provider sessions and cancellation to the owning profile, Connected Agent, conversation, and turn
- treat ambiguous Hermes attach timeouts as recoverable ambiguous delivery rather than blindly retrying
- return the narrow trusted-turn error for uncorrelated browser commands
- update the clean-clone golden path to exercise MCP calls through a legitimate correlated turn

## Phase 2 requirements

Covers API-01, RTR-01–03, EVT-01–03, CON-02, ISO-02, REC-01, and REC-02 from the Connected Agents implementation plan. Codex runtime/auth work remains in later phases.

## Verification

- focused browser-command + runtime/contract/Hermes suite: passed
- `pnpm check`: passed
  - desktop: 554 passed
  - Python: 940 passed, 4 skipped
  - lint, typecheck, public-tree checks, build: passed
- `pnpm contracts:check`: passed
- generated OpenAPI and TypeScript contracts staged and committed
- `pnpm public:smoke-clean-clone`: passed on exact commit `ae085104feaa46a22e81138dce56bca1620a6bd7`
- independent bounded review findings resolved

Fixes #113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for routing conversations across multiple agent providers.
  * MCP tools now operate within both conversation and active-turn scope.
  * Browser commands accept an optional conversation correlation parameter.
  * Added richer event tracking, sequencing, replay, and recovery support.

* **Bug Fixes**
  * Improved validation for stale, mismatched, or unauthorized conversation and turn requests.
  * Ambiguous delivery outcomes now remain recoverable instead of being incorrectly marked failed.
  * Improved cancellation, deduplication, and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->