### PR TITLE
Phase 5: run full JobOS MCP workflows through Codex chats

### DIFF
--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -7,6 +7,7 @@ import re
 import sqlite3
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import wraps
@@ -145,6 +146,7 @@ from jobos_api.career_profile_portability import (
     CareerProfileRestoreRequest,
     CareerProfileRestoreResult,
 )
+from jobos_api.codex_adapter import CodexGatewayFactory
 from jobos_api.codex_runtime import CodexAppServerProcess, CodexRuntimeError
 from jobos_api.composition import create_job_services
 from jobos_api.connected_agent_auth import (
@@ -621,8 +623,16 @@ def create_app(
             settings.codex_app_server_path,
             settings.resolved_codex_home(),
             request_timeout=settings.codex_request_timeout,
+            mcp_command=settings.codex_mcp_command,
+            mcp_args=settings.codex_mcp_args,
+            mcp_device_id=settings.device_id,
         )
-        codex_vault = CodexCredentialVault(codex_client, settings.resolved_codex_home())
+        codex_vault = CodexCredentialVault(
+            codex_client,
+            settings.resolved_codex_home(),
+            mcp_command=settings.codex_mcp_command,
+            mcp_args=settings.codex_mcp_args,
+        )
         if selected_connected_agent_runtime is None:
             selected_connected_agent_runtime = CodexConnectedAgentRuntime(
                 codex_client, codex_vault
@@ -639,6 +649,7 @@ def create_app(
     )
     profile_fence_enabled = settings.installation_registry_path.is_file()
     hermes_agent_ids: set[str] = set()
+    codex_agent_ids: set[str] = set()
     if profile_fence_enabled:
         migration_runtime = {
             "job_provider": settings.job_provider,
@@ -653,6 +664,9 @@ def create_app(
         registry_data = installation_profiles.load_or_bootstrap(migration_runtime)
         hermes_agent_ids = {
             agent.id for agent in registry_data.connected_agents if agent.provider == "hermes"
+        }
+        codex_agent_ids = {
+            agent.id for agent in registry_data.connected_agents if agent.provider == "codex"
         }
         if (
             registry_data.connected_agent_migration is not None
@@ -715,11 +729,27 @@ def create_app(
         )
         configured_gateway = True
     selected_gateway_factory = gateway_factory or OfflineAgentGatewayFactory()
+    codex_gateway_factory = (
+        CodexGatewayFactory(
+            codex_client,
+            cwd=settings.resolved_codex_home() / "workspace",
+        )
+        if codex_client is not None
+        else None
+    )
+    if codex_gateway_factory is not None:
+        configured_gateway = True
+    runtime_adapters: dict[Any, AgentGatewayFactory] = {
+        "hermes": selected_gateway_factory,
+        **{("hermes", agent_id): selected_gateway_factory for agent_id in hermes_agent_ids},
+    }
+    if codex_gateway_factory is not None:
+        runtime_adapters["codex"] = codex_gateway_factory
+        runtime_adapters.update(
+            {("codex", agent_id): codex_gateway_factory for agent_id in codex_agent_ids}
+        )
     runtime_router = AgentRuntimeRouter(
-        {
-            "hermes": selected_gateway_factory,
-            **{("hermes", agent_id): selected_gateway_factory for agent_id in hermes_agent_ids},
-        },
+        runtime_adapters,
         profile_id=settings.installation_profile_id,
     )
     conversation_manager = ConversationManager(
@@ -1310,6 +1340,10 @@ def create_app(
         except ConnectedAgentAuthorizationError as error:
             raise HTTPException(status_code=403, detail=str(error)) from error
 
+    mcp_mutation_scope: ContextVar[dict[str, object] | None] = ContextVar(
+        "jobos_mcp_mutation_scope", default=None
+    )
+
     @app.middleware("http")
     async def enforce_mcp_conversation_job_scope(
         request: Request, call_next: Callable[[Request], Any]
@@ -1433,7 +1467,20 @@ def create_app(
                         message="This agent session is attached to a different job",
                         retryable=False,
                     )
-            return await call_next(request)
+            binding = scoped_service.store.binding()
+            scope_token = mcp_mutation_scope.set(
+                {
+                    "profile_id": settings.installation_profile_id,
+                    "conversation_id": conversation_id,
+                    "turn_id": turn_id,
+                    "connected_agent_id": binding.get("connected_agent_id"),
+                    "provider": binding.get("provider"),
+                }
+            )
+            try:
+                return await call_next(request)
+            finally:
+                mcp_mutation_scope.reset(scope_token)
 
     def mutation_hash(command_name: str, payload: dict[str, object]) -> str:
         return hashlib.sha256(
@@ -1443,6 +1490,9 @@ def create_app(
                 sort_keys=True,
             ).encode()
         ).hexdigest()
+
+    def scoped_mcp_detail(origin: str) -> dict[str, object]:
+        return dict(mcp_mutation_scope.get() or {}) if origin == "mcp" else {}
 
     def mutation_replay(
         *,
@@ -1493,6 +1543,7 @@ def create_app(
                 "state": outcome,
                 "origin": origin,
                 "outcome": outcome,
+                **scoped_mcp_detail(origin),
                 **(detail or {}),
             },
             job_id=job_id,
@@ -1528,6 +1579,7 @@ def create_app(
                 "state": "completed",
                 "origin": origin,
                 "outcome": "completed",
+                **scoped_mcp_detail(origin),
                 **(detail or {}),
             },
             job_id=job_id,
@@ -1545,7 +1597,12 @@ def create_app(
     ) -> None:
         if origin != "mcp" or not idempotency_key:
             return
-        audit_detail = {"label": label, "origin": "mcp", **(detail or {})}
+        audit_detail = {
+            "label": label,
+            "origin": "mcp",
+            **scoped_mcp_detail("mcp"),
+            **(detail or {}),
+        }
         request_hash = mutation_hash(command_name, audit_detail)
         try:
             state_store.record_mutation_result(
@@ -1717,6 +1774,7 @@ def create_app(
                     "origin": "mcp",
                     "outcome": result.outcome,
                     "error": result.error.model_dump() if result.error else None,
+                    **scoped_mcp_detail("mcp"),
                 },
             )
 
@@ -1757,6 +1815,7 @@ def create_app(
                         "origin": command.origin,
                         "outcome": result.outcome,
                         "error": result.error.model_dump() if result.error else None,
+                        **scoped_mcp_detail(command.origin),
                     },
                 )
             audit_non_durable_command(result)
@@ -5181,6 +5240,7 @@ def create_app(
                 "state": command.state,
                 "origin": "mcp",
                 "outcome": command.state,
+                **scoped_mcp_detail("mcp"),
             },
             inject_event_id=True,
         )

--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -1374,7 +1374,11 @@ def create_app(
         conversation_id = request.query_params.get("conversation_id")
         turn_id = request.query_params.get("turn_id")
         if conversation_id is None and turn_id is None:
-            if path != "/v1/browser/commands":
+            # Career Profile collaboration uses its own connected-agent token and
+            # revisioned audit model; it is not a conversation-turn capability.
+            if path == "/v1/career-profile/consumer-projection" or path.startswith(
+                "/v1/career-profile/agent-"
+            ):
                 return await call_next(request)
             return error_response(
                 request,
@@ -5202,7 +5206,9 @@ def create_app(
     def report_activity(
         command: ActivityReportRequest,
         identity: Annotated[DeviceIdentity, Depends(authenticated_device)],
+        mcp_token: Annotated[str | None, Header(alias="X-JobOS-MCP-Token")] = None,
     ) -> ActivityReportResponse:
+        require_trusted_mcp(identity, command.origin, mcp_token)
         request_hash = mutation_hash(
             "activity.report",
             {

--- a/services/api/jobos_api/codex_adapter.py
+++ b/services/api/jobos_api/codex_adapter.py
@@ -4,9 +4,8 @@ import asyncio
 import os
 import re
 import secrets
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
-from typing import cast
 
 from .agent_gateway import AgentContext, ConnectionState, GatewayEvent
 from .codex_runtime import CodexRpcClient, CodexRuntimeError, jobos_mcp_ready
@@ -68,12 +67,12 @@ class CodexAppServerGateway:
         client: CodexRpcClient,
         cwd: Path,
         conversation_id: str,
-        unregister: object,
+        unregister: Callable[[str, CodexAppServerGateway], None],
     ) -> None:
         self._client = client
         self._cwd = cwd
         self._conversation_id = conversation_id
-        self._unregister = cast(object, unregister)
+        self._unregister = unregister
         self._thread_id: str | None = None
         self._jobos_turn_id: str | None = None
         self._provider_turn_id: str | None = None
@@ -386,7 +385,5 @@ class CodexAppServerGateway:
         self._thread_id = None
         self._jobos_turn_id = None
         self._provider_turn_id = None
-        unregister = self._unregister
-        if callable(unregister):
-            unregister(self._conversation_id, self)
+        self._unregister(self._conversation_id, self)
         await self._events.put(None)

--- a/services/api/jobos_api/codex_adapter.py
+++ b/services/api/jobos_api/codex_adapter.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import secrets
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import cast
+
+from .agent_gateway import AgentContext, ConnectionState, GatewayEvent
+from .codex_runtime import CodexRpcClient, CodexRuntimeError, jobos_mcp_ready
+from .hermes_adapter import _prompt_with_context
+from .redaction import redact_detail, sanitize_assistant_text, sanitize_text
+
+_TERMINAL_STATUSES = {"completed", "failed", "interrupted"}
+_STREAM_TOKEN_TAIL = re.compile(r"[A-Za-z0-9_+=.\-]+$")
+
+
+class CodexGatewayFactory:
+    """Create isolated JobOS conversation gateways over one private app-server."""
+
+    def __init__(self, client: CodexRpcClient, *, cwd: Path) -> None:
+        self._client = client
+        self._cwd = cwd.expanduser().absolute()
+        self._gateways: dict[str, CodexAppServerGateway] = {}
+        self._subscribed = False
+
+    def create(self, conversation_id: str) -> CodexAppServerGateway:
+        if not self._subscribed:
+            self._client.subscribe(self._dispatch)
+            self._subscribed = True
+        gateway = CodexAppServerGateway(
+            client=self._client,
+            cwd=self._cwd,
+            conversation_id=conversation_id,
+            unregister=self._unregister,
+        )
+        self._gateways[conversation_id] = gateway
+        return gateway
+
+    async def _dispatch(self, method: str, params: object) -> None:
+        if method == "jobos/runtime/disconnected":
+            for gateway in tuple(self._gateways.values()):
+                await gateway.handle_runtime_disconnect()
+            return
+        if not isinstance(params, dict):
+            return
+        thread_id = params.get("threadId")
+        if not isinstance(thread_id, str):
+            thread = params.get("thread")
+            thread_id = thread.get("id") if isinstance(thread, dict) else None
+        if not isinstance(thread_id, str):
+            return
+        for gateway in tuple(self._gateways.values()):
+            if gateway.thread_id == thread_id:
+                await gateway.handle_notification(method, params)
+
+    def _unregister(self, conversation_id: str, gateway: CodexAppServerGateway) -> None:
+        if self._gateways.get(conversation_id) is gateway:
+            self._gateways.pop(conversation_id, None)
+
+
+class CodexAppServerGateway:
+    def __init__(
+        self,
+        *,
+        client: CodexRpcClient,
+        cwd: Path,
+        conversation_id: str,
+        unregister: object,
+    ) -> None:
+        self._client = client
+        self._cwd = cwd
+        self._conversation_id = conversation_id
+        self._unregister = cast(object, unregister)
+        self._thread_id: str | None = None
+        self._jobos_turn_id: str | None = None
+        self._provider_turn_id: str | None = None
+        self._event_namespace = secrets.token_hex(8)
+        self._event_sequence = 0
+        self._assistant_pending = ""
+        self._events: asyncio.Queue[GatewayEvent | None] = asyncio.Queue()
+        self._closed = False
+
+    @property
+    def connection_state(self) -> ConnectionState:
+        return "online" if not self._closed and self._client.is_running else "offline"
+
+    @property
+    def thread_id(self) -> str | None:
+        return self._thread_id
+
+    async def start(self) -> None:
+        if self._closed:
+            raise ConnectionError("Codex gateway is closed")
+        was_running = self._client.is_running
+        await self._client.start()
+        if self._cwd.parent.is_symlink() or self._cwd.is_symlink():
+            raise CodexRuntimeError(
+                "AGENT_PROVIDER_UNAVAILABLE", "Codex workspace is unsafe"
+            )
+        self._cwd.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if self._cwd.is_symlink() or not self._cwd.is_dir():
+            raise CodexRuntimeError(
+                "AGENT_PROVIDER_UNAVAILABLE", "Codex workspace is unsafe"
+            )
+        os.chmod(self._cwd, 0o700)
+        if not was_running and self._thread_id is not None:
+            result = await self._client.request(
+                "thread/resume",
+                {
+                    "threadId": self._thread_id,
+                    "cwd": str(self._cwd),
+                    "approvalPolicy": "never",
+                    "approvalsReviewer": "user",
+                    "sandbox": "read-only",
+                },
+            )
+            thread = result.get("thread") if isinstance(result, dict) else None
+            resumed_id = thread.get("id") if isinstance(thread, dict) else None
+            if resumed_id != self._thread_id:
+                raise CodexRuntimeError(
+                    "AGENT_PROVIDER_UNAVAILABLE", "Codex resumed the wrong conversation"
+                )
+
+    async def create_or_resume_conversation(
+        self, stored_session_id: str | None
+    ) -> tuple[str, str]:
+        await self.start()
+        params: dict[str, object] = {
+            "cwd": str(self._cwd),
+            "approvalPolicy": "never",
+            "approvalsReviewer": "user",
+            "sandbox": "read-only",
+        }
+        if stored_session_id is None:
+            method = "thread/start"
+        else:
+            method = "thread/resume"
+            params["threadId"] = stored_session_id
+        result = await self._client.request(method, params)
+        thread = result.get("thread") if isinstance(result, dict) else None
+        thread_id = thread.get("id") if isinstance(thread, dict) else None
+        if not isinstance(thread_id, str) or not thread_id:
+            raise CodexRuntimeError(
+                "AGENT_PROVIDER_UNAVAILABLE", "Codex conversation lifecycle failed"
+            )
+        if stored_session_id is not None and thread_id != stored_session_id:
+            raise CodexRuntimeError(
+                "AGENT_PROVIDER_UNAVAILABLE", "Codex resumed the wrong conversation"
+            )
+        self._thread_id = thread_id
+        return thread_id, thread_id
+
+    async def detach_conversation(self) -> None:
+        self._thread_id = None
+        self._jobos_turn_id = None
+        self._provider_turn_id = None
+        self._assistant_pending = ""
+
+    async def _require_jobos_mcp(self) -> None:
+        if self._thread_id is None:
+            raise RuntimeError("Codex conversation is not attached")
+        result = await self._client.request(
+            "mcpServerStatus/list",
+            {"threadId": self._thread_id, "detail": "full"},
+        )
+        if not jobos_mcp_ready(result):
+            raise CodexRuntimeError("JOBOS_TOOLS_UNAVAILABLE", "JobOS tools unavailable")
+
+    async def handle_runtime_disconnect(self) -> None:
+        turn_id = self._jobos_turn_id
+        provider_turn_id = self._provider_turn_id
+        if turn_id is None or provider_turn_id is None:
+            return
+        self._event_sequence += 1
+        await self._events.put(
+            GatewayEvent(
+                "error",
+                "failed",
+                "Codex runtime disconnected",
+                {"reason": "transport_lost", "recovery_required": True},
+                turn_id,
+                f"codex:{self._event_namespace}:{provider_turn_id}:{self._event_sequence}",
+            )
+        )
+        self._jobos_turn_id = None
+        self._provider_turn_id = None
+        self._assistant_pending = ""
+
+    async def submit_turn(self, text: str, context: AgentContext) -> None:
+        if self._thread_id is None:
+            raise RuntimeError("Codex conversation is not attached")
+        await self._require_jobos_mcp()
+        prompt = _prompt_with_context(
+            text,
+            {
+                "selected_job_id": context.selected_job_id,
+                "selected_job": context.selected_job,
+                "workspace": context.workspace,
+                "career_profile": context.career_profile,
+                "career_profile_context": context.career_profile_context,
+            },
+            context.conversation_id,
+            context.turn_id,
+        )
+        params: dict[str, object] = {
+            "threadId": self._thread_id,
+            "input": [{"type": "text", "text": prompt}],
+            "clientUserMessageId": context.turn_id,
+            "approvalPolicy": "never",
+            "approvalsReviewer": "user",
+            "sandboxPolicy": {"type": "readOnly", "networkAccess": False},
+        }
+        if context.model_id is not None:
+            params["model"] = context.model_id
+        if context.reasoning_effort is not None:
+            params["effort"] = context.reasoning_effort
+        result = await self._client.request("turn/start", params)
+        turn = result.get("turn") if isinstance(result, dict) else None
+        provider_turn_id = turn.get("id") if isinstance(turn, dict) else None
+        if not isinstance(provider_turn_id, str) or not provider_turn_id:
+            raise CodexRuntimeError("AGENT_PROVIDER_UNAVAILABLE", "Codex turn did not start")
+        self._jobos_turn_id = context.turn_id
+        self._provider_turn_id = provider_turn_id
+        self._assistant_pending = ""
+
+    def stream_events(self) -> AsyncIterator[GatewayEvent]:
+        return self._stream_events()
+
+    async def _stream_events(self) -> AsyncIterator[GatewayEvent]:
+        while True:
+            event = await self._events.get()
+            if event is None:
+                return
+            yield event
+
+    async def interrupt_turn(self, turn_id: str) -> None:
+        if (
+            self._thread_id is None
+            or self._jobos_turn_id != turn_id
+            or self._provider_turn_id is None
+        ):
+            return
+        await self._client.request(
+            "turn/interrupt",
+            {"threadId": self._thread_id, "turnId": self._provider_turn_id},
+        )
+
+    async def recover_active_turn(self, stored_session_id: str, turn_id: str) -> None:
+        await self.start()
+        resumed = await self._client.request(
+            "thread/resume",
+            {
+                "threadId": stored_session_id,
+                "cwd": str(self._cwd),
+                "approvalPolicy": "never",
+                "approvalsReviewer": "user",
+                "sandbox": "read-only",
+            },
+        )
+        resumed_thread = resumed.get("thread") if isinstance(resumed, dict) else None
+        if not isinstance(resumed_thread, dict) or resumed_thread.get("id") != stored_session_id:
+            raise CodexRuntimeError("AGENT_PROVIDER_UNAVAILABLE", "Codex recovery failed")
+        result = await self._client.request(
+            "thread/read", {"threadId": stored_session_id, "includeTurns": True}
+        )
+        thread = result.get("thread") if isinstance(result, dict) else None
+        if not isinstance(thread, dict) or thread.get("id") != stored_session_id:
+            raise CodexRuntimeError("AGENT_PROVIDER_UNAVAILABLE", "Codex recovery failed")
+        turns = thread.get("turns")
+        active = [
+            item
+            for item in turns if isinstance(item, dict) and item.get("status") == "inProgress"
+        ] if isinstance(turns, list) else []
+        if len(active) > 1:
+            raise CodexRuntimeError("AGENT_PROVIDER_UNAVAILABLE", "Codex recovery is ambiguous")
+        self._thread_id = stored_session_id
+        if not active:
+            return
+        provider_turn_id = active[0].get("id")
+        if not isinstance(provider_turn_id, str):
+            raise CodexRuntimeError("AGENT_PROVIDER_UNAVAILABLE", "Codex recovery failed")
+        self._jobos_turn_id = turn_id
+        self._provider_turn_id = provider_turn_id
+        await self._client.request(
+            "turn/interrupt",
+            {"threadId": stored_session_id, "turnId": provider_turn_id},
+        )
+
+    async def handle_notification(self, method: str, params: dict[str, object]) -> None:
+        provider_turn_id = params.get("turnId")
+        turn = params.get("turn")
+        if not isinstance(provider_turn_id, str) and isinstance(turn, dict):
+            provider_turn_id = turn.get("id")
+        if (
+            self._thread_id is None
+            or params.get("threadId") != self._thread_id
+            or self._jobos_turn_id is None
+            or provider_turn_id != self._provider_turn_id
+        ):
+            return
+        if method == "turn/completed" and self._assistant_pending:
+            pending = sanitize_assistant_text(self._assistant_pending)
+            self._assistant_pending = ""
+            self._event_sequence += 1
+            await self._events.put(
+                GatewayEvent(
+                    "assistant_message",
+                    "streaming",
+                    pending,
+                    {"text": pending},
+                    self._jobos_turn_id,
+                    f"codex:{self._event_namespace}:{provider_turn_id}:{self._event_sequence}",
+                )
+            )
+        event = self._normalize(method, params)
+        if event is not None:
+            await self._events.put(event)
+        if method == "turn/completed":
+            self._jobos_turn_id = None
+            self._provider_turn_id = None
+            self._assistant_pending = ""
+
+    def _normalize(self, method: str, params: dict[str, object]) -> GatewayEvent | None:
+        turn_id = self._jobos_turn_id
+        provider_turn_id = self._provider_turn_id
+        if turn_id is None or provider_turn_id is None:
+            return None
+        self._event_sequence += 1
+        source_id = (
+            f"codex:{self._event_namespace}:{provider_turn_id}:{self._event_sequence}"
+        )
+        if method == "item/agentMessage/delta":
+            combined = self._assistant_pending + str(params.get("delta") or "")
+            trailing = _STREAM_TOKEN_TAIL.search(combined)
+            if trailing is None:
+                safe_prefix = combined
+                self._assistant_pending = ""
+            else:
+                safe_prefix = combined[: trailing.start()]
+                self._assistant_pending = trailing.group(0)
+            if not safe_prefix:
+                return None
+            delta = sanitize_assistant_text(safe_prefix)
+            return GatewayEvent(
+                "assistant_message", "streaming", delta, {"text": delta}, turn_id, source_id
+            )
+        if method in {"item/started", "item/completed", "item/mcpToolCall/progress"}:
+            item = params.get("item")
+            detail = redact_detail(item if isinstance(item, dict) else params)
+            state = "completed" if method == "item/completed" else "working"
+            summary = sanitize_text(str(detail.get("name") or "Codex tool activity"))[:500]
+            return GatewayEvent("activity", state, summary, detail, turn_id, source_id)
+        if method == "error":
+            if params.get("willRetry") is True:
+                return GatewayEvent(
+                    "activity",
+                    "working",
+                    "Codex is retrying the turn",
+                    {"reason": "provider_retry"},
+                    turn_id,
+                    source_id,
+                )
+            return GatewayEvent(
+                "error",
+                "failed",
+                "Codex turn failed",
+                {"reason": "provider_error"},
+                turn_id,
+                source_id,
+            )
+        if method == "turn/completed":
+            turn = params.get("turn")
+            status = turn.get("status") if isinstance(turn, dict) else None
+            if status not in _TERMINAL_STATUSES:
+                return None
+            state = "interrupted" if status == "interrupted" else status
+            summary = "Codex turn completed" if state == "completed" else "Codex turn ended"
+            return GatewayEvent("assistant_message", state, summary, {}, turn_id, source_id)
+        return None
+
+    async def close(self) -> None:
+        self._closed = True
+        self._thread_id = None
+        self._jobos_turn_id = None
+        self._provider_turn_id = None
+        unregister = self._unregister
+        if callable(unregister):
+            unregister(self._conversation_id, self)
+        await self._events.put(None)

--- a/services/api/jobos_api/codex_runtime.py
+++ b/services/api/jobos_api/codex_runtime.py
@@ -5,6 +5,8 @@ import hashlib
 import json
 import os
 import stat
+import tempfile
+import tomllib
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from pathlib import Path
@@ -31,6 +33,9 @@ class CodexRpcError(CodexRuntimeError):
 
 
 class CodexRpcClient(Protocol):
+    @property
+    def is_running(self) -> bool: ...
+
     async def start(self) -> None: ...
 
     async def request(self, method: str, params: object | None = None) -> object: ...
@@ -42,7 +47,91 @@ class CodexRpcClient(Protocol):
     def subscribe(self, callback: Callable[[str, object], Awaitable[None]]) -> None: ...
 
 
-def prepare_codex_home(codex_home: Path, *, standalone_home: Path | None = None) -> None:
+def codex_config(mcp_command: Path | None, mcp_args: tuple[str, ...]) -> str:
+    if mcp_command is None:
+        return CODEX_CONFIG
+    try:
+        resolved = mcp_command.expanduser().resolve(strict=True)
+        executable = resolved.is_file() and bool(resolved.stat().st_mode & stat.S_IXUSR)
+    except OSError:
+        executable = False
+        resolved = mcp_command
+    if not executable:
+        raise CodexRuntimeError("JOBOS_TOOLS_UNAVAILABLE", "JobOS tools unavailable")
+    if any(ord(char) < 32 for char in str(resolved)) or any(
+        len(item) > 4096 or any(ord(char) < 32 for char in item) for item in mcp_args
+    ):
+        raise CodexRuntimeError("JOBOS_TOOLS_UNAVAILABLE", "JobOS tools unavailable")
+    args = ", ".join(json.dumps(item, ensure_ascii=False) for item in mcp_args)
+    return (
+        CODEX_CONFIG
+        + "\n[mcp_servers.jobos]\n"
+        + f"command = {json.dumps(str(resolved), ensure_ascii=False)}\n"
+        + f"args = [{args}]\n"
+    )
+
+
+def jobos_mcp_ready(result: object) -> bool:
+    data = result.get("data") if isinstance(result, dict) else None
+    statuses = data if isinstance(data, list) else []
+    jobos = next(
+        (
+            item
+            for item in statuses
+            if isinstance(item, dict) and item.get("name") == "jobos"
+        ),
+        None,
+    )
+    tools = jobos.get("tools") if isinstance(jobos, dict) else None
+    resources = jobos.get("resources") if isinstance(jobos, dict) else None
+    resource_uris = (
+        {item.get("uri") for item in resources if isinstance(item, dict)}
+        if isinstance(resources, list)
+        else set()
+    )
+    return (
+        isinstance(tools, dict)
+        and bool(tools)
+        and all(
+            isinstance(tool, dict)
+            and isinstance(tool.get("name"), str)
+            and isinstance(tool.get("inputSchema"), dict)
+            for tool in tools.values()
+        )
+        and "jobos://capability-map" in resource_uris
+    )
+
+
+def _is_jobos_managed_config(value: str) -> bool:
+    try:
+        parsed = tomllib.loads(value)
+    except tomllib.TOMLDecodeError:
+        return False
+    if set(parsed) != {"cli_auth_credentials_store", "mcp_servers"}:
+        return False
+    if parsed.get("cli_auth_credentials_store") != "keyring":
+        return False
+    servers = parsed.get("mcp_servers")
+    if not isinstance(servers, dict) or set(servers) != {"jobos"}:
+        return False
+    jobos = servers.get("jobos")
+    return (
+        isinstance(jobos, dict)
+        and set(jobos) == {"command", "args"}
+        and isinstance(jobos.get("command"), str)
+        and bool(jobos["command"])
+        and isinstance(jobos.get("args"), list)
+        and all(isinstance(argument, str) for argument in jobos["args"])
+    )
+
+
+def prepare_codex_home(
+    codex_home: Path,
+    *,
+    standalone_home: Path | None = None,
+    mcp_command: Path | None = None,
+    mcp_args: tuple[str, ...] = (),
+) -> None:
     expanded = codex_home.expanduser()
     if expanded.is_symlink():
         raise CodexRuntimeError("AUTH_VAULT_UNAVAILABLE", "JobOS Codex home is unsafe")
@@ -64,21 +153,37 @@ def prepare_codex_home(codex_home: Path, *, standalone_home: Path | None = None)
     config_path = resolved / "config.toml"
     if config_path.is_symlink():
         raise CodexRuntimeError("AUTH_VAULT_UNAVAILABLE", "JobOS Codex config is unsafe")
+    expected_config = codex_config(mcp_command, mcp_args)
     try:
-        if config_path.exists() and config_path.read_text(encoding="utf-8") != CODEX_CONFIG:
+        existing_config = config_path.read_text(encoding="utf-8") if config_path.exists() else None
+        if existing_config not in {None, CODEX_CONFIG, expected_config} and not (
+            existing_config is not None and _is_jobos_managed_config(existing_config)
+        ):
             raise CodexRuntimeError(
                 "AUTH_VAULT_UNAVAILABLE", "JobOS Codex credential storage is not keyring-only"
             )
-        if not config_path.exists():
-            descriptor = os.open(
-                config_path,
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
-                0o600,
+        if existing_config != expected_config:
+            descriptor, temporary_name = tempfile.mkstemp(
+                prefix=".config.toml.", dir=resolved
             )
-            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
-                stream.write(CODEX_CONFIG)
-                stream.flush()
-                os.fsync(stream.fileno())
+            temporary_path = Path(temporary_name)
+            try:
+                os.fchmod(descriptor, 0o600)
+                with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                    descriptor = -1
+                    stream.write(expected_config)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                os.replace(temporary_path, config_path)
+                directory = os.open(resolved, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+                try:
+                    os.fsync(directory)
+                finally:
+                    os.close(directory)
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
+                temporary_path.unlink(missing_ok=True)
         os.chmod(config_path, 0o600)
     except OSError as error:
         raise CodexRuntimeError(
@@ -116,11 +221,17 @@ class CodexAppServerProcess:
         *,
         request_timeout: float = 15.0,
         verify_binary: Callable[[Path], None] = verify_codex_binary,
+        mcp_command: Path | None = None,
+        mcp_args: tuple[str, ...] = (),
+        mcp_device_id: str = "primary-device",
     ) -> None:
         self.binary_path = binary_path
         self.codex_home = codex_home
         self.request_timeout = request_timeout
         self._verify_binary = verify_binary
+        self._mcp_command = mcp_command
+        self._mcp_args = mcp_args
+        self._mcp_device_id = mcp_device_id
         self._process: asyncio.subprocess.Process | None = None
         self._reader_task: asyncio.Task[None] | None = None
         self._stderr_task: asyncio.Task[None] | None = None
@@ -128,15 +239,24 @@ class CodexAppServerProcess:
         self._pending: dict[int, asyncio.Future[object]] = {}
         self._subscribers: list[Callable[[str, object], Awaitable[None]]] = []
         self._start_lock = asyncio.Lock()
+        self._closing = False
 
     def subscribe(self, callback: Callable[[str, object], Awaitable[None]]) -> None:
         self._subscribers.append(callback)
+
+    @property
+    def is_running(self) -> bool:
+        return self._process is not None and self._process.returncode is None
 
     async def start(self) -> None:
         async with self._start_lock:
             if self._process is not None and self._process.returncode is None:
                 return
-            prepare_codex_home(self.codex_home)
+            prepare_codex_home(
+                self.codex_home,
+                mcp_command=self._mcp_command,
+                mcp_args=self._mcp_args,
+            )
             self._verify_binary(self.binary_path)
             environment = {
                 "CODEX_HOME": str(self.codex_home.expanduser().resolve()),
@@ -151,6 +271,7 @@ class CodexAppServerProcess:
                         "/sbin",
                     )
                 ),
+                "JOBOS_DEVICE_ID": self._mcp_device_id,
             }
             try:
                 self._process = await asyncio.create_subprocess_exec(
@@ -279,6 +400,17 @@ class CodexAppServerProcess:
             for future in tuple(self._pending.values()):
                 if not future.done():
                     future.set_exception(failure)
+        finally:
+            if not self._closing:
+                failure = CodexRuntimeError(
+                    "AGENT_PROVIDER_UNAVAILABLE", "Codex App Server stopped"
+                )
+                for future in tuple(self._pending.values()):
+                    if not future.done():
+                        future.set_exception(failure)
+                for subscriber in tuple(self._subscribers):
+                    with suppress(Exception):
+                        await subscriber("jobos/runtime/disconnected", {})
 
     async def _discard_stderr(self) -> None:
         process = self._process
@@ -291,6 +423,7 @@ class CodexAppServerProcess:
             raise
 
     async def close(self) -> None:
+        self._closing = True
         process, self._process = self._process, None
         for task in (self._reader_task, self._stderr_task):
             if task is not None:
@@ -314,3 +447,4 @@ class CodexAppServerProcess:
             except TimeoutError:
                 process.kill()
                 await process.wait()
+        self._closing = False

--- a/services/api/jobos_api/connected_agent_auth.py
+++ b/services/api/jobos_api/connected_agent_auth.py
@@ -13,10 +13,11 @@ from pydantic import BaseModel, ConfigDict, Field
 from .codex_runtime import (
     CODEX_APP_SERVER_RECEIPT_ID,
     CODEX_APP_SERVER_VERSION,
-    CODEX_CONFIG,
     CodexRpcClient,
     CodexRpcError,
     CodexRuntimeError,
+    codex_config,
+    jobos_mcp_ready,
     prepare_codex_home,
 )
 from .installation_profiles import (
@@ -88,6 +89,9 @@ class AuthFlowBroker(Protocol):
 
 
 class CredentialVault(Protocol):
+    @property
+    def tools_configured(self) -> bool: ...
+
     async def inspect(self, vault_ref: str) -> VaultStatus: ...
 
     async def verify_isolation(self, vault_ref: str) -> IsolationProof: ...
@@ -159,9 +163,29 @@ def _namespace_from_reference(reference: str) -> str:
 class CodexCredentialVault:
     """Verifies Codex-owned Keychain state without reading raw credentials."""
 
-    def __init__(self, client: CodexRpcClient, codex_home: Path) -> None:
+    def __init__(
+        self,
+        client: CodexRpcClient,
+        codex_home: Path,
+        *,
+        mcp_command: Path | None = None,
+        mcp_args: tuple[str, ...] = (),
+    ) -> None:
         self.client = client
         self.codex_home = codex_home
+        self.mcp_command = mcp_command
+        self.mcp_args = mcp_args
+
+    @property
+    def tools_configured(self) -> bool:
+        if self.mcp_command is None:
+            return False
+        try:
+            return "[mcp_servers.jobos]" in codex_config(
+                self.mcp_command, self.mcp_args
+            )
+        except CodexRuntimeError:
+            return False
 
     async def inspect(self, vault_ref: str) -> VaultStatus:
         _namespace_from_reference(vault_ref)
@@ -176,7 +200,11 @@ class CodexCredentialVault:
     async def verify_isolation(self, vault_ref: str) -> IsolationProof:
         _namespace_from_reference(vault_ref)
         try:
-            prepare_codex_home(self.codex_home)
+            prepare_codex_home(
+                self.codex_home,
+                mcp_command=self.mcp_command,
+                mcp_args=self.mcp_args,
+            )
             config = (self.codex_home / "config.toml").read_text(encoding="utf-8")
             plaintext_absent = not (self.codex_home / "auth.json").exists()
         except (OSError, CodexRuntimeError) as error:
@@ -185,7 +213,7 @@ class CodexCredentialVault:
             ) from error
         proof = IsolationProof(
             isolated=True,
-            keyring_only=config == CODEX_CONFIG,
+            keyring_only=config == codex_config(self.mcp_command, self.mcp_args),
             plaintext_credentials_absent=plaintext_absent,
             runtime_receipt_id=CODEX_APP_SERVER_RECEIPT_ID,
         )
@@ -464,7 +492,7 @@ class CodexAuthFlowBroker:
 
 
 class CodexConnectedAgentRuntime:
-    """Phase 4 runtime health/models/logout control; chat sessions arrive in Phase 5."""
+    """Codex runtime health, MCP readiness, models, and logout control."""
 
     def __init__(self, client: CodexRpcClient, vault: CredentialVault) -> None:
         self.client = client
@@ -486,12 +514,21 @@ class CodexConnectedAgentRuntime:
             state, label = "sign_in_required", "Sign-in required"
         else:
             state, label = "connected", "Connected"
+        tools_available = False
+        if status.available and status.authenticated and self.vault.tools_configured:
+            try:
+                await self.client.start()
+                result = await self.client.request(
+                    "mcpServerStatus/list", {"detail": "full"}
+                )
+                tools_available = jobos_mcp_ready(result)
+            except (CodexRuntimeError, CodexRpcError, AuthFlowError):
+                tools_available = False
         return {
             "state": state,
             "label": label,
             "provider_available": status.available and status.authenticated,
-            # Phase 5 owns MCP/capability readiness and Codex chat acceptance.
-            "tools_available": False,
+            "tools_available": tools_available,
             "retry_after_seconds": None,
         }
 

--- a/services/api/jobos_api/main.py
+++ b/services/api/jobos_api/main.py
@@ -14,7 +14,12 @@ from jobos_api.local_config import (
     settings_from_config,
 )
 from jobos_api.responses import ApiErrorResponse
-from jobos_api.settings import Settings, parse_device_credentials, parse_device_ids
+from jobos_api.settings import (
+    Settings,
+    parse_command_args,
+    parse_device_credentials,
+    parse_device_ids,
+)
 
 
 def settings_from_environment() -> Settings:
@@ -35,6 +40,10 @@ def settings_from_environment() -> Settings:
             updates["codex_home_path"] = Path(codex_home)
         if codex_timeout := os.environ.get("JOBOS_CODEX_REQUEST_TIMEOUT"):
             updates["codex_request_timeout"] = float(codex_timeout)
+        if codex_mcp_command := os.environ.get("JOBOS_CODEX_MCP_COMMAND"):
+            updates["codex_mcp_command"] = Path(codex_mcp_command)
+        if codex_mcp_args := os.environ.get("JOBOS_CODEX_MCP_ARGS_JSON"):
+            updates["codex_mcp_args"] = parse_command_args(codex_mcp_args)
         for environment_name, field_name in (
             ("JOBOS_CAREER_PROFILE_AGENT_ID", "career_profile_agent_id"),
             ("JOBOS_CAREER_PROFILE_AGENT_DISPLAY_NAME", "career_profile_agent_display_name"),
@@ -86,6 +95,10 @@ def settings_from_environment() -> Settings:
         ),
         codex_home_path=(Path(value) if (value := os.environ.get("JOBOS_CODEX_HOME")) else None),
         codex_request_timeout=float(os.environ.get("JOBOS_CODEX_REQUEST_TIMEOUT", "15")),
+        codex_mcp_command=(
+            Path(value) if (value := os.environ.get("JOBOS_CODEX_MCP_COMMAND")) else None
+        ),
+        codex_mcp_args=parse_command_args(os.environ.get("JOBOS_CODEX_MCP_ARGS_JSON")),
         career_profile_enabled=os.environ.get("JOBOS_CAREER_PROFILE_ENABLED") == "1",
         career_profile_owner_device_ids=parse_device_ids(
             os.environ.get("JOBOS_CAREER_PROFILE_OWNER_DEVICE_IDS_JSON")

--- a/services/api/jobos_api/settings.py
+++ b/services/api/jobos_api/settings.py
@@ -44,6 +44,18 @@ def parse_device_ids(raw: str | None) -> tuple[str, ...]:
         raise ValueError("device identifier list is invalid") from None
 
 
+def parse_command_args(raw: str | None) -> tuple[str, ...]:
+    if not raw:
+        return ()
+    try:
+        value = json.loads(raw)
+        if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+            raise ValueError
+        return tuple(value)
+    except (json.JSONDecodeError, ValueError):
+        raise ValueError("command arguments are invalid") from None
+
+
 class Settings(BaseModel):
     """Runtime inputs for the API process.
 
@@ -72,6 +84,8 @@ class Settings(BaseModel):
     codex_app_server_path: Path | None = None
     codex_home_path: Path | None = None
     codex_request_timeout: float = Field(default=15.0, gt=0, le=60)
+    codex_mcp_command: Path | None = None
+    codex_mcp_args: tuple[str, ...] = ()
     career_profile_enabled: bool = False
     career_profile_owner_device_ids: tuple[str, ...] = ()
     career_profile_agent_id: str = Field(

--- a/services/api/tests/test_browser_capability.py
+++ b/services/api/tests/test_browser_capability.py
@@ -810,6 +810,26 @@ def test_activity_report_is_idempotent_without_injecting_agent_chat_activity(tmp
     assert detail["label"] == "Reviewed listing"
 
 
+def test_mcp_audit_writes_require_trusted_active_turn_scope(tmp_path):
+    body = {
+        "label": "Uncorrelated activity",
+        "state": "completed",
+        "detail": {},
+        "origin": "mcp",
+        "idempotency_key": "uncorrelated-activity-1",
+    }
+    with TestClient(make_app(tmp_path)) as client:
+        uncorrelated = client.post("/v1/activity", headers=mcp_auth(), json=body)
+        untrusted = client.post("/v1/activity", headers=auth(), json=body)
+
+    assert uncorrelated.status_code == 422
+    assert uncorrelated.json()["code"] == "mcp_turn_required"
+    assert untrusted.status_code == 403
+    assert untrusted.json()["detail"] == (
+        "MCP operations require the trusted local MCP credential"
+    )
+
+
 @pytest.mark.parametrize(
     ("payload", "message"),
     [

--- a/services/api/tests/test_codex_adapter.py
+++ b/services/api/tests/test_codex_adapter.py
@@ -320,9 +320,22 @@ async def test_codex_redacts_credentials_split_across_stream_deltas(tmp_path: Pa
             "threadId": "thread-a",
             "turnId": "provider-turn-a",
             "itemId": "message-secret",
-            "delta": "ijklmnopqrstuvwx done ",
+            "delta": "ijklmnopqrstuvwx done tail",
         },
     )
     redacted = await anext(events)
     assert redacted.summary == "[redacted] done "
     assert "sk-proj" not in prefix.summary + redacted.summary
+
+    await client.emit(
+        "turn/completed",
+        {
+            "threadId": "thread-a",
+            "turn": {"id": "provider-turn-a", "status": "completed"},
+        },
+    )
+    tail = await anext(events)
+    terminal = await anext(events)
+    assert tail.summary == "tail"
+    assert terminal.state == "completed"
+    assert "sk-proj" not in tail.summary

--- a/services/api/tests/test_codex_adapter.py
+++ b/services/api/tests/test_codex_adapter.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import pytest
+from jobos_api.agent_gateway import AgentContext
+from jobos_api.codex_adapter import CodexGatewayFactory
+from jobos_api.codex_runtime import CodexRuntimeError
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class FakeCodexClient:
+    def __init__(self, *, ready: bool = True) -> None:
+        self.ready = ready
+        self.requests: list[tuple[str, object | None]] = []
+        self.subscribers: list[Callable[[str, object], Awaitable[None]]] = []
+        self.started = False
+        self.turns: list[dict[str, object]] = []
+
+    @property
+    def is_running(self) -> bool:
+        return self.started
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def request(self, method: str, params: object | None = None) -> object:
+        self.requests.append((method, params))
+        if method == "thread/start":
+            return {"thread": {"id": "thread-a", "turns": []}}
+        if method == "thread/resume":
+            assert isinstance(params, dict)
+            return {"thread": {"id": params["threadId"], "turns": self.turns}}
+        if method == "mcpServerStatus/list":
+            resources = [{"name": "capabilities", "uri": "jobos://capability-map"}]
+            tools = {"document_publish": {"name": "document_publish", "inputSchema": {}}}
+            if not self.ready:
+                resources = []
+            return {
+                "data": [
+                    {
+                        "name": "jobos",
+                        "authStatus": "unsupported",
+                        "resources": resources,
+                        "resourceTemplates": [],
+                        "tools": tools,
+                    }
+                ]
+            }
+        if method == "turn/start":
+            return {"turn": {"id": "provider-turn-a", "status": "inProgress"}}
+        if method == "thread/read":
+            assert isinstance(params, dict)
+            return {"thread": {"id": params["threadId"], "turns": self.turns}}
+        if method == "turn/interrupt":
+            return {}
+        raise AssertionError(method)
+
+    async def notify(self, method: str, params: object | None = None) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    def subscribe(self, callback: Callable[[str, object], Awaitable[None]]) -> None:
+        self.subscribers.append(callback)
+
+    async def emit(self, method: str, params: object) -> None:
+        if method == "jobos/runtime/disconnected":
+            self.started = False
+        for callback in tuple(self.subscribers):
+            await callback(method, params)
+
+
+def context(conversation_id: str = "conv_alpha") -> AgentContext:
+    return AgentContext(
+        turn_id="turn_12345678",
+        selected_job_id="(FAKE)-job-alpha",
+        selected_job={"id": "(FAKE)-job-alpha", "title": "(FAKE) Role"},
+        workspace={"active_document": "(FAKE)-resume"},
+        career_profile={"summary": "(FAKE) profile"},
+        career_profile_context={"schema_version": 1},
+        conversation_id=conversation_id,
+        profile_id="jprof_00000000000000000000000000000000",
+        connected_agent_id="cagent_codex",
+        provider="codex",
+        model_id="gpt-5.6-codex",
+        reasoning_effort="medium",
+        permission_state={"scope": "global"},
+    )
+
+
+@pytest.mark.anyio
+async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: Path) -> None:
+    client = FakeCodexClient()
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+
+    assert gateway.connection_state == "offline"
+    assert await gateway.create_or_resume_conversation(None) == ("thread-a", "thread-a")
+    assert gateway.connection_state == "online"
+    await gateway.submit_turn("Tailor this", context())
+
+    methods = [method for method, _ in client.requests]
+    assert methods == ["thread/start", "mcpServerStatus/list", "turn/start"]
+    thread_params = client.requests[0][1]
+    assert isinstance(thread_params, dict)
+    assert thread_params["sandbox"] == "read-only"
+    assert thread_params["cwd"] == str(tmp_path)
+    turn_params = client.requests[-1][1]
+    assert isinstance(turn_params, dict)
+    assert turn_params["threadId"] == "thread-a"
+    assert turn_params["clientUserMessageId"] == "turn_12345678"
+    assert turn_params["model"] == "gpt-5.6-codex"
+    assert turn_params["effort"] == "medium"
+    assert turn_params["approvalPolicy"] == "never"
+    assert turn_params["sandboxPolicy"] == {
+        "type": "readOnly",
+        "networkAccess": False,
+    }
+    prompt = turn_params["input"][0]["text"]  # type: ignore[index]
+    assert "conversation_id=\"conv_alpha\"" in prompt
+    assert "turn_id=\"turn_12345678\"" in prompt
+    assert "(FAKE)-job-alpha" in prompt
+    assert "Tailor this" in prompt
+    client.started = False
+    assert gateway.connection_state == "offline"
+
+
+@pytest.mark.anyio
+async def test_codex_rejects_turn_when_canonical_jobos_mcp_is_not_ready(tmp_path: Path) -> None:
+    client = FakeCodexClient(ready=False)
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+
+    with pytest.raises(CodexRuntimeError, match="JobOS tools unavailable") as captured:
+        await gateway.submit_turn("Do work", context())
+
+    assert captured.value.code == "JOBOS_TOOLS_UNAVAILABLE"
+    assert "turn/start" not in [method for method, _ in client.requests]
+
+
+@pytest.mark.anyio
+async def test_codex_events_are_isolated_lossless_and_terminal(tmp_path: Path) -> None:
+    client = FakeCodexClient()
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    events = gateway.stream_events()
+
+    await client.emit(
+        "item/agentMessage/delta",
+        {
+            "threadId": "wrong-thread",
+            "turnId": "provider-turn-a",
+            "itemId": "message-a",
+            "delta": "wrong",
+        },
+    )
+    await client.emit(
+        "item/agentMessage/delta",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "itemId": "message-a",
+            "delta": "Hello ",
+        },
+    )
+    delta = await anext(events)
+    assert delta.turn_id == "turn_12345678"
+    assert delta.summary == "Hello "
+    assert delta.source_event_id and delta.source_event_id.startswith("codex:")
+
+    await client.emit(
+        "item/agentMessage/delta",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "itemId": "message-a",
+            "delta": "Hello ",
+        },
+    )
+    repeated_delta = await anext(events)
+    assert repeated_delta.summary == "Hello "
+    assert repeated_delta.source_event_id != delta.source_event_id
+
+    await client.emit(
+        "error",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "willRetry": True,
+            "error": {"message": "(FAKE) transient upstream error"},
+        },
+    )
+    retrying = await anext(events)
+    assert retrying.event_type == "activity"
+    assert retrying.state == "working"
+    assert retrying.detail == {"reason": "provider_retry"}
+
+    await client.emit(
+        "turn/completed",
+        {
+            "threadId": "thread-a",
+            "turn": {"id": "provider-turn-a", "status": "completed", "items": []},
+        },
+    )
+    terminal = await anext(events)
+    assert terminal.event_type == "assistant_message"
+    assert terminal.state == "completed"
+    assert terminal.turn_id == "turn_12345678"
+
+
+@pytest.mark.anyio
+async def test_codex_interrupt_and_recovery_use_exact_provider_turn(tmp_path: Path) -> None:
+    client = FakeCodexClient()
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    await gateway.interrupt_turn("turn_12345678")
+
+    assert client.requests[-1] == (
+        "turn/interrupt",
+        {"threadId": "thread-a", "turnId": "provider-turn-a"},
+    )
+
+    client.turns = [{"id": "provider-turn-recovered", "status": "inProgress", "items": []}]
+    recovered = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    await recovered.recover_active_turn("thread-a", "turn_87654321")
+    assert [method for method, _params in client.requests[-3:]] == [
+        "thread/resume",
+        "thread/read",
+        "turn/interrupt",
+    ]
+    assert client.requests[-1] == (
+        "turn/interrupt",
+        {"threadId": "thread-a", "turnId": "provider-turn-recovered"},
+    )
+
+
+@pytest.mark.anyio
+async def test_codex_recovery_fails_closed_when_multiple_turns_are_active(tmp_path: Path) -> None:
+    client = FakeCodexClient()
+    client.turns = [
+        {"id": "provider-turn-a", "status": "inProgress"},
+        {"id": "provider-turn-b", "status": "inProgress"},
+    ]
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+
+    with pytest.raises(CodexRuntimeError, match="ambiguous"):
+        await gateway.recover_active_turn("thread-a", "turn_87654321")
+
+
+@pytest.mark.anyio
+async def test_codex_rejects_symlinked_workspace(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    alias = tmp_path / "workspace"
+    alias.symlink_to(target, target_is_directory=True)
+    gateway = CodexGatewayFactory(FakeCodexClient(), cwd=alias).create("conv_alpha")
+
+    with pytest.raises(CodexRuntimeError, match="unsafe"):
+        await gateway.create_or_resume_conversation(None)
+
+
+@pytest.mark.anyio
+async def test_codex_runtime_disconnect_settles_turn_and_resumes_exact_thread(
+    tmp_path: Path,
+) -> None:
+    client = FakeCodexClient()
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    events = gateway.stream_events()
+
+    await client.emit("jobos/runtime/disconnected", {})
+    terminal = await anext(events)
+    assert terminal.event_type == "error"
+    assert terminal.state == "failed"
+    assert terminal.turn_id == "turn_12345678"
+    assert terminal.detail == {
+        "reason": "transport_lost",
+        "recovery_required": True,
+    }
+    assert gateway.connection_state == "offline"
+
+    await gateway.start()
+    assert client.requests[-1][0] == "thread/resume"
+    assert client.requests[-1][1]["threadId"] == "thread-a"  # type: ignore[index]
+    assert gateway.connection_state == "online"
+
+
+@pytest.mark.anyio
+async def test_codex_redacts_credentials_split_across_stream_deltas(tmp_path: Path) -> None:
+    client = FakeCodexClient()
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    events = gateway.stream_events()
+
+    await client.emit(
+        "item/agentMessage/delta",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "itemId": "message-secret",
+            "delta": "The secret is sk-proj-abcdefgh",
+        },
+    )
+    prefix = await anext(events)
+    assert prefix.summary == "The secret is "
+
+    await client.emit(
+        "item/agentMessage/delta",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "itemId": "message-secret",
+            "delta": "ijklmnopqrstuvwx done ",
+        },
+    )
+    redacted = await anext(events)
+    assert redacted.summary == "[redacted] done "
+    assert "sk-proj" not in prefix.summary + redacted.summary

--- a/services/api/tests/test_codex_runtime.py
+++ b/services/api/tests/test_codex_runtime.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -50,6 +52,88 @@ def test_prepare_codex_home_rejects_standalone_plaintext_and_symlink(tmp_path: P
         prepare_codex_home(alias, standalone_home=standalone)
 
 
+def test_prepare_codex_home_configures_only_the_trusted_jobos_mcp(tmp_path: Path) -> None:
+    codex_home = tmp_path / "jobos" / "codex-home"
+    launcher = tmp_path / "jobos-mcp-launcher"
+    launcher.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    launcher.chmod(0o700)
+
+    prepare_codex_home(codex_home, standalone_home=tmp_path / "standalone")
+    prepare_codex_home(
+        codex_home,
+        standalone_home=tmp_path / "standalone",
+        mcp_command=launcher,
+        mcp_args=("--runtime", "(FAKE)-runtime.json"),
+    )
+
+    config = (codex_home / "config.toml").read_text(encoding="utf-8")
+    assert config.startswith(CODEX_CONFIG)
+    assert "[mcp_servers.jobos]" in config
+    assert f'command = "{launcher}"' in config
+    assert 'args = ["--runtime", "(FAKE)-runtime.json"]' in config
+    assert "token" not in config.lower()
+
+    with pytest.raises(CodexRuntimeError, match="tools unavailable"):
+        prepare_codex_home(
+            tmp_path / "missing-home",
+            standalone_home=tmp_path / "standalone",
+            mcp_command=tmp_path / "missing-launcher",
+        )
+
+
+def test_prepare_codex_home_updates_previous_jobos_owned_mcp_config(tmp_path: Path) -> None:
+    codex_home = tmp_path / "codex-home"
+    old_launcher = tmp_path / "old-launcher"
+    new_launcher = tmp_path / "new-launcher"
+    for launcher in (old_launcher, new_launcher):
+        launcher.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        launcher.chmod(0o700)
+
+    prepare_codex_home(codex_home, mcp_command=old_launcher, mcp_args=("old",))
+    prepare_codex_home(codex_home, mcp_command=new_launcher, mcp_args=("new",))
+
+    config = (codex_home / "config.toml").read_text(encoding="utf-8")
+    assert str(new_launcher) in config
+    assert str(old_launcher) not in config
+    assert 'args = ["new"]' in config
+
+
+def test_prepare_codex_home_preserves_live_config_when_atomic_replace_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    codex_home = tmp_path / "codex-home"
+    old_launcher = tmp_path / "old-launcher"
+    new_launcher = tmp_path / "new-launcher"
+    for launcher in (old_launcher, new_launcher):
+        launcher.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        launcher.chmod(0o700)
+    prepare_codex_home(codex_home, mcp_command=old_launcher, mcp_args=("old",))
+    original = (codex_home / "config.toml").read_bytes()
+
+    def fail_replace(_source, _destination) -> None:
+        raise OSError("(FAKE) interrupted replacement")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+    with pytest.raises(CodexRuntimeError, match="configuration is unavailable"):
+        prepare_codex_home(codex_home, mcp_command=new_launcher, mcp_args=("new",))
+
+    assert (codex_home / "config.toml").read_bytes() == original
+    assert list(codex_home.glob(".config.toml.*")) == []
+
+
+def test_prepare_codex_home_writes_valid_unicode_toml(tmp_path: Path) -> None:
+    codex_home = tmp_path / "codex-home"
+    launcher = tmp_path / "jobos-\U0001F525-launcher"
+    launcher.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    launcher.chmod(0o700)
+
+    prepare_codex_home(codex_home, mcp_command=launcher, mcp_args=("--label", "\U0001F525"))
+
+    parsed = tomllib.loads((codex_home / "config.toml").read_text(encoding="utf-8"))
+    assert parsed["mcp_servers"]["jobos"]["command"] == str(launcher)
+    assert parsed["mcp_servers"]["jobos"]["args"] == ["--label", "\U0001F525"]
+
+
 @pytest.mark.anyio
 async def test_stdio_supervisor_initializes_and_uses_dedicated_home(tmp_path: Path) -> None:
     requests_path = tmp_path / "requests.jsonl"
@@ -65,7 +149,11 @@ output = Path({str(requests_path)!r})
 for line in sys.stdin:
     message = json.loads(line)
     with output.open("a", encoding="utf-8") as stream:
-        record = {{"message": message, "codex_home": os.environ["CODEX_HOME"]}}
+        record = {{
+            "message": message,
+            "codex_home": os.environ["CODEX_HOME"],
+            "device_id": os.environ.get("JOBOS_DEVICE_ID"),
+        }}
         stream.write(json.dumps(record) + "\\n")
     if "id" not in message:
         continue
@@ -84,6 +172,7 @@ for line in sys.stdin:
         codex_home,
         request_timeout=2,
         verify_binary=lambda _: None,
+        mcp_device_id="(FAKE)-device",
     )
     try:
         await client.start()
@@ -98,6 +187,7 @@ for line in sys.stdin:
         "model/list",
     ]
     assert {record["codex_home"] for record in records} == {str(codex_home)}
+    assert {record["device_id"] for record in records} == {"(FAKE)-device"}
 
 
 @pytest.mark.anyio
@@ -159,7 +249,7 @@ for line in sys.stdin:
     client = CodexAppServerProcess(
         server,
         tmp_path / "codex-home",
-        request_timeout=0.25,
+        request_timeout=1.0,
         verify_binary=lambda _: None,
     )
     try:

--- a/services/api/tests/test_connected_agent_auth.py
+++ b/services/api/tests/test_connected_agent_auth.py
@@ -9,6 +9,7 @@ from jobos_api.connected_agent_auth import (
     AuthFlowError,
     CodexAuthFlowBroker,
     CodexConnectedAgentRuntime,
+    CodexCredentialVault,
     IsolationProof,
     RemovalProof,
     VaultStatus,
@@ -32,10 +33,15 @@ def anyio_backend() -> str:
 
 class FakeCodexClient:
     def __init__(
-        self, *, device_unavailable: bool = False, invalid_models: bool = False
+        self,
+        *,
+        device_unavailable: bool = False,
+        invalid_models: bool = False,
+        mcp_ready: bool = True,
     ) -> None:
         self.device_unavailable = device_unavailable
         self.invalid_models = invalid_models
+        self.mcp_ready = mcp_ready
         self.calls: list[tuple[str, object | None]] = []
         self.subscribers = []
         self.account: dict[str, object] | None = {
@@ -102,6 +108,14 @@ class FakeCodexClient:
                     },
                 ]
             }
+        if method == "mcpServerStatus/list":
+            resources = [{"uri": "jobos://capability-map"}] if self.mcp_ready else []
+            tools = (
+                {"jobos.test": {"name": "jobos.test", "inputSchema": {"type": "object"}}}
+                if self.mcp_ready
+                else {}
+            )
+            return {"data": [{"name": "jobos", "resources": resources, "tools": tools}]}
         raise AssertionError(f"unexpected method: {method}")
 
     async def complete_login(self, *, success: bool = True) -> None:
@@ -116,6 +130,10 @@ class FakeVault:
         self.removed = False
         self.isolation_error: AuthFlowError | None = None
         self.removal_error: AuthFlowError | None = None
+
+    @property
+    def tools_configured(self) -> bool:
+        return True
 
     async def inspect(self, vault_ref: str) -> VaultStatus:
         assert vault_ref.startswith("vault_ref_codex:")
@@ -307,6 +325,14 @@ async def test_runtime_models_are_live_and_disconnect_is_vault_verified(tmp_path
     agent = registry.load().connected_agents[0]
     runtime = CodexConnectedAgentRuntime(client, vault)
 
+    health = await runtime.inspect_connection(agent)
+    assert health["provider_available"] is True
+    assert health["tools_available"] is True
+    client.mcp_ready = False
+    unavailable_health = await runtime.inspect_connection(agent)
+    assert unavailable_health["provider_available"] is True
+    assert unavailable_health["tools_available"] is False
+    client.mcp_ready = True
     models = await runtime.list_models(agent)
     assert models == {
         "live": True,
@@ -409,3 +435,26 @@ async def test_invalid_model_catalog_after_login_cleans_up_credentials(tmp_path:
     assert failed.error_code == "AGENT_PROVIDER_UNAVAILABLE"
     assert vault.removed is True
     assert registry.load().connected_agents[0].lifecycle == "disconnected"
+
+
+@pytest.mark.anyio
+async def test_keyring_isolation_accepts_the_trusted_jobos_mcp_config(tmp_path: Path) -> None:
+    launcher = tmp_path / "jobos-mcp"
+    launcher.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    launcher.chmod(0o700)
+    vault = CodexCredentialVault(
+        FakeCodexClient(),
+        tmp_path / "codex-home",
+        mcp_command=launcher,
+        mcp_args=("--profile", "(FAKE)-profile"),
+    )
+
+    first = await vault.verify_isolation("vault_ref_codex:FAKE-jobos-test")
+    second = await vault.verify_isolation("vault_ref_codex:FAKE-jobos-test")
+
+    assert first.keyring_only is True
+    assert first.plaintext_credentials_absent is True
+    assert second == first
+    config = (tmp_path / "codex-home" / "config.toml").read_text(encoding="utf-8")
+    assert "[mcp_servers.jobos]" in config
+    assert str(launcher.resolve()) in config

--- a/services/api/tests/test_initialize.py
+++ b/services/api/tests/test_initialize.py
@@ -179,6 +179,25 @@ def test_config_backed_settings_honor_explicit_career_profile_activation(tmp_pat
     assert configured.career_profile_enabled is True
 
 
+def test_config_backed_settings_preserve_codex_mcp_args_without_env_override(
+    tmp_path, monkeypatch
+):
+    initialize_jobos(tmp_path)
+    config = tmp_path / "config.json"
+    configured = settings_from_config(config).model_copy(
+        update={"codex_mcp_args": ("--runtime", "(FAKE)-runtime.json")}
+    )
+    monkeypatch.delenv("JOBOS_DEVICE_TOKEN", raising=False)
+    monkeypatch.delenv("JOBOS_MCP_TOKEN", raising=False)
+    monkeypatch.delenv("JOBOS_CODEX_MCP_ARGS_JSON", raising=False)
+    monkeypatch.setenv("JOBOS_CONFIG_PATH", str(config))
+    monkeypatch.setattr("jobos_api.main.settings_from_config", lambda _path: configured)
+
+    loaded = settings_from_environment()
+
+    assert loaded.codex_mcp_args == ("--runtime", "(FAKE)-runtime.json")
+
+
 def test_file_credentials_reject_symlinks(tmp_path):
     target = tmp_path / "outside.json"
     target.write_text('{"deviceToken":"device","mcpToken":"mcp"}', encoding="utf-8")

--- a/services/api/tests/test_jobs_contract.py
+++ b/services/api/tests/test_jobs_contract.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
 from hashlib import sha256
 from pathlib import Path
 
@@ -12,8 +13,15 @@ import pytest
 from conftest import build_minimal_pdf
 from fastapi.testclient import TestClient
 from jobos_api.app import create_app
+from jobos_api.conversation_store import ConversationStore
 from jobos_api.documents import ArtifactPublishRequest
 from jobos_api.editable_documents import blank_content, default_settings
+from jobos_api.installation_profiles import (
+    AnchoredRuntime,
+    InstallationProfileRecord,
+    InstallationProfileRegistry,
+    InstallationProfileRegistryData,
+)
 from jobos_api.private_adapters.job_hunter import adapt_job_hunter_facade
 from jobos_api.settings import DeviceCredential, Settings
 from jobos_api.state_store import JobOsStateStore, mutation_activity_source_id
@@ -307,7 +315,7 @@ def start_active_turn(client, conversation_id, *, headers=None, key="mcp-scope-a
         headers=headers or auth_headers(),
         json={"text": "Keep MCP scope active", "idempotency_key": key},
     )
-    assert response.status_code == 201
+    assert response.status_code == 201, response.text
     return response.json()["turn_id"]
 
 
@@ -1023,6 +1031,200 @@ def test_trusted_local_mcp_scopes_publication_to_a_remote_device_conversation(
     assert missing.json()["code"] == "conversation_not_found"
     assert remote_mcp_attempt.status_code == 403
     assert remote_mcp_attempt.json()["code"] == "mcp_local_device_required"
+
+
+@pytest.mark.parametrize("provider", ["hermes", "codex"])
+def test_provider_bound_mcp_publication_records_exactly_once_turn_attribution(
+    tmp_path, minimal_docx, monkeypatch, provider
+):
+    facade = FakeJobHunterFacade()
+    facade.jobs = facade.jobs[:1]
+    state_path = tmp_path / "jobos.db"
+    registry_path = tmp_path / "installation-profiles.json"
+    profile_id = f"jprof_{'b' * 32}"
+    agent_id = f"jagent_{('a' if provider == 'codex' else 'c') * 32}"
+    now = datetime(2026, 8, 25, tzinfo=UTC)
+    registry = InstallationProfileRegistry(registry_path)
+    registry.write(
+        InstallationProfileRegistryData(
+            registry_revision=1,
+            active_profile_id=profile_id,
+            profiles=(
+                InstallationProfileRecord(
+                    profile_id=profile_id,
+                    display_name=f"(FAKE) {provider.title()} profile",
+                    storage_mode="anchored",
+                    created_at=now,
+                    updated_at=now,
+                    anchored_runtime=AnchoredRuntime(
+                        job_provider="sqlite",
+                        artifact_provider="local",
+                        state_db_path=state_path.absolute(),
+                        jobs_db_path=(tmp_path / "jobs.db").absolute(),
+                        local_artifact_root=(tmp_path / "artifacts").absolute(),
+                    ),
+                ),
+            ),
+        )
+    )
+    registry.create_connected_agent(
+        provider=provider,
+        display_name=f"(FAKE) {provider.title()}",
+        avatar_id=provider,
+        default_model_id=f"(FAKE)-{provider}-model",
+        default_reasoning_effort="medium",
+        connection_config=(
+            {"runtime_namespace": "FAKE-jobos-test"}
+            if provider == "codex"
+            else {"endpoint_url": "http://127.0.0.1:9220"}
+        ),
+        credential_reference=("vault_ref_provider_attribution" if provider == "codex" else None),
+        expected_registry_revision=1,
+        idempotency_key="(FAKE)-create-codex-attribution-agent",
+        agent_id=agent_id,
+        now=now,
+    )
+    state_store = JobOsStateStore(state_path)
+    state_store.initialize(owner_device_id="primary-device")
+    conversation = state_store.create_conversation(
+        actor_id="primary-device",
+        selected_job_id="job-0",
+        connected_agent_id=agent_id,
+        provider=provider,
+        model_id=f"(FAKE)-{provider}-model",
+        reasoning_effort="medium",
+    )
+    conversation_id = str(conversation["conversation_id"])
+    ConversationStore(state_path, conversation_id).complete_provisioning(
+        f"(FAKE)-{provider}-thread-attribution"
+    )
+    monkeypatch.setattr(
+        "jobos_api.app.CodexGatewayFactory",
+        lambda *_args, **_kwargs: PendingGatewayFactory(),
+    )
+    repository, artifact_gateway = adapt_job_hunter_facade(facade)
+    app = create_app(
+        Settings(
+            device_token="test-device-token",
+            mcp_token="test-mcp-trusted-token",
+            state_db_path=state_path,
+            artifact_roots=(tmp_path,),
+            hermes_job_hunter_cwd=tmp_path,
+            codex_app_server_path=tmp_path / "(FAKE)-codex-app-server",
+            codex_home_path=tmp_path / "(FAKE)-codex-home",
+            installation_registry_path=registry_path,
+            installation_profile_id=profile_id,
+            installation_profile_name=f"(FAKE) {provider.title()} profile",
+        ),
+        job_repository=repository,
+        artifact_gateway=artifact_gateway,
+        state_store=state_store,
+        agent_gateway_factory=PendingGatewayFactory(),
+    )
+    payload = {
+        "document_key": "resume",
+        "document_label": "Resume",
+        "source_filename": "resume.md",
+        "source_base64": base64.b64encode(f"# (FAKE) {provider.title()} resume".encode()).decode(
+            "ascii"
+        ),
+        "artifact_filename": "resume.docx",
+        "artifact_base64": base64.b64encode(
+            minimal_docx(f"(FAKE) {provider.title()} resume")
+        ).decode("ascii"),
+        "origin": "mcp",
+        "idempotency_key": f"{provider}-attributed-publication",
+    }
+
+    with TestClient(app) as client:
+        profile_headers = {
+            **auth_headers(),
+            "X-JobOS-Profile-ID": profile_id,
+        }
+        turn_id = start_active_turn(
+            client,
+            conversation_id,
+            headers=profile_headers,
+            key=f"{provider}-attribution-active-turn",
+        )
+        params = {"conversation_id": conversation_id, "turn_id": turn_id}
+        published = client.post(
+            "/v1/jobs/job-0/artifacts/publish",
+            headers=mcp_auth_headers(),
+            params=params,
+            json=payload,
+        )
+        replay = client.post(
+            "/v1/jobs/job-0/artifacts/publish",
+            headers=mcp_auth_headers(),
+            params=params,
+            json=payload,
+        )
+        activity = client.post(
+            "/v1/activity",
+            headers=mcp_auth_headers(),
+            params=params,
+            json={
+                "label": f"(FAKE) {provider.title()} activity",
+                "state": "completed",
+                "detail": {"proof": "direct-audit-write"},
+                "origin": "mcp",
+                "idempotency_key": f"{provider}-attributed-activity",
+            },
+        )
+
+    assert published.status_code == 200
+    assert replay.status_code == 200
+    assert activity.status_code == 200
+    assert replay.json() == published.json()
+    with sqlite3.connect(state_path) as connection:
+        rows = connection.execute(
+            """
+            SELECT payload_json FROM job_events
+            WHERE command_name = 'document.publish' AND idempotency_key = ?
+            """,
+            (payload["idempotency_key"],),
+        ).fetchall()
+        activity_rows = connection.execute(
+            """
+            SELECT payload_json FROM job_events
+            WHERE command_name = 'activity.report' AND idempotency_key = ?
+            """,
+            (f"{provider}-attributed-activity",),
+        ).fetchall()
+    assert len(rows) == 1
+    attribution = json.loads(rows[0][0])
+    assert attribution == {
+        "artifact_id": published.json()["artifacts"][0]["artifact_id"],
+        "connected_agent_id": agent_id,
+        "conversation_id": conversation_id,
+        "document_key": "resume",
+        "label": "Published Resume DOCX",
+        "origin": "mcp",
+        "outcome": "completed",
+        "profile_id": profile_id,
+        "provider": provider,
+        "state": "completed",
+        "turn_id": turn_id,
+    }
+    assert len(activity_rows) == 1
+    activity_attribution = json.loads(activity_rows[0][0])
+    assert {
+        key: activity_attribution[key]
+        for key in (
+            "profile_id",
+            "conversation_id",
+            "turn_id",
+            "connected_agent_id",
+            "provider",
+        )
+    } == {
+        "profile_id": profile_id,
+        "conversation_id": conversation_id,
+        "turn_id": turn_id,
+        "connected_agent_id": agent_id,
+        "provider": provider,
+    }
 
 
 def test_inspect_and_history_expose_normalized_facade_records(tmp_path):

--- a/services/mcp/jobos_mcp/server.py
+++ b/services/mcp/jobos_mcp/server.py
@@ -19,15 +19,15 @@ ConversationId = Annotated[str, Field(pattern=r"^conv_[A-Za-z0-9_-]{1,128}$", ma
 TurnId = Annotated[str, Field(pattern=r"^turn_[A-Za-z0-9_-]{8,200}$", max_length=205)]
 
 
-def local_mcp_token() -> str:
-    configured = os.environ.get("JOBOS_MCP_TOKEN", "")
+def _local_keychain_token(environment_name: str, service: str) -> str:
+    configured = os.environ.get(environment_name, "")
     if configured:
         return configured
     if sys.platform == "darwin":
         account = os.environ.get("JOBOS_DEVICE_ID", "primary-device")
         for arguments in (
-            ["-s", "com.cobibean.jobos.mcp-token", "-a", account],
-            ["-s", "com.cobibean.jobos.mcp-token"],
+            ["-s", service, "-a", account],
+            ["-s", service],
         ):
             result = subprocess.run(
                 ["security", "find-generic-password", "-w", *arguments],
@@ -39,7 +39,15 @@ def local_mcp_token() -> str:
             token = result.stdout.strip()
             if result.returncode == 0 and token:
                 return token
-    raise RuntimeError("JOBOS_MCP_TOKEN is required")
+    raise RuntimeError(f"{environment_name} is required")
+
+
+def local_mcp_token() -> str:
+    return _local_keychain_token("JOBOS_MCP_TOKEN", "com.cobibean.jobos.mcp-token")
+
+
+def local_device_token() -> str:
+    return _local_keychain_token("JOBOS_DEVICE_TOKEN", "com.cobibean.jobos.device-token")
 
 
 def _local_config_path() -> Path:
@@ -1100,9 +1108,7 @@ def create_server(client: JobOsMcpClient, *, artifact_root: Path | None = None) 
 
 def main() -> None:
     base_url = os.environ.get("JOBOS_API_BASE_URL", "http://127.0.0.1:8766")
-    device_token = os.environ.get("JOBOS_DEVICE_TOKEN", "")
-    if not device_token:
-        raise RuntimeError("JOBOS_DEVICE_TOKEN is required")
+    device_token = local_device_token()
     mcp_token = local_mcp_token()
     client = JobOsMcpClient(
         base_url=base_url,

--- a/services/mcp/jobos_mcp/server.py
+++ b/services/mcp/jobos_mcp/server.py
@@ -25,17 +25,25 @@ def _local_keychain_token(environment_name: str, service: str) -> str:
         return configured
     if sys.platform == "darwin":
         account = os.environ.get("JOBOS_DEVICE_ID", "primary-device")
-        for arguments in (
-            ["-s", service, "-a", account],
-            ["-s", service],
-        ):
+        try:
             result = subprocess.run(
-                ["security", "find-generic-password", "-w", *arguments],
+                [
+                    "security",
+                    "find-generic-password",
+                    "-w",
+                    "-s",
+                    service,
+                    "-a",
+                    account,
+                ],
                 check=False,
                 capture_output=True,
                 text=True,
                 timeout=5,
             )
+        except (OSError, subprocess.SubprocessError):
+            result = None
+        if result is not None:
             token = result.stdout.strip()
             if result.returncode == 0 and token:
                 return token

--- a/services/mcp/tests/test_jobs_tools.py
+++ b/services/mcp/tests/test_jobs_tools.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import re
+import subprocess
 from pathlib import Path
 
 import httpx
@@ -18,6 +19,26 @@ from jobos_mcp.server import (
     create_server,
 )
 from mcp.server.fastmcp.exceptions import ToolError  # type: ignore[import-not-found]
+
+
+def test_local_mcp_credentials_load_from_device_scoped_keychain(monkeypatch):
+    calls = []
+
+    def find_password(arguments, **kwargs):
+        calls.append((arguments, kwargs))
+        service = arguments[arguments.index("-s") + 1]
+        value = "(FAKE)-device-token" if service.endswith("device-token") else "(FAKE)-mcp-token"
+        return subprocess.CompletedProcess(arguments, 0, stdout=value, stderr="")
+
+    monkeypatch.delenv("JOBOS_DEVICE_TOKEN", raising=False)
+    monkeypatch.delenv("JOBOS_MCP_TOKEN", raising=False)
+    monkeypatch.setenv("JOBOS_DEVICE_ID", "(FAKE)-device")
+    monkeypatch.setattr(server_module.sys, "platform", "darwin")
+    monkeypatch.setattr(server_module.subprocess, "run", find_password)
+
+    assert server_module.local_device_token() == "(FAKE)-device-token"
+    assert server_module.local_mcp_token() == "(FAKE)-mcp-token"
+    assert all("(FAKE)-device" in arguments for arguments, _kwargs in calls)
 
 
 @pytest.mark.parametrize("value", ["../job", "job/other", "job\\other", "job\nother", ""])

--- a/services/mcp/tests/test_jobs_tools.py
+++ b/services/mcp/tests/test_jobs_tools.py
@@ -41,6 +41,21 @@ def test_local_mcp_credentials_load_from_device_scoped_keychain(monkeypatch):
     assert all("(FAKE)-device" in arguments for arguments, _kwargs in calls)
 
 
+@pytest.mark.parametrize("error", [FileNotFoundError(), subprocess.TimeoutExpired("security", 5)])
+def test_local_mcp_credentials_use_stable_error_when_keychain_is_unavailable(monkeypatch, error):
+    monkeypatch.delenv("JOBOS_MCP_TOKEN", raising=False)
+    monkeypatch.setenv("JOBOS_DEVICE_ID", "(FAKE)-device")
+    monkeypatch.setattr(server_module.sys, "platform", "darwin")
+
+    def fail_lookup(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(server_module.subprocess, "run", fail_lookup)
+
+    with pytest.raises(RuntimeError, match="JOBOS_MCP_TOKEN is required"):
+        server_module.local_mcp_token()
+
+
 @pytest.mark.parametrize("value", ["../job", "job/other", "job\\other", "job\nother", ""])
 def test_mcp_path_segments_reject_traversal_and_control_characters(value):
     with pytest.raises(ValueError, match="Invalid job ID"):


### PR DESCRIPTION
## What changed

Ships Connected Agents Phase 5 without expanding into the Phase 6 UI or Phase 7 hardening work:

- adds the Codex thread/turn adapter with opaque one-chat/one-thread mapping;
- translates Codex text, activity, retry, terminal, cancellation, recovery, and disconnect events into the provider-neutral JobOS stream;
- requires the live canonical JobOS MCP server, tool schemas, and capability-map resource before every turn;
- sends the same trusted JobOS context envelope, sealed model/effort, global permissions, and review policy used by Hermes;
- preserves exact profile/conversation/turn/agent/provider attribution for reviewed document publication and deduplicates mutation replay;
- resumes exact threads during restart recovery and fails closed on ambiguous active turns;
- keeps JobOS bearer credentials out of the Codex process environment; the MCP runtime reads device-scoped credentials from macOS Keychain;
- buffers token-like stream tails so credentials split across provider deltas cannot reconstruct in transcripts.

## Acceptance mapping

- **CAP-01 / CAP-02:** live MCP status, schemas, capability map, trusted instructions/context, and fail-closed no-tools tests.
- **CAP-03 / CAP-05:** trusted per-turn profile/job/Career Profile context plus existing permission/review boundaries.
- **CAP-04 / RTR-02 / RTR-03:** Hermes/Codex parameterized integration proves exactly one reviewed document mutation with exact profile, conversation, turn, agent, and provider readback.
- **RTR-01:** exact opaque thread lifecycle and wrong-thread isolation.
- **EVT-01–EVT-03:** normalized/lossless event tests, retry semantics, terminal integrity, cancellation, runtime-disconnect quarantine, and exact-thread restart recovery.
- **SEC-01:** synthetic fixtures, secret-pattern scan, Keychain lookup, restricted process environment, and split-delta credential regression.

## Verification

- `pnpm install --frozen-lockfile` — passed
- `uv sync --all-packages --frozen` — passed
- focused Phase 5 suite — **61 passed**; post-review regression suite — **62 passed**
- `pnpm check` — passed
  - desktop: **554 passed**
  - Python: **993 passed, 4 skipped**
  - public/privacy, licenses, lint, typecheck, production build, and packaged-renderer verification passed
- `pnpm contracts:check` — passed
- `pnpm public:smoke-clean-clone` — passed against commit `a910cf85b4874824301de2d14c5b7b3592ccbf65`
- bounded Codex and CodeRabbit reviews completed; concrete runtime, recovery, redaction, workspace, readiness, Keychain scoping, and MCP attribution findings were fixed and covered by regressions

## Scope / risk

- No renderer UX from Phase 6.
- No production deployment or installed-profile migration.
- No real credentials, device codes, or user data in source or evidence.
- Installed-app and MacBook golden-path acceptance remain owned by Phase 8.

Fixes #116
