### PR TITLE
Phase 6: ship Connected Agents desktop UX

### DIFF
--- a/apps/desktop/src/main/agent.test.ts
+++ b/apps/desktop/src/main/agent.test.ts
@@ -15,6 +15,14 @@ const envelope = (conversationId: string, eventId: number, overrides: Record<str
 const apiSnapshot = (conversationId: string, position: number) => ({
   conversation_id: conversationId, position, title: `Session ${position}`, created_at: '2026-08-16T09:00:00Z',
   entries: [], active_turn: null, connection: { state: 'online' }, recovery_state: 'ready', latest_event_id: 0,
+  binding: {
+    connected_agent_id: `jagent_${'a'.repeat(32)}`,
+    provider: 'hermes',
+    model_id: '(FAKE)-model-stable',
+    reasoning_effort: 'medium',
+    binding_state: 'sealed'
+  },
+  availability: { state: 'ready', reason: null },
   job_context: {
     selected_job_id: null,
     active_artifact_id: null,

--- a/apps/desktop/src/main/agent.ts
+++ b/apps/desktop/src/main/agent.ts
@@ -12,6 +12,8 @@ import {
 import type { ConversationResponse, ConversationSummary, TurnMutationResponse } from '@jobos/contracts'
 
 import type {
+  AgentChatSelection,
+  AgentConversationBinding,
   AgentConversationSnapshot,
   AgentConnectionState,
   AgentRecoveryState,
@@ -146,6 +148,30 @@ function normalizeJobContext(value: unknown): AgentSessionJobContext {
   }
 }
 
+function normalizeBinding(value: unknown): AgentConversationBinding | null {
+  if (value === null || value === undefined) return null
+  if (!isRecord(value)
+    || typeof value.connected_agent_id !== 'string'
+    || !['hermes', 'codex'].includes(String(value.provider))
+    || typeof value.model_id !== 'string'
+    || typeof value.reasoning_effort !== 'string') throw new Error('Conversation binding unavailable')
+  return {
+    connectedAgentId: value.connected_agent_id,
+    provider: value.provider as AgentConversationBinding['provider'],
+    modelId: value.model_id,
+    reasoningEffort: value.reasoning_effort
+  }
+}
+
+function normalizeAvailability(value: unknown): { state: 'ready' | 'locked'; reason: string | null } {
+  if (value === undefined) return { state: 'locked', reason: 'LEGACY_BINDING_UNAVAILABLE' }
+  if (!isRecord(value) || !['ready', 'locked'].includes(String(value.state))
+    || (value.reason !== null && value.reason !== undefined && typeof value.reason !== 'string')) {
+    throw new Error('Conversation availability unavailable')
+  }
+  return { state: value.state as 'ready' | 'locked', reason: typeof value.reason === 'string' ? value.reason : null }
+}
+
 function normalizeSummary(value: ConversationSummary): AgentSessionSummary {
   if (!isRecord(value) || !validConversationId(value.conversation_id)
     || !Number.isInteger(value.position) || Number(value.position) < 1 || Number(value.position) > 5
@@ -163,7 +189,9 @@ function normalizeSummary(value: ConversationSummary): AgentSessionSummary {
     connection: value.connection.state,
     recoveryState: normalizeRecoveryState(value.recovery_state),
     latestEventId: value.latest_event_id,
-    jobContext: normalizeJobContext(value.job_context)
+    jobContext: normalizeJobContext(value.job_context),
+    binding: normalizeBinding((value as unknown as Record<string, unknown>).binding),
+    availability: normalizeAvailability((value as unknown as Record<string, unknown>).availability)
   }
 }
 
@@ -186,7 +214,9 @@ function normalizeSnapshot(value: ConversationResponse): AgentConversationSnapsh
     connection: value.connection.state,
     recoveryState: normalizeRecoveryState(value.recovery_state),
     latestEventId: value.latest_event_id,
-    jobContext: normalizeJobContext(value.job_context)
+    jobContext: normalizeJobContext(value.job_context),
+    binding: normalizeBinding((value as unknown as Record<string, unknown>).binding),
+    availability: normalizeAvailability((value as unknown as Record<string, unknown>).availability)
   }
 }
 
@@ -280,12 +310,21 @@ export function createScopedMainAgentClient(config: AgentConfig, registry?: Agen
       if (!registry) return request()
       return registry.runExclusive(request, summaries => registry.replace(summaries.map(summary => summary.conversationId)))
     },
-    async create(initialSelectedJobId?: string | null): Promise<AgentConversationSnapshot> {
+    async create(selection?: AgentChatSelection): Promise<AgentConversationSnapshot> {
       const request = async () => {
         const result = await conversationCreateV1ConversationsPost({
-          client, body: { selected_job_id: initialSelectedJobId ?? null }
+          client,
+          body: selection ? {
+            connected_agent_id: selection.connectedAgentId,
+            model_id: selection.modelId,
+            reasoning_effort: selection.reasoningEffort,
+            expected_profile_revision: selection.expectedProfileRevision,
+            expected_agent_registry_revision: selection.expectedAgentRegistryRevision,
+            idempotency_key: selection.idempotencyKey,
+            selected_job_id: selection.initialSelectedJobId ?? null
+          } : null
         })
-        return normalizeSnapshot(unwrap(result, [201], 'New session could not be started'))
+        return normalizeSnapshot(unwrap(result, [200, 201], 'New session could not be started'))
       }
       if (!registry) return request()
       return registry.runExclusive(request, snapshot => registry.add(snapshot.conversationId))

--- a/apps/desktop/src/main/agentIpc.ts
+++ b/apps/desktop/src/main/agentIpc.ts
@@ -1,6 +1,7 @@
 import type { IpcMain, IpcMainInvokeEvent } from 'electron'
 
 import type { createMainAgentClient } from './agent.js'
+import { validateAgentChatSelection } from './connectedAgentsIpc.js'
 
 type AgentClient = ReturnType<typeof createMainAgentClient>
 
@@ -27,13 +28,9 @@ export function registerAgentIpc(
   trusted: (event: IpcMainInvokeEvent) => AgentClient
 ): void {
   ipc.handle('jobos:agent:list', event => trusted(event).list())
-  ipc.handle('jobos:agent:create', (event, selectedJobId: unknown) => {
-    if (selectedJobId !== undefined && selectedJobId !== null
-      && (typeof selectedJobId !== 'string' || !selectedJobId || selectedJobId.length > 512)) {
-      throw new Error('Invalid initial job')
-    }
-    return trusted(event).create(selectedJobId as string | null | undefined)
-  })
+  ipc.handle('jobos:agent:create', (event, selection: unknown) => (
+    trusted(event).create(selection === undefined ? undefined : validateAgentChatSelection(selection))
+  ))
   ipc.handle('jobos:agent:get', (event, conversation: unknown) => trusted(event).get(conversationId(conversation)))
   ipc.handle('jobos:agent:archive', (event, conversation: unknown) => trusted(event).archive(conversationId(conversation)))
   ipc.handle('jobos:agent:send', (event, conversation: unknown, text: unknown, key: unknown) => {

--- a/apps/desktop/src/main/connectedAgents.test.ts
+++ b/apps/desktop/src/main/connectedAgents.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+
+import { expect, test, vi } from 'vitest'
+
+import { createMainConnectedAgentsClient } from './connectedAgents.js'
+
+const agentId = `jagent_${'e'.repeat(32)}`
+const rawAgent = {
+  id: agentId,
+  provider: 'codex',
+  display_name: 'Codex',
+  avatar_id: 'spark',
+  default_model_id: 'gpt-live',
+  default_reasoning_effort: 'medium',
+  lifecycle: 'connected',
+  account_summary: { label: '(FAKE) account' },
+  account_fingerprint: 'f'.repeat(64),
+  health: { state: 'ready', label: 'Ready', provider_available: true, tools_available: true, retry_after_seconds: null },
+  impact: { active_chats: 1, locked_chats: 0 }
+}
+
+test('normalizes the profile roster and uses only runtime-provided models', async () => {
+  const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    const url = new URL(request.url)
+    expect(request.headers.get('authorization')).toBe('Bearer test-device-token')
+    if (url.pathname.endsWith('/models')) {
+      return Response.json({ live: true, models: [{ model_id: 'gpt-live', display_name: 'GPT Live', reasoning_efforts: ['medium'] }] })
+    }
+    return Response.json({ registry_revision: 8, profile_id: 'default', default_connected_agent_id: agentId, agents: [rawAgent] })
+  })
+  const client = createMainConnectedAgentsClient({ baseUrl: 'http://jobos.test', deviceToken: 'test-device-token', fetch: fetcher })
+
+  expect(await client.list()).toEqual({
+    registryRevision: 8,
+    profileId: 'default',
+    defaultConnectedAgentId: agentId,
+    agents: [expect.objectContaining({ id: agentId, provider: 'codex', displayName: 'Codex', activeChats: 1 })]
+  })
+  expect(await client.models(agentId)).toEqual({
+    live: true,
+    models: [{ modelId: 'gpt-live', displayName: 'GPT Live', reasoningEfforts: ['medium'] }]
+  })
+  expect(JSON.stringify(await client.list())).not.toContain('test-device-token')
+})
+
+test('accepts the safe auth transaction returned when cancellation succeeds', async () => {
+  const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    expect(request.method).toBe('DELETE')
+    return Response.json({
+      transaction_id: `jauth_${'a'.repeat(32)}`,
+      agent_id: agentId,
+      method: 'device_code',
+      status: 'cancelled',
+      verification_url: null,
+      user_code: null,
+      expires_at: '2026-08-25T02:00:00Z',
+      error_code: null
+    })
+  })
+  const client = createMainConnectedAgentsClient({ baseUrl: 'http://jobos.test', deviceToken: 'test-device-token', fetch: fetcher })
+
+  await expect(client.cancelAuth(`jauth_${'a'.repeat(32)}`)).resolves.toBeUndefined()
+})
+
+test('starts replacement auth from the actual 200 response with continuity fingerprint', async () => {
+  const fingerprint = 'f'.repeat(64)
+  const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    expect(request.method).toBe('POST')
+    expect(await request.json()).toEqual({ mode: 'replace', expected_account_fingerprint: fingerprint })
+    return Response.json({
+      transaction_id: `jauth_${'b'.repeat(32)}`,
+      agent_id: agentId,
+      method: 'device_code',
+      status: 'login_pending',
+      verification_url: 'https://example.test/device',
+      user_code: '(FAKE)-CODE',
+      expires_at: '2026-08-25T02:00:00Z',
+      error_code: null
+    }, { status: 200 })
+  })
+  const client = createMainConnectedAgentsClient({ baseUrl: 'http://jobos.test', deviceToken: 'test-device-token', fetch: fetcher })
+
+  await expect(client.startAuth(agentId, 'replace', fingerprint)).resolves.toEqual(
+    expect.objectContaining({ status: 'login_pending' })
+  )
+})

--- a/apps/desktop/src/main/connectedAgents.ts
+++ b/apps/desktop/src/main/connectedAgents.ts
@@ -1,0 +1,176 @@
+import {
+  connectedAgentAuthCancelV1ConnectedAgentAuthTransactionIdDelete,
+  connectedAgentAuthReadV1ConnectedAgentAuthTransactionIdGet,
+  connectedAgentAuthStartV1ConnectedAgentsAgentIdAuthDeviceCodePost,
+  connectedAgentCreateV1ConnectedAgentsPost,
+  connectedAgentDisconnectImpactV1ConnectedAgentsAgentIdDisconnectImpactGet,
+  connectedAgentDisconnectV1ConnectedAgentsAgentIdDisconnectPost,
+  connectedAgentModelsV1ConnectedAgentsAgentIdModelsGet,
+  connectedAgentsListV1ConnectedAgentsGet,
+  connectedAgentTestV1ConnectedAgentsAgentIdTestPost,
+  connectedAgentUpdateV1ConnectedAgentsAgentIdPatch,
+  createJobOsApiClient,
+  installationProfileDefaultAgentV1InstallationProfilesProfileIdDefaultAgentPut
+} from '@jobos/contracts'
+
+import type {
+  ConnectedAgentModelsSnapshot,
+  ConnectedAgentsSnapshot,
+  ConnectedAgentSummary
+} from '../shared/contracts.js'
+
+interface ConnectedAgentsConfig {
+  baseUrl: string
+  deviceToken: string
+  installationProfileId?: string
+  fetch?: typeof fetch
+}
+
+interface ApiResult<T> {
+  data?: T
+  error?: unknown
+  response?: Response
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (!isRecord(error)) return fallback
+  if (typeof error.detail === 'string') return error.detail.slice(0, 500)
+  if (isRecord(error.detail) && typeof error.detail.message === 'string') return error.detail.message.slice(0, 500)
+  return fallback
+}
+
+function unwrap<T>(result: ApiResult<T>, statuses: number[], fallback: string): T {
+  if (result.response && statuses.includes(result.response.status) && result.data !== undefined) return result.data
+  throw new Error(errorMessage(result.error, fallback))
+}
+
+function impact(value: unknown): { activeChats: number; lockedChats: number; defaultProfileIds: string[] } {
+  if (!isRecord(value)) return { activeChats: 0, lockedChats: 0, defaultProfileIds: [] }
+  return {
+    activeChats: Number.isInteger(value.active_chats) ? Number(value.active_chats) : 0,
+    lockedChats: Number.isInteger(value.locked_chats) ? Number(value.locked_chats) : 0,
+    defaultProfileIds: Array.isArray(value.default_profile_ids)
+      ? value.default_profile_ids.filter((item): item is string => typeof item === 'string')
+      : []
+  }
+}
+
+function agent(value: unknown): ConnectedAgentSummary {
+  if (!isRecord(value) || typeof value.id !== 'string' || !['hermes', 'codex'].includes(String(value.provider))
+    || typeof value.display_name !== 'string' || typeof value.avatar_id !== 'string'
+    || !['connected', 'disconnected'].includes(String(value.lifecycle)) || !isRecord(value.health)) {
+    throw new Error('Connected Agent response unavailable')
+  }
+  const totals = impact(value.impact)
+  return {
+    id: value.id,
+    provider: value.provider as ConnectedAgentSummary['provider'],
+    displayName: value.display_name,
+    avatarId: value.avatar_id,
+    defaultModelId: typeof value.default_model_id === 'string' ? value.default_model_id : null,
+    defaultReasoningEffort: typeof value.default_reasoning_effort === 'string' ? value.default_reasoning_effort : null,
+    lifecycle: value.lifecycle as ConnectedAgentSummary['lifecycle'],
+    accountSummary: isRecord(value.account_summary)
+      ? Object.fromEntries(Object.entries(value.account_summary).filter((entry): entry is [string, string] => typeof entry[1] === 'string'))
+      : null,
+    accountFingerprint: typeof value.account_fingerprint === 'string' ? value.account_fingerprint : null,
+    health: {
+      state: typeof value.health.state === 'string' ? value.health.state : 'unavailable',
+      label: typeof value.health.label === 'string' ? value.health.label : 'Unavailable',
+      providerAvailable: value.health.provider_available === true,
+      toolsAvailable: value.health.tools_available === true,
+      retryAfterSeconds: typeof value.health.retry_after_seconds === 'number' ? value.health.retry_after_seconds : null
+    },
+    activeChats: totals.activeChats,
+    lockedChats: totals.lockedChats
+  }
+}
+
+function auth(value: unknown) {
+  if (!isRecord(value) || typeof value.transaction_id !== 'string' || typeof value.status !== 'string'
+    || typeof value.expires_at !== 'string') throw new Error('Authentication status unavailable')
+  return {
+    transactionId: value.transaction_id,
+    status: value.status,
+    userCode: typeof value.user_code === 'string' ? value.user_code : null,
+    verificationUrl: typeof value.verification_url === 'string' ? value.verification_url : null,
+    expiresAt: value.expires_at,
+    errorCode: typeof value.error_code === 'string' ? value.error_code : null
+  }
+}
+
+export function createMainConnectedAgentsClient(config: ConnectedAgentsConfig) {
+  const client = createJobOsApiClient(config.baseUrl, config.deviceToken, config.installationProfileId)
+  if (config.fetch) client.setConfig({ fetch: config.fetch })
+  return {
+    async list(): Promise<ConnectedAgentsSnapshot> {
+      const value = unwrap(await connectedAgentsListV1ConnectedAgentsGet({ client }), [200], 'Connected Agents unavailable')
+      const raw = value as unknown as Record<string, unknown>
+      if (!Number.isInteger(raw.registry_revision) || typeof raw.profile_id !== 'string' || !Array.isArray(raw.agents)) {
+        throw new Error('Connected Agents response unavailable')
+      }
+      return {
+        registryRevision: Number(raw.registry_revision),
+        profileId: raw.profile_id,
+        defaultConnectedAgentId: typeof raw.default_connected_agent_id === 'string' ? raw.default_connected_agent_id : null,
+        agents: raw.agents.map(agent)
+      }
+    },
+    async models(agentId: string): Promise<ConnectedAgentModelsSnapshot> {
+      const value = unwrap(await connectedAgentModelsV1ConnectedAgentsAgentIdModelsGet({ client, path: { agent_id: agentId } }), [200], 'Models unavailable')
+      return {
+        live: value.live,
+        models: value.models.map(model => ({ modelId: model.model_id, displayName: model.display_name, reasoningEfforts: model.reasoning_efforts }))
+      }
+    },
+    async test(agentId: string) {
+      return agent(unwrap(await connectedAgentTestV1ConnectedAgentsAgentIdTestPost({ client, path: { agent_id: agentId } }), [200], 'Connection test failed'))
+    },
+    async createCodex(displayName: string, avatarId: string, expectedRegistryRevision: number, idempotencyKey: string) {
+      return agent(unwrap(await connectedAgentCreateV1ConnectedAgentsPost({
+        client,
+        body: { provider: 'codex', display_name: displayName, avatar_id: avatarId, expected_registry_revision: expectedRegistryRevision, idempotency_key: idempotencyKey }
+      }), [201], 'Codex connection could not be created'))
+    },
+    async update(current: ConnectedAgentSummary, modelId: string | null, reasoningEffort: string | null, expectedRegistryRevision: number, idempotencyKey: string) {
+      return agent(unwrap(await connectedAgentUpdateV1ConnectedAgentsAgentIdPatch({
+        client,
+        path: { agent_id: current.id },
+        body: { display_name: current.displayName, avatar_id: current.avatarId, default_model_id: modelId, default_reasoning_effort: reasoningEffort, expected_registry_revision: expectedRegistryRevision, idempotency_key: idempotencyKey }
+      }), [200], 'Connected Agent could not be updated'))
+    },
+    async setDefault(profileId: string, agentId: string | null, expectedRevision: number, idempotencyKey: string) {
+      const value = unwrap(await installationProfileDefaultAgentV1InstallationProfilesProfileIdDefaultAgentPut({
+        client,
+        path: { profile_id: profileId },
+        body: { connected_agent_id: agentId, expected_profile_revision: expectedRevision, expected_agent_registry_revision: expectedRevision, idempotency_key: idempotencyKey }
+      }), [200], 'Profile default could not be updated')
+      return value.registry_revision
+    },
+    async impact(agentId: string) {
+      return impact(unwrap(await connectedAgentDisconnectImpactV1ConnectedAgentsAgentIdDisconnectImpactGet({ client, path: { agent_id: agentId } }), [200], 'Disconnect impact unavailable'))
+    },
+    async disconnect(agentId: string, expectedRegistryRevision: number, idempotencyKey: string) {
+      return agent(unwrap(await connectedAgentDisconnectV1ConnectedAgentsAgentIdDisconnectPost({
+        client,
+        path: { agent_id: agentId },
+        body: { confirmation_token: agentId, expected_registry_revision: expectedRegistryRevision, idempotency_key: idempotencyKey }
+      }), [200], 'Connected Agent could not be disconnected'))
+    },
+    async startAuth(agentId: string, mode: 'connect' | 'reconnect' | 'replace', expectedAccountFingerprint: string | null) {
+      return auth(unwrap(await connectedAgentAuthStartV1ConnectedAgentsAgentIdAuthDeviceCodePost({
+        client, path: { agent_id: agentId }, body: { mode, expected_account_fingerprint: expectedAccountFingerprint }
+      }), [200], 'Authentication could not start'))
+    },
+    async readAuth(transactionId: string) {
+      return auth(unwrap(await connectedAgentAuthReadV1ConnectedAgentAuthTransactionIdGet({ client, path: { transaction_id: transactionId } }), [200], 'Authentication status unavailable'))
+    },
+    async cancelAuth(transactionId: string) {
+      unwrap(await connectedAgentAuthCancelV1ConnectedAgentAuthTransactionIdDelete({ client, path: { transaction_id: transactionId } }), [200, 204], 'Authentication could not be cancelled')
+    }
+  }
+}

--- a/apps/desktop/src/main/connectedAgentsIpc.test.ts
+++ b/apps/desktop/src/main/connectedAgentsIpc.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+
+import type { IpcMain, IpcMainInvokeEvent } from 'electron'
+import { expect, test, vi } from 'vitest'
+
+import { registerConnectedAgentsIpc, validateAgentChatSelection } from './connectedAgentsIpc.js'
+
+const agentId = `jagent_${'c'.repeat(32)}`
+
+test('chat selection validates immutable IDs, revisions, model, effort, and idempotency', () => {
+  expect(validateAgentChatSelection({
+    connectedAgentId: agentId,
+    modelId: 'gpt-live',
+    reasoningEffort: 'medium',
+    expectedProfileRevision: 4,
+    expectedAgentRegistryRevision: 4,
+    idempotencyKey: 'desktop-new-chat-test'
+  })).toEqual(expect.objectContaining({ connectedAgentId: agentId, modelId: 'gpt-live', initialSelectedJobId: null }))
+  expect(() => validateAgentChatSelection({ connectedAgentId: '../agent' })).toThrow('Invalid Connected Agent')
+})
+
+test('Connected Agents IPC rejects malformed IDs and accepts provider auth transaction IDs', () => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>()
+  const ipc = { handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => handlers.set(channel, handler)) } as unknown as Pick<IpcMain, 'handle'>
+  const client = {
+    list: vi.fn(), models: vi.fn(), test: vi.fn(), createCodex: vi.fn(), update: vi.fn(), setDefault: vi.fn(),
+    impact: vi.fn(), disconnect: vi.fn(), startAuth: vi.fn(), readAuth: vi.fn(), cancelAuth: vi.fn()
+  }
+  registerConnectedAgentsIpc(ipc, () => client as never)
+  const event = {} as IpcMainInvokeEvent
+
+  expect(() => handlers.get('jobos:connected-agents:models')?.(event, '../agent')).toThrow('Invalid Connected Agent')
+  expect(() => handlers.get('jobos:connected-agents:auth:read')?.(event, 'auth_wrong')).toThrow('Invalid authentication transaction')
+  handlers.get('jobos:connected-agents:auth:read')?.(event, `jauth_${'d'.repeat(32)}`)
+  expect(client.readAuth).toHaveBeenCalledWith(`jauth_${'d'.repeat(32)}`)
+})

--- a/apps/desktop/src/main/connectedAgentsIpc.ts
+++ b/apps/desktop/src/main/connectedAgentsIpc.ts
@@ -1,0 +1,92 @@
+import type { IpcMain, IpcMainInvokeEvent } from 'electron'
+
+import type { AgentChatSelection, ConnectedAgentSummary } from '../shared/contracts.js'
+import type { createMainConnectedAgentsClient } from './connectedAgents.js'
+
+type Client = ReturnType<typeof createMainConnectedAgentsClient>
+const agentPattern = /^jagent_[a-f0-9]{32}$/
+const transactionPattern = /^jauth_[a-f0-9]{32}$/
+
+function connectedAgentId(value: unknown): string {
+  if (typeof value !== 'string' || !agentPattern.test(value)) throw new Error('Invalid Connected Agent')
+  return value
+}
+
+function transactionId(value: unknown): string {
+  if (typeof value !== 'string' || !transactionPattern.test(value)) throw new Error('Invalid authentication transaction')
+  return value
+}
+
+function revision(value: unknown): number {
+  if (!Number.isInteger(value) || Number(value) < 1) throw new Error('Invalid Connected Agent revision')
+  return Number(value)
+}
+
+function key(value: unknown): string {
+  if (typeof value !== 'string' || value.length < 8 || value.length > 200 || /[\r\n]/.test(value)) throw new Error('Invalid idempotency key')
+  return value
+}
+
+function text(value: unknown, maximum = 120): string {
+  if (typeof value !== 'string' || !value.trim() || value.length > maximum) throw new Error('Invalid Connected Agent value')
+  return value.trim()
+}
+
+export function validateAgentChatSelection(value: unknown): AgentChatSelection {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Agent selection is required')
+  const candidate = value as Record<string, unknown>
+  return {
+    connectedAgentId: connectedAgentId(candidate.connectedAgentId),
+    modelId: text(candidate.modelId, 256),
+    reasoningEffort: text(candidate.reasoningEffort, 64),
+    expectedProfileRevision: revision(candidate.expectedProfileRevision),
+    expectedAgentRegistryRevision: revision(candidate.expectedAgentRegistryRevision),
+    idempotencyKey: key(candidate.idempotencyKey),
+    initialSelectedJobId: candidate.initialSelectedJobId === null || candidate.initialSelectedJobId === undefined
+      ? null
+      : text(candidate.initialSelectedJobId, 512)
+  }
+}
+
+export function registerConnectedAgentsIpc(
+  ipc: Pick<IpcMain, 'handle'>,
+  trusted: (event: IpcMainInvokeEvent) => Client
+): void {
+  ipc.handle('jobos:connected-agents:list', event => trusted(event).list())
+  ipc.handle('jobos:connected-agents:models', (event, id) => trusted(event).models(connectedAgentId(id)))
+  ipc.handle('jobos:connected-agents:test', (event, id) => trusted(event).test(connectedAgentId(id)))
+  ipc.handle('jobos:connected-agents:create-codex', (event, displayName, avatarId, expected, idempotencyKey) => (
+    trusted(event).createCodex(text(displayName), text(avatarId, 64), revision(expected), key(idempotencyKey))
+  ))
+  ipc.handle('jobos:connected-agents:update', (event, current, modelId, effort, expected, idempotencyKey) => {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) throw new Error('Invalid Connected Agent')
+    const candidate = current as ConnectedAgentSummary
+    const safeCurrent: ConnectedAgentSummary = {
+      ...candidate,
+      id: connectedAgentId(candidate.id),
+      displayName: text(candidate.displayName),
+      avatarId: text(candidate.avatarId, 64)
+    }
+    return trusted(event).update(
+      safeCurrent,
+      modelId === null ? null : text(modelId, 256),
+      effort === null ? null : text(effort, 64),
+      revision(expected),
+      key(idempotencyKey)
+    )
+  })
+  ipc.handle('jobos:connected-agents:set-default', (event, profileId, agentId, expected, idempotencyKey) => (
+    trusted(event).setDefault(text(profileId, 64), agentId === null ? null : connectedAgentId(agentId), revision(expected), key(idempotencyKey))
+  ))
+  ipc.handle('jobos:connected-agents:impact', (event, id) => trusted(event).impact(connectedAgentId(id)))
+  ipc.handle('jobos:connected-agents:disconnect', (event, id, expected, idempotencyKey) => (
+    trusted(event).disconnect(connectedAgentId(id), revision(expected), key(idempotencyKey))
+  ))
+  ipc.handle('jobos:connected-agents:auth:start', (event, id, mode, fingerprint) => {
+    if (!['connect', 'reconnect', 'replace'].includes(String(mode))) throw new Error('Invalid authentication mode')
+    if (fingerprint !== null && !/^[a-f0-9]{64}$/.test(String(fingerprint))) throw new Error('Invalid account fingerprint')
+    return trusted(event).startAuth(connectedAgentId(id), mode as 'connect' | 'reconnect' | 'replace', fingerprint as string | null)
+  })
+  ipc.handle('jobos:connected-agents:auth:read', (event, id) => trusted(event).readAuth(transactionId(id)))
+  ipc.handle('jobos:connected-agents:auth:cancel', (event, id) => trusted(event).cancelAuth(transactionId(id)))
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -16,6 +16,8 @@ import type {
 } from '../shared/contracts.js'
 import { AgentConversationRegistry, createScopedMainAgentClient, startAgentEventStream } from './agent.js'
 import { registerAgentIpc } from './agentIpc.js'
+import { createMainConnectedAgentsClient } from './connectedAgents.js'
+import { registerConnectedAgentsIpc } from './connectedAgentsIpc.js'
 import { createApiLifecycle } from './apiLifecycle.js'
 import { BrowserManager, remoteBrowserViewOptions } from './browser.js'
 import { canonicalListingUrl, safeApplicationUrl, validatedBrowserJobExtraction } from './browserJobExtraction.js'
@@ -583,10 +585,16 @@ function registerCareerProfileInterface(): void {
 function registerAgentInterface(): void {
   const config = jobsConfig()
   const agent = config ? createScopedMainAgentClient(config, activeAgentConversationIds) : null
+  const connectedAgents = config ? createMainConnectedAgentsClient(config) : null
   registerAgentIpc(ipcMain, event => {
     assertTrustedRenderer(event)
     if (!agent) throw new Error('Device credential unavailable')
     return agent
+  })
+  registerConnectedAgentsIpc(ipcMain, event => {
+    assertTrustedRenderer(event)
+    if (!connectedAgents) throw new Error('Device credential unavailable')
+    return connectedAgents
   })
 }
 

--- a/apps/desktop/src/preload/preload.cts
+++ b/apps/desktop/src/preload/preload.cts
@@ -4,7 +4,9 @@ import type { IpcRendererEvent } from 'electron'
 import type { DocxExternalChangeEvent, SaveDocxRequest } from '../shared/docxDocuments.js'
 
 import type {
+  AgentChatSelection,
   AgentSessionStreamUpdate,
+  ConnectedAgentSummary,
   BrowserBounds,
   BrowserJobExtraction,
   BrowserRestoreState,
@@ -166,7 +168,7 @@ const bridge: JobOsRendererBridge = Object.freeze({
   }),
   agent: Object.freeze({
     list: () => ipcRenderer.invoke('jobos:agent:list'),
-    create: (initialSelectedJobId?: string | null) => ipcRenderer.invoke('jobos:agent:create', initialSelectedJobId),
+    create: (selection?: AgentChatSelection) => ipcRenderer.invoke('jobos:agent:create', selection),
     get: (conversationId: string) => ipcRenderer.invoke('jobos:agent:get', conversationId),
     archive: (conversationId: string) => ipcRenderer.invoke('jobos:agent:archive', conversationId),
     send: (conversationId: string, text: string, idempotencyKey: string) => ipcRenderer.invoke('jobos:agent:send', conversationId, text, idempotencyKey),
@@ -177,6 +179,19 @@ const bridge: JobOsRendererBridge = Object.freeze({
       ipcRenderer.on('jobos:agent:event', wrapped)
       return () => ipcRenderer.removeListener('jobos:agent:event', wrapped)
     }
+  }),
+  connectedAgents: Object.freeze({
+    list: () => ipcRenderer.invoke('jobos:connected-agents:list'),
+    models: (agentId: string) => ipcRenderer.invoke('jobos:connected-agents:models', agentId),
+    test: (agentId: string) => ipcRenderer.invoke('jobos:connected-agents:test', agentId),
+    createCodex: (displayName: string, avatarId: string, expectedRevision: number, idempotencyKey: string) => ipcRenderer.invoke('jobos:connected-agents:create-codex', displayName, avatarId, expectedRevision, idempotencyKey),
+    update: (agent: ConnectedAgentSummary, modelId: string | null, reasoningEffort: string | null, expectedRevision: number, idempotencyKey: string) => ipcRenderer.invoke('jobos:connected-agents:update', agent, modelId, reasoningEffort, expectedRevision, idempotencyKey),
+    setDefault: (profileId: string, agentId: string | null, expectedRevision: number, idempotencyKey: string) => ipcRenderer.invoke('jobos:connected-agents:set-default', profileId, agentId, expectedRevision, idempotencyKey),
+    impact: (agentId: string) => ipcRenderer.invoke('jobos:connected-agents:impact', agentId),
+    disconnect: (agentId: string, expectedRevision: number, idempotencyKey: string) => ipcRenderer.invoke('jobos:connected-agents:disconnect', agentId, expectedRevision, idempotencyKey),
+    startAuth: (agentId: string, mode: 'connect' | 'reconnect' | 'replace', expectedAccountFingerprint: string | null) => ipcRenderer.invoke('jobos:connected-agents:auth:start', agentId, mode, expectedAccountFingerprint),
+    readAuth: (transactionId: string) => ipcRenderer.invoke('jobos:connected-agents:auth:read', transactionId),
+    cancelAuth: (transactionId: string) => ipcRenderer.invoke('jobos:connected-agents:auth:cancel', transactionId)
   }),
   jobs: Object.freeze({
     getState: () => ipcRenderer.invoke('jobos:jobs:get-state'),

--- a/apps/desktop/src/renderer/App.test.tsx
+++ b/apps/desktop/src/renderer/App.test.tsx
@@ -1,8 +1,13 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, expect, test, vi } from 'vitest'
 
-import type { AgentSessionStreamUpdate, JobListItem } from '../shared/contracts'
-import { App } from './App'
+import type {
+  AgentSessionStreamUpdate,
+  ConnectedAgentSummary,
+  ConnectedAgentsSnapshot,
+  JobListItem
+} from '../shared/contracts'
+import { App, requireDefaultAgentModel, requireDefaultConnectedAgent } from './App'
 import { isExpectedSaveNavigation, parseAgentJobSaveError } from './components/CenterWorkspace'
 
 afterEach(() => { cleanup(); window.localStorage.clear() })
@@ -13,6 +18,58 @@ const emptyJobContext = {
   activeArtifactPage: 1,
   activeArtifactZoom: 1
 }
+
+const readyDefaultAgent: ConnectedAgentSummary = {
+  id: 'agent-codex',
+  provider: 'codex',
+  displayName: 'Codex',
+  avatarId: 'codex',
+  defaultModelId: 'gpt-live',
+  defaultReasoningEffort: 'medium',
+  lifecycle: 'connected',
+  accountSummary: null,
+  accountFingerprint: null,
+  health: {
+    state: 'ready',
+    label: 'Ready',
+    providerAvailable: true,
+    toolsAvailable: true,
+    retryAfterSeconds: null
+  },
+  activeChats: 0,
+  lockedChats: 0
+}
+
+const connectedAgentsSnapshot: ConnectedAgentsSnapshot = {
+  registryRevision: 2,
+  profileId: 'profile-1',
+  defaultConnectedAgentId: readyDefaultAgent.id,
+  agents: [readyDefaultAgent]
+}
+
+test('browser save requires the exact configured default agent without silent fallback', () => {
+  expect(requireDefaultConnectedAgent(connectedAgentsSnapshot)).toBe(readyDefaultAgent)
+  expect(() => requireDefaultConnectedAgent({
+    ...connectedAgentsSnapshot,
+    defaultConnectedAgentId: 'missing-agent',
+    agents: [readyDefaultAgent, { ...readyDefaultAgent, id: 'other-ready-agent' }]
+  })).toThrow('Default Connected Agent is unavailable')
+})
+
+test('browser save requires the exact live default model and reasoning effort', () => {
+  expect(requireDefaultAgentModel(readyDefaultAgent, {
+    live: true,
+    models: [{ modelId: 'gpt-live', displayName: 'GPT Live', reasoningEfforts: ['low', 'medium'] }]
+  })).toEqual({ modelId: 'gpt-live', reasoningEffort: 'medium' })
+  expect(() => requireDefaultAgentModel(readyDefaultAgent, {
+    live: true,
+    models: [{ modelId: 'different-model', displayName: 'Different', reasoningEfforts: ['medium'] }]
+  })).toThrow('Default model is unavailable')
+  expect(() => requireDefaultAgentModel({ ...readyDefaultAgent, defaultReasoningEffort: 'high' }, {
+    live: true,
+    models: [{ modelId: 'gpt-live', displayName: 'GPT Live', reasoningEfforts: ['medium'] }]
+  })).toThrow('Default reasoning effort is unavailable')
+})
 
 test('missing configuration opens setup without starting workbench services', async () => {
   const getConnectivity = vi.fn()
@@ -198,8 +255,9 @@ test('exact Command shortcuts create and select sessions from the composer witho
   const createEvent = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'n', metaKey: true })
   composer.dispatchEvent(createEvent)
   expect(createEvent.defaultPrevented).toBe(true)
-  expect(await screen.findByRole('tab', { name: 'Session 2, Idle' })).not.toBeNull()
-  expect(create).toHaveBeenCalledOnce()
+  expect(await screen.findByRole('dialog', { name: 'Pick the agent for this chat' })).not.toBeNull()
+  expect(create).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button', { name: 'Close New Chat' }))
 
   const missing = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: '5', metaKey: true })
   composer.dispatchEvent(missing)
@@ -209,7 +267,7 @@ test('exact Command shortcuts create and select sessions from the composer witho
   expect(select.defaultPrevented).toBe(true)
   expect(screen.getByRole('tab', { name: 'Session 1, Idle' }).getAttribute('aria-selected')).toBe('true')
   expect((screen.getByRole('textbox', { name: 'Message the agent' }) as HTMLTextAreaElement).value).toBe('keep this draft')
-  expect(create).toHaveBeenCalledOnce()
+  expect(create).not.toHaveBeenCalled()
 })
 
 test('Command 1 through Command 5 map to visible positions and Command N announces the five-session cap', async () => {
@@ -235,7 +293,7 @@ test('Command 1 through Command 5 map to visible positions and Command N announc
   const capped = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'n', metaKey: true })
   act(() => { composer.dispatchEvent(capped) })
   expect(capped.defaultPrevented).toBe(true)
-  expect(await screen.findByText('Maximum 5 sessions.')).not.toBeNull()
+  expect(await screen.findByText('Five chats are already open')).not.toBeNull()
   expect(create).not.toHaveBeenCalled()
 })
 
@@ -433,6 +491,7 @@ test('saving dispatches job-hunter and reconciles a failure emitted before send 
     ...emptyJobContext,
     selectedJobId: jobId
   }))
+  const connectedAgentModels = vi.fn().mockResolvedValue({ live: true, models: [{ modelId: '(FAKE)-model-stable', displayName: '(FAKE) Stable', reasoningEfforts: ['medium'] }] })
   const workspace = {
     revision: 1,
     selectedPreset: 'research' as const,
@@ -456,6 +515,20 @@ test('saving dispatches job-hunter and reconciles a failure emitted before send 
       get: getConversation,
       send, cancel, retry: vi.fn(),
       subscribe: vi.fn(listener => { agentListeners.push(listener); return () => undefined })
+    },
+    connectedAgents: {
+      list: vi.fn().mockResolvedValue({
+        registryRevision: 3,
+        profileId: 'jprof_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        defaultConnectedAgentId: 'agent_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        agents: [{
+          id: 'agent_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', provider: 'hermes', displayName: 'Devonte', avatarId: 'default',
+          defaultModelId: '(FAKE)-model-stable', defaultReasoningEffort: 'medium', lifecycle: 'connected', accountSummary: null,
+          health: { state: 'ready', label: 'Ready', providerAvailable: true, toolsAvailable: true, retryAfterSeconds: null },
+          activeChats: 0, lockedChats: 0
+        }]
+      }),
+      models: connectedAgentModels
     },
     jobs: {
       getState: vi.fn().mockImplementation(async () => ({
@@ -483,7 +556,12 @@ test('saving dispatches job-hunter and reconciles a failure emitted before send 
   fireEvent.click(screen.getByRole('button', { name: 'Save this job to JobOS' }))
 
   await waitFor(() => expect(send).toHaveBeenCalledOnce())
-  expect(createSession).toHaveBeenLastCalledWith(null)
+  expect(createSession).toHaveBeenLastCalledWith(expect.objectContaining({
+    connectedAgentId: 'agent_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    modelId: '(FAKE)-model-stable',
+    reasoningEffort: 'medium'
+  }))
+  expect(connectedAgentModels).toHaveBeenCalledWith('agent_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
   expect(send.mock.calls[0]?.[0]).toBe('conv-1')
   expect(send.mock.calls[0]?.[1]).toContain('job-tab')
   expect(send.mock.calls[0]?.[1]).toContain(listing.canonicalUrl)
@@ -614,7 +692,11 @@ test('saving dispatches job-hunter and reconciles a failure emitted before send 
   expect(saveFromBrowser).not.toHaveBeenCalled()
   expect(createBrowserTab).not.toHaveBeenCalled()
   expect(createSession).toHaveBeenCalledTimes(5)
-  expect(createSession.mock.calls.every(call => call[0] === null)).toBe(true)
+  expect(createSession.mock.calls.every(call => (
+    call[0]?.connectedAgentId === 'agent_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    && call[0]?.modelId === '(FAKE)-model-stable'
+    && call[0]?.reasoningEffort === 'medium'
+  ))).toBe(true)
   expect(selectJob).toHaveBeenCalledWith('conv-5', 'job-saved-by-turn')
   expect(await screen.findByText(`Saved to JobOS: Northstar Labs · ${listing.title}`)).not.toBeNull()
   expect(await screen.findByRole('button', {
@@ -1191,10 +1273,9 @@ test('creating an additive session leaves the active native browser surface atta
   setBounds.mockClear()
 
   fireEvent.click(screen.getByRole('button', { name: 'New agent session' }))
-  await waitFor(() => expect(createSession).toHaveBeenCalledOnce())
-  expect(setBounds).not.toHaveBeenCalledWith(expect.objectContaining({ visible: false }))
-  expect(screen.queryByRole('alertdialog')).toBeNull()
-  expect(await screen.findByRole('tab', { name: 'Session 2, Idle' })).not.toBeNull()
+  expect(await screen.findByRole('dialog', { name: 'Pick the agent for this chat' })).not.toBeNull()
+  expect(createSession).not.toHaveBeenCalled()
+  await waitFor(() => expect(setBounds).toHaveBeenCalledWith(expect.objectContaining({ visible: false })))
   resolveDetach()
   rect.mockRestore()
 })

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -13,12 +13,20 @@ import { DocxDocumentEditorShell } from './document-editor/DocxDocumentEditorShe
 import { useConnectivity } from './hooks/useConnectivity'
 import { useJobs } from './hooks/useJobs'
 import { useAgentSessions } from './hooks/useAgentSessions'
+import { useConnectedAgents } from './hooks/useConnectedAgents'
 import { useWorkspace } from './hooks/useWorkspace'
 import { useTheme } from './theme/useTheme'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { DocxOpenResult } from '../shared/docxDocuments'
-import type { SetupSnapshot } from '../shared/contracts'
+import type {
+  AgentChatSelection,
+  ConnectedAgentModelsSnapshot,
+  ConnectedAgentSummary,
+  ConnectedAgentsSnapshot,
+  SetupSnapshot
+} from '../shared/contracts'
 import { OnboardingScreen } from './onboarding/OnboardingScreen'
+import { NewAgentChatDialog } from './components/NewAgentChatDialog'
 
 export function App() {
   const [setup, setSetup] = useState<SetupSnapshot | null>(
@@ -39,9 +47,58 @@ export function App() {
   return <WorkbenchApp />
 }
 
+export function requireDefaultConnectedAgent(snapshot: ConnectedAgentsSnapshot): ConnectedAgentSummary {
+  const agent = snapshot.defaultConnectedAgentId
+    ? snapshot.agents.find(item => item.id === snapshot.defaultConnectedAgentId)
+    : undefined
+  if (
+    !agent ||
+    agent.lifecycle !== 'connected' ||
+    !agent.health.providerAvailable ||
+    !agent.health.toolsAvailable
+  ) {
+    throw new Error('Default Connected Agent is unavailable. Choose a ready default in Settings.')
+  }
+  return agent
+}
+
+export function requireDefaultAgentModel(
+  agent: ConnectedAgentSummary,
+  catalog: ConnectedAgentModelsSnapshot
+): { modelId: string; reasoningEffort: string } {
+  if (!catalog.live || !agent.defaultModelId) {
+    throw new Error('Default model is unavailable. Choose a live model in Connected Agents settings.')
+  }
+  const model = catalog.models.find(item => item.modelId === agent.defaultModelId)
+  if (!model) {
+    throw new Error('Default model is unavailable. Choose a live model in Connected Agents settings.')
+  }
+  if (!agent.defaultReasoningEffort || !model.reasoningEfforts.includes(agent.defaultReasoningEffort)) {
+    throw new Error('Default reasoning effort is unavailable. Update the agent defaults in Settings.')
+  }
+  return { modelId: model.modelId, reasoningEffort: agent.defaultReasoningEffort }
+}
+
 function WorkbenchApp() {
   const connectivity = useConnectivity()
   const agentSessions = useAgentSessions()
+  const connectedAgents = useConnectedAgents()
+  const createJoblessSession = useCallback(async () => {
+    const snapshot = connectedAgents.snapshot ?? await connectedAgents.refresh()
+    if (!snapshot) return null
+    const agent = requireDefaultConnectedAgent(snapshot)
+    const catalog = await connectedAgents.loadModels(agent.id, true)
+    const model = requireDefaultAgentModel(agent, catalog)
+    const selection: AgentChatSelection = {
+      connectedAgentId: agent.id,
+      modelId: model.modelId,
+      reasoningEffort: model.reasoningEffort,
+      expectedProfileRevision: snapshot.registryRevision,
+      expectedAgentRegistryRevision: snapshot.registryRevision,
+      idempotencyKey: `desktop-save-chat-${crypto.randomUUID()}`
+    }
+    return agentSessions.createJobless(selection)
+  }, [agentSessions.createJobless, connectedAgents])
   const activeJobContext = agentSessions.activeSession?.summary.jobContext ?? null
   const jobState = useJobs(
     agentSessions.activeId,
@@ -56,6 +113,7 @@ function WorkbenchApp() {
   const theme = useTheme()
   const agentAvatar = useAgentAvatarPreference()
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [newChatOpen, setNewChatOpen] = useState(false)
   const [settingsPreparing, setSettingsPreparing] = useState(false)
   const [careerProfileEnabled, setCareerProfileEnabled] = useState(false)
   const [careerProfileOpen, setCareerProfileOpen] = useState(false)
@@ -81,7 +139,7 @@ function WorkbenchApp() {
   const activeLayout = layoutState.workspace.layouts[activePreset]
   const browseVisible = activeTopLevelWorkspace === 'browse' && browseDetachState === 'ready'
   const browserTransitionPending = browseDetachState === 'preparing'
-  const nativeBrowserVisible = layoutState.hydrated && activeTopLevelWorkspace !== 'browse' && !careerProfileOpen && !browserTransitionPending && !activeLayout.collapsed.includes('center') && !settingsOpen && !settingsPreparing && !profileOverlayActive
+  const nativeBrowserVisible = layoutState.hydrated && activeTopLevelWorkspace !== 'browse' && !careerProfileOpen && !browserTransitionPending && !activeLayout.collapsed.includes('center') && !settingsOpen && !settingsPreparing && !newChatOpen && !profileOverlayActive
 
   useEffect(() => {
     const bridge = window.jobos?.careerProfile
@@ -149,9 +207,7 @@ function WorkbenchApp() {
       }
       if (key === 'n') {
         event.preventDefault()
-        void agentSessions.create().then(handled => {
-          if (handled) requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>('#agent-message')?.focus())
-        })
+        setNewChatOpen(true)
         return
       }
       const index = Number(event.key) - 1
@@ -162,7 +218,7 @@ function WorkbenchApp() {
     }
     window.addEventListener('keydown', handleAgentShortcut)
     return () => window.removeEventListener('keydown', handleAgentShortcut)
-  }, [agentSessions.create, agentSessions.order, agentSessions.selectByIndex, settingsOpen, settingsPreparing])
+  }, [agentSessions.order, agentSessions.selectByIndex, settingsOpen, settingsPreparing])
 
   const showPublishedDocument = useCallback(() => {
     setDocumentMutationGeneration(generation => generation + 1)
@@ -337,10 +393,12 @@ function WorkbenchApp() {
       ) : (
       <WorkbenchLayout
         agent={<AgentPanel
+          agentLabel={connectedAgents.snapshot?.agents.find(agent => agent.id === agentSessions.activeSession?.summary.binding?.connectedAgentId)?.displayName}
           avatarId={agentAvatar.avatarId}
           apiState={connectivity.state}
           contextLabel={jobState.selectedJob ? `${jobState.selectedJob.company} · ${jobState.selectedJob.title}` : 'No active job'}
           onArtifactRendered={showPublishedDocument}
+          onNewChat={() => setNewChatOpen(true)}
           sessions={agentSessions}
         />}
         center={<CenterWorkspace
@@ -356,7 +414,7 @@ function WorkbenchApp() {
           browserRepaired={Boolean(layoutState.workspace.repairedBrowser)}
           browserRepairReasons={layoutState.workspace.browserRepairReasons ?? []}
           browserVisible={nativeBrowserVisible && !panelReorderActive}
-          onCreateSaveSession={agentSessions.createJobless}
+          onCreateSaveSession={createJoblessSession}
           documentMutationGeneration={documentMutationGeneration}
           documentPreviewMode={documentPreviewMode}
           jobListingRequest={jobListingRequest}
@@ -441,10 +499,25 @@ function WorkbenchApp() {
           activeAgentAvatarId={agentAvatar.avatarId}
           activeThemeId={theme.themeId}
           careerProfileBridge={window.jobos.careerProfile}
+          connectedAgentsState={connectedAgents}
+          onConnectedAgentsChanged={agentSessions.refreshAvailability}
           mode={theme.mode}
           onClose={() => setSettingsOpen(false)}
           onSelectAgentAvatar={agentAvatar.selectAvatar}
           onSelectTheme={theme.selectTheme}
+        />
+      ) : null}
+      {newChatOpen ? (
+        <NewAgentChatDialog
+          atMaximum={agentSessions.atMaximum}
+          connectedAgents={connectedAgents}
+          onArchiveCurrent={() => {
+            if (agentSessions.activeId) void agentSessions.archive(agentSessions.activeId).then(archived => {
+              if (archived) setNewChatOpen(false)
+            })
+          }}
+          onClose={() => setNewChatOpen(false)}
+          onCreate={agentSessions.create}
         />
       ) : null}
     </div>

--- a/apps/desktop/src/renderer/components/AgentPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.test.tsx
@@ -10,6 +10,8 @@ afterEach(() => { cleanup(); window.localStorage.clear(); vi.restoreAllMocks() }
 const summary = (position: number, activeTurn: AgentSessionSummary['activeTurn'] = null): AgentSessionSummary => ({
   conversationId: `conv_${position}`, position, title: `Session ${position}`, createdAt: '2026-08-16T10:00:00Z',
   activeTurn, connection: 'online', recoveryState: 'ready', latestEventId: 0,
+  binding: { connectedAgentId: 'agent-hermes', provider: 'hermes', modelId: 'default', reasoningEffort: 'medium' },
+  availability: { state: 'ready', reason: null },
   jobContext: { selectedJobId: null, activeArtifactId: null, activeArtifactPage: 1, activeArtifactZoom: 1 }
 })
 const snapshot = (position: number, entries: ConversationEvent[] = [], activeTurn: AgentSessionSummary['activeTurn'] = null): AgentConversationSnapshot => ({
@@ -37,9 +39,9 @@ function install(summaries = [summary(1)], snapshots = summaries.map(item => sna
   return { agent, emit: (update: AgentSessionStreamUpdate) => listener(update) }
 }
 
-function Harness() {
+function Harness({ onNewChat }: { onNewChat?: () => void } = {}) {
   const sessions = useAgentSessions()
-  return <AgentPanel avatarId="ninja" apiState="connected" contextLabel="Northstar · Staff PM" sessions={sessions} />
+  return <AgentPanel avatarId="ninja" apiState="connected" contextLabel="Northstar · Staff PM" onNewChat={onNewChat} sessions={sessions} />
 }
 
 function deferred<T>() {
@@ -65,16 +67,16 @@ function installClock(isoTime: string) {
   }
 }
 
-test('renders accessible tabs and creates a fresh additive session without a reset modal', async () => {
+test('renders accessible tabs and routes additive creation through the New Chat picker', async () => {
   const { agent } = install()
-  render(<Harness />)
+  const onNewChat = vi.fn()
+  render(<Harness onNewChat={onNewChat} />)
   expect(await screen.findByRole('tab', { name: 'Session 1, Idle' })).not.toBeNull()
   expect(screen.getByRole('tablist', { name: 'Agent sessions' })).not.toBeNull()
   fireEvent.click(screen.getByRole('button', { name: 'New agent session' }))
-  expect(await screen.findByRole('tab', { name: 'Session 2, Idle' })).not.toBeNull()
-  expect(agent.create).toHaveBeenCalledOnce()
+  expect(onNewChat).toHaveBeenCalledOnce()
+  expect(agent.create).not.toHaveBeenCalled()
   expect(screen.queryByRole('alertdialog')).toBeNull()
-  expect(screen.getByRole('tab', { name: 'Session 2, Idle' }).getAttribute('aria-selected')).toBe('true')
 })
 
 test('every session tab controls a persistent panel while only the selected panel is visible', async () => {
@@ -222,8 +224,10 @@ test('close stays disabled across the pending send response gap', async () => {
   const { agent } = install([summary(1), summary(2)])
   agent.send.mockReturnValue(response.promise)
   render(<Harness />)
-  const composer = await screen.findByRole('textbox', { name: 'Message the agent' })
+  await waitFor(() => expect(agent.get).toHaveBeenCalledTimes(2))
+  const composer = screen.getByRole('textbox', { name: 'Message the agent' })
   fireEvent.change(composer, { target: { value: 'Pending message' } })
+  await waitFor(() => expect((screen.getByRole('button', { name: 'Send message' }) as HTMLButtonElement).disabled).toBe(false))
   fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
   await waitFor(() => expect(agent.send).toHaveBeenCalledOnce())
   expect((screen.getByRole('button', { name: 'Close Session 1' }) as HTMLButtonElement).disabled).toBe(true)
@@ -240,6 +244,18 @@ test('close stays disabled across the pending retry response gap', async () => {
   await waitFor(() => expect(agent.retry).toHaveBeenCalledOnce())
   expect((screen.getByRole('button', { name: 'Close Session 1' }) as HTMLButtonElement).disabled).toBe(true)
   await act(async () => response.resolve({ turnId: 'turn-retry', status: 'running' }))
+})
+
+test('locked chat keeps retryable history readable without exposing retry mutation', async () => {
+  const failed = event(1, { type: 'error', state: 'failed', summary: 'Try again', detail: { retry: true } })
+  const locked = {
+    ...snapshot(1, [failed]),
+    availability: { state: 'locked' as const, reason: 'AGENT_DISCONNECTED' }
+  }
+  install([{ ...summary(1), availability: locked.availability }], [locked])
+  render(<Harness />)
+  expect(await screen.findByText('Try again')).not.toBeNull()
+  expect(screen.queryByRole('button', { name: 'Retry turn' })).toBeNull()
 })
 
 test('runtime transport quarantine updates the tab and close gate until ready streams', async () => {

--- a/apps/desktop/src/renderer/components/AgentPanel.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.tsx
@@ -40,10 +40,12 @@ function AgentElapsedTime({ startedAt }: { startedAt: number }) {
 }
 
 interface AgentPanelProps {
+  agentLabel?: string
   avatarId: AgentAvatarId
   contextLabel: string
   apiState?: ConnectivityState
   onArtifactRendered?: () => void
+  onNewChat?: () => void
   sessions: AgentSessionsController
 }
 
@@ -60,7 +62,7 @@ function ConnectionNotice({ apiState, connection }: { apiState: ConnectivityStat
   return null
 }
 
-export function AgentPanel({ avatarId, contextLabel, apiState = 'connected', onArtifactRendered, sessions }: AgentPanelProps) {
+export function AgentPanel({ agentLabel, avatarId, contextLabel, apiState = 'connected', onArtifactRendered, onNewChat, sessions }: AgentPanelProps) {
   const conversation = sessions.activeConversation ?? {
     ...initialAgentConversationState,
     items: [],
@@ -68,6 +70,7 @@ export function AgentPanel({ avatarId, contextLabel, apiState = 'connected', onA
     operationPending: false
   }
   const activeId = sessions.activeId
+  const activeSummary = sessions.activeSession?.summary
   const panelRefs = useRef(new Map<string, HTMLDivElement>())
   const lastScrollTops = useRef(new Map<string, number>())
   const pinnedToBottom = useRef(true)
@@ -80,6 +83,7 @@ export function AgentPanel({ avatarId, contextLabel, apiState = 'connected', onA
     && !conversation.restoring
     && !conversation.operationPending
     && apiState === 'connected'
+    && activeSummary?.availability?.state !== 'locked'
   )
 
 
@@ -189,7 +193,17 @@ export function AgentPanel({ avatarId, contextLabel, apiState = 'connected', onA
       <div className="agent-context">
         <span title={contextLabel}><BriefcaseBusiness aria-hidden="true" size={16} strokeWidth={1.5} /> <span>{contextLabel}</span></span>
       </div>
-      <AgentSessionTabs controller={sessions} />
+      <AgentSessionTabs controller={sessions} onNewChat={onNewChat} />
+      {activeSummary?.binding ? (
+        <div className="agent-binding" role="status">
+          <strong>{agentLabel ?? (activeSummary.binding.provider === 'codex' ? 'ChatGPT · Codex' : 'Hermes')}</strong>
+          <span>{activeSummary.binding.modelId} · {activeSummary.binding.reasoningEffort}</span>
+          <small>Locked for this chat</small>
+        </div>
+      ) : null}
+      {activeSummary?.availability?.state === 'locked' ? (
+        <div className="agent-connection offline" role="status"><WifiOff aria-hidden="true" size={14} /> This chat is read-only · {activeSummary.availability.reason ?? 'Reconnect its agent to continue'}</div>
+      ) : null}
 
       {(sessions.order.length ? sessions.order : ['']).map(panelId => {
         const selected = !panelId || panelId === activeId
@@ -260,7 +274,7 @@ export function AgentPanel({ avatarId, contextLabel, apiState = 'connected', onA
                       <article className={`agent-notice ${terminal.kind} ${waiting ? 'waiting' : terminal.state}`}>
                         <strong><CircleAlert aria-hidden="true" size={14} /> {waiting ? 'Waiting for you' : terminal.state === 'waiting' ? 'Turn paused' : terminal.state === 'interrupted' ? 'Turn interrupted' : 'Turn failed'}</strong>
                         <p>{terminal.label}</p>
-                        {terminal.retryable && !conversation.activeTurn && (
+                        {terminal.retryable && !conversation.activeTurn && activeSummary?.availability?.state !== 'locked' && (
                           <button aria-label="Retry turn" className="retry-button" onClick={() => { if (activeId) void sessions.retry(activeId, item.turnId) }} type="button">
                             <RotateCcw aria-hidden="true" size={13} /> Retry
                           </button>
@@ -285,7 +299,7 @@ export function AgentPanel({ avatarId, contextLabel, apiState = 'connected', onA
                 <article className={`agent-notice ${item.kind} ${item.state}`} key={item.id}>
                   <strong><CircleAlert aria-hidden="true" size={14} /> {noticeLabel}</strong>
                   <p>{item.label}</p>
-                  {item.retryable && !conversation.activeTurn && (
+                  {item.retryable && !conversation.activeTurn && activeSummary?.availability?.state !== 'locked' && (
                     <button aria-label="Retry turn" className="retry-button" onClick={() => { if (activeId) void sessions.retry(activeId, item.turnId ?? '') }} type="button">
                       <RotateCcw aria-hidden="true" size={13} /> Retry
                     </button>

--- a/apps/desktop/src/renderer/components/AgentSessionTabs.test.tsx
+++ b/apps/desktop/src/renderer/components/AgentSessionTabs.test.tsx
@@ -13,6 +13,8 @@ function session(position: number, status?: 'running' | 'waiting'): AgentSession
     summary: {
       conversationId: `conv_${position}`, position, title: `Session ${position}`, createdAt: '', activeTurn: null,
       connection: 'online', recoveryState: 'ready', latestEventId: 0,
+      binding: { connectedAgentId: 'agent-hermes', provider: 'hermes', modelId: 'default', reasoningEffort: 'medium' },
+      availability: { state: 'ready', reason: null },
       jobContext: { selectedJobId: null, activeArtifactId: null, activeArtifactPage: 1, activeArtifactZoom: 1 }
     },
     conversation: {
@@ -36,7 +38,7 @@ function controller(count = 3): AgentSessionsController {
     atMaximum: count === 5,
     select: vi.fn(() => true), selectByIndex: vi.fn(() => true), create: vi.fn(async () => true),
     createJobless: vi.fn(async () => 'conv_save'),
-    archive: vi.fn(async () => true), updateJobContext: vi.fn(), setDraft: vi.fn(), send: vi.fn(), stop: vi.fn(), retry: vi.fn(), saveScroll: vi.fn()
+    archive: vi.fn(async () => true), updateJobContext: vi.fn(), setDraft: vi.fn(), send: vi.fn(), stop: vi.fn(), retry: vi.fn(), refreshAvailability: vi.fn(), saveScroll: vi.fn()
   }
 }
 
@@ -51,12 +53,12 @@ test('arrow, Home, and End navigation selects and focuses tabs', () => {
   expect(value.select).toHaveBeenCalledWith('conv_3')
 })
 
-test('five-session cap disables add with an exact label and close constraints are explicit', () => {
+test('five-session cap keeps New Chat available for the archive recovery flow', () => {
   const value = controller(5)
   value.activeId = 'conv_2'
   value.sessions.conv_2 = session(2, 'running')
   render(<AgentSessionTabs controller={value} />)
-  expect((screen.getByRole('button', { name: 'New agent session' }) as HTMLButtonElement).disabled).toBe(true)
+  expect((screen.getByRole('button', { name: 'New agent session' }) as HTMLButtonElement).disabled).toBe(false)
   expect(screen.getByRole('button', { name: 'New agent session' }).getAttribute('title')).toBe('Maximum 5 sessions')
   const close = screen.getByRole('button', { name: 'Close Session 2' }) as HTMLButtonElement
   expect(close.disabled).toBe(true)

--- a/apps/desktop/src/renderer/components/AgentSessionTabs.tsx
+++ b/apps/desktop/src/renderer/components/AgentSessionTabs.tsx
@@ -31,9 +31,10 @@ const stateLabel = {
 
 interface AgentSessionTabsProps {
   controller: AgentSessionsController
+  onNewChat?: () => void
 }
 
-export function AgentSessionTabs({ controller }: AgentSessionTabsProps) {
+export function AgentSessionTabs({ controller, onNewChat }: AgentSessionTabsProps) {
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
   const moveFocus = (index: number) => {
     const count = controller.order.length
@@ -123,8 +124,8 @@ export function AgentSessionTabs({ controller }: AgentSessionTabsProps) {
         <button
           aria-label="New agent session"
           className="agent-session-add"
-          disabled={!controller.available || controller.atMaximum || controller.creating}
-          onClick={() => { void controller.create() }}
+          disabled={!controller.available || controller.creating}
+          onClick={() => onNewChat?.()}
           title={controller.atMaximum ? 'Maximum 5 sessions' : 'New agent session (⌘N)'}
           type="button"
         ><Plus aria-hidden="true" size={17} /></button>

--- a/apps/desktop/src/renderer/components/ConnectedAgentsSettings.test.tsx
+++ b/apps/desktop/src/renderer/components/ConnectedAgentsSettings.test.tsx
@@ -95,10 +95,28 @@ test('disconnect requires impact disclosure and promises readable history', asyn
   render(<ConnectedAgentsSettings state={value} />)
   fireEvent.click(screen.getByRole('button', { name: /Disconnect/ }))
   const dialog = await screen.findByRole('alertdialog')
+  await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Keep connected' })))
   expect(dialog.textContent).toContain('2 active chats will become read-only')
   expect(dialog.textContent).toContain('Chat history stays visible')
   expect(dialog.textContent).toContain('New Chat default for 1 profile: default')
   fireEvent.click(screen.getByRole('button', { name: 'Keep connected' }))
+  await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+})
+
+test('disconnect disclosure pluralizes singular impact and traps keyboard focus', async () => {
+  const value = state()
+  value.bridge!.impact = vi.fn().mockResolvedValue({ activeChats: 1, lockedChats: 1, defaultProfileIds: [] })
+  render(<ConnectedAgentsSettings state={value} />)
+  fireEvent.click(screen.getByRole('button', { name: /Disconnect/ }))
+
+  const dialog = await screen.findByRole('alertdialog')
+  expect(dialog.textContent).toContain('1 active chat will become read-only. 1 is already locked.')
+  const keep = screen.getByRole('button', { name: 'Keep connected' })
+  const disconnect = screen.getByRole('button', { name: 'Disconnect agent' })
+  disconnect.focus()
+  fireEvent.keyDown(disconnect, { key: 'Tab' })
+  expect(document.activeElement).toBe(keep)
+  fireEvent.keyDown(keep, { key: 'Escape' })
   await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
 })
 

--- a/apps/desktop/src/renderer/components/ConnectedAgentsSettings.test.tsx
+++ b/apps/desktop/src/renderer/components/ConnectedAgentsSettings.test.tsx
@@ -1,0 +1,182 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+import type { useConnectedAgents } from '../hooks/useConnectedAgents'
+import { authTerminalNotice, ConnectedAgentsSettings } from './ConnectedAgentsSettings'
+
+const agentId = `jagent_${'b'.repeat(32)}`
+
+test('authentication terminal states remain visible and actionable', () => {
+  expect(authTerminalNotice('expired', null)).toContain('expired')
+  expect(authTerminalNotice('cancelled', null)).toContain('cancelled')
+  expect(authTerminalNotice('failed', null)).toContain('failed')
+  expect(authTerminalNotice('cleanup_required', 'AUTH_CLEANUP_REQUIRED')).toContain('cleaned up safely')
+})
+
+function state(): ReturnType<typeof useConnectedAgents> {
+  const catalog = { live: true, models: [{ modelId: 'hermes-live', displayName: 'Hermes Live', reasoningEfforts: ['medium'] }] }
+  const bridge = {
+    update: vi.fn().mockResolvedValue(undefined),
+    setDefault: vi.fn().mockResolvedValue(4),
+    test: vi.fn(),
+    impact: vi.fn().mockResolvedValue({ activeChats: 2, lockedChats: 1, defaultProfileIds: ['default'] }),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    createCodex: vi.fn(),
+    startAuth: vi.fn(),
+    readAuth: vi.fn(),
+    cancelAuth: vi.fn()
+  }
+  return {
+    bridge: bridge as never,
+    snapshot: {
+      registryRevision: 3,
+      profileId: 'default',
+      defaultConnectedAgentId: agentId,
+      agents: [{
+        id: agentId,
+        provider: 'hermes',
+        displayName: 'Hermes',
+        avatarId: 'ninja',
+        defaultModelId: 'hermes-live',
+        defaultReasoningEffort: 'medium',
+        lifecycle: 'connected',
+        accountSummary: null,
+        accountFingerprint: null,
+        health: { state: 'ready', label: 'Ready', providerAvailable: true, toolsAvailable: true, retryAfterSeconds: null },
+        activeChats: 2,
+        lockedChats: 1
+      }]
+    },
+    models: { [agentId]: catalog },
+    loading: false,
+    error: null,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    loadModels: vi.fn().mockResolvedValue(catalog)
+  }
+}
+
+afterEach(() => { cleanup(); vi.useRealTimers() })
+
+test('renders the roster inspector, live defaults, and immutable-chat explanation', async () => {
+  render(<ConnectedAgentsSettings state={state()} />)
+  expect(screen.getByRole('list', { name: 'Connected Agent roster' })).toBeTruthy()
+  expect(screen.getByText('Provider and JobOS tools are ready.')).toBeTruthy()
+  expect(screen.queryByText(/Existing chats keep their original model/i)).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Save defaults' }))
+  expect(await screen.findByText(/Existing chats keep their original model/i)).toBeTruthy()
+})
+
+test('refreshes both the roster and recovered chat summaries', async () => {
+  const value = state()
+  const onAgentsChanged = vi.fn().mockResolvedValue(undefined)
+  render(<ConnectedAgentsSettings onAgentsChanged={onAgentsChanged} state={value} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Refresh Connected Agents' }))
+
+  await waitFor(() => expect(value.refresh).toHaveBeenCalledTimes(1))
+  expect(onAgentsChanged).toHaveBeenCalledTimes(1)
+})
+
+test('testing an agent refreshes recovered chat summaries', async () => {
+  const value = state()
+  const onAgentsChanged = vi.fn().mockResolvedValue(undefined)
+  value.bridge!.test = vi.fn().mockResolvedValue({ health: value.snapshot!.agents[0]!.health })
+  render(<ConnectedAgentsSettings onAgentsChanged={onAgentsChanged} state={value} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Test' }))
+
+  await waitFor(() => expect(value.bridge!.test).toHaveBeenCalledWith(agentId))
+  expect(value.refresh).toHaveBeenCalledTimes(1)
+  expect(onAgentsChanged).toHaveBeenCalledTimes(1)
+})
+
+test('disconnect requires impact disclosure and promises readable history', async () => {
+  const value = state()
+  render(<ConnectedAgentsSettings state={value} />)
+  fireEvent.click(screen.getByRole('button', { name: /Disconnect/ }))
+  const dialog = await screen.findByRole('alertdialog')
+  expect(dialog.textContent).toContain('2 active chats will become read-only')
+  expect(dialog.textContent).toContain('Chat history stays visible')
+  expect(dialog.textContent).toContain('New Chat default for 1 profile: default')
+  fireEvent.click(screen.getByRole('button', { name: 'Keep connected' }))
+  await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+})
+
+test('pending device auth can be cancelled and is cleaned up when settings closes', async () => {
+  const value = state()
+  const codex = value.snapshot!.agents[0]!
+  codex.provider = 'codex'
+  codex.accountSummary = null
+  const transactionId = `jauth_${'d'.repeat(32)}`
+  value.bridge!.startAuth = vi.fn().mockResolvedValue({
+    transactionId,
+    status: 'login_pending', userCode: '(FAKE)-CODE', verificationUrl: 'https://example.test/device', expiresAt: ''
+  })
+  value.bridge!.cancelAuth = vi.fn().mockResolvedValue(undefined)
+  const rendered = render(<ConnectedAgentsSettings state={value} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Finish ChatGPT sign in' }))
+  fireEvent.click(await screen.findByRole('button', { name: 'Cancel sign in' }))
+  await waitFor(() => expect(value.bridge!.cancelAuth).toHaveBeenCalledWith(transactionId))
+
+  fireEvent.click(screen.getByRole('button', { name: 'Finish ChatGPT sign in' }))
+  await screen.findByRole('button', { name: 'Cancel sign in' })
+  rendered.unmount()
+  expect(value.bridge!.cancelAuth).toHaveBeenCalledTimes(2)
+})
+
+test('successful device auth force-refreshes the runtime model catalog', async () => {
+  vi.useFakeTimers()
+  const value = state()
+  const codex = value.snapshot!.agents[0]!
+  codex.provider = 'codex'
+  codex.accountSummary = null
+  value.bridge!.startAuth = vi.fn().mockResolvedValue({
+    transactionId: `jauth_${'a'.repeat(32)}`,
+    status: 'login_pending', userCode: '(FAKE)-CODE', verificationUrl: 'https://example.test/device', expiresAt: ''
+  })
+  value.bridge!.readAuth = vi.fn().mockResolvedValue({
+    transactionId: `jauth_${'a'.repeat(32)}`,
+    status: 'connected', userCode: null, verificationUrl: null, expiresAt: '', errorCode: null
+  })
+  render(<ConnectedAgentsSettings state={value} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Finish ChatGPT sign in' }))
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await vi.advanceTimersByTimeAsync(1500) })
+  expect(value.loadModels).toHaveBeenCalledWith(agentId, true)
+})
+
+test('a disconnected Codex identity offers explicit account replacement on the same durable card', async () => {
+  const value = state()
+  const codex = value.snapshot!.agents[0]!
+  codex.provider = 'codex'
+  codex.lifecycle = 'disconnected'
+  codex.accountSummary = { label: '(FAKE) preserved account' }
+  codex.accountFingerprint = 'a'.repeat(64)
+  value.bridge!.startAuth = vi.fn().mockResolvedValue({
+    transactionId: `jauth_${'b'.repeat(32)}`,
+    status: 'login_pending', userCode: '(FAKE)-CODE', verificationUrl: 'https://example.test/device', expiresAt: ''
+  })
+  render(<ConnectedAgentsSettings state={value} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Replace ChatGPT account' }))
+  await waitFor(() => expect(value.bridge!.startAuth).toHaveBeenCalledWith(agentId, 'replace', 'a'.repeat(64)))
+  expect(screen.getByText(/cannot verify the original account/i)).toBeTruthy()
+})
+
+test('an unhealthy connected Codex identity offers reconnect', async () => {
+  const value = state()
+  const codex = value.snapshot!.agents[0]!
+  codex.provider = 'codex'
+  codex.accountSummary = { label: '(FAKE) existing account' }
+  codex.accountFingerprint = null
+  codex.health = { ...codex.health, state: 'unavailable', label: 'Sign in required', providerAvailable: false }
+  value.bridge!.startAuth = vi.fn().mockResolvedValue({
+    transactionId: `jauth_${'c'.repeat(32)}`,
+    status: 'login_pending', userCode: '(FAKE)-CODE', verificationUrl: 'https://example.test/device', expiresAt: ''
+  })
+
+  render(<ConnectedAgentsSettings state={value} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Replace ChatGPT account' }))
+
+  await waitFor(() => expect(value.bridge!.startAuth).toHaveBeenCalledWith(agentId, 'replace', null))
+})

--- a/apps/desktop/src/renderer/components/ConnectedAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/components/ConnectedAgentsSettings.tsx
@@ -31,6 +31,8 @@ export function ConnectedAgentsSettings({ state, onAgentsChanged }: ConnectedAge
   const [effort, setEffort] = useState('')
   const [auth, setAuth] = useState<{ transactionId: string; status: string; userCode: string | null; verificationUrl: string | null; errorCode?: string | null } | null>(null)
   const pendingAuthRef = useRef<string | null>(null)
+  const disconnectDialog = useRef<HTMLDivElement>(null)
+  const disconnectCancel = useRef<HTMLButtonElement>(null)
   const [disconnecting, setDisconnecting] = useState<{ agent: ConnectedAgentSummary; activeChats: number; lockedChats: number; defaultProfileIds: string[] } | null>(null)
   const selected = useMemo(() => snapshot?.agents.find(item => item.id === selectedId) ?? snapshot?.agents[0] ?? null, [selectedId, snapshot])
   const catalog = selected ? models[selected.id] : undefined
@@ -66,6 +68,11 @@ export function ConnectedAgentsSettings({ state, onAgentsChanged }: ConnectedAge
   useEffect(() => () => {
     if (pendingAuthRef.current && bridge) void bridge.cancelAuth(pendingAuthRef.current)
   }, [bridge])
+
+  useEffect(() => {
+    if (!disconnecting) return
+    requestAnimationFrame(() => disconnectCancel.current?.focus())
+  }, [disconnecting])
 
   const run = async (label: string, action: () => Promise<void>) => {
     setBusy(label)
@@ -133,13 +140,15 @@ export function ConnectedAgentsSettings({ state, onAgentsChanged }: ConnectedAge
         <div className="connected-agents-layout">
           <div aria-label="Connected Agent roster" className="connected-agent-roster" role="list">
             {snapshot.agents.map(item => (
-              <button aria-current={item.id === selected?.id ? 'true' : undefined} className={item.id === selected?.id ? 'selected' : ''} key={item.id} onClick={() => setSelectedId(item.id)} type="button">
-                <span className={`connected-agent-dot ${item.health.providerAvailable && item.health.toolsAvailable ? 'ready' : 'warning'}`} />
-                <span><strong>{item.displayName}</strong><small>{item.provider === 'codex' ? 'ChatGPT · Codex' : 'Hermes'} · {item.health.label}</small></span>
-                {snapshot.defaultConnectedAgentId === item.id ? <span className="connected-agent-default"><Check aria-hidden="true" size={12} /> Default</span> : null}
-              </button>
+              <div key={item.id} role="listitem">
+                <button aria-current={item.id === selected?.id ? 'true' : undefined} className={item.id === selected?.id ? 'selected' : ''} onClick={() => setSelectedId(item.id)} type="button">
+                  <span className={`connected-agent-dot ${item.health.providerAvailable && item.health.toolsAvailable ? 'ready' : 'warning'}`} />
+                  <span><strong>{item.displayName}</strong><small>{item.provider === 'codex' ? 'ChatGPT · Codex' : 'Hermes'} · {item.health.label}</small></span>
+                  {snapshot.defaultConnectedAgentId === item.id ? <span className="connected-agent-default"><Check aria-hidden="true" size={12} /> Default</span> : null}
+                </button>
+              </div>
             ))}
-            {!snapshot.agents.some(item => item.provider === 'codex') ? <button className="connected-agent-add" disabled={busy !== null} onClick={connectCodex} type="button"><Plug aria-hidden="true" size={15} /> Connect ChatGPT</button> : null}
+            {!snapshot.agents.some(item => item.provider === 'codex') ? <div role="listitem"><button className="connected-agent-add" disabled={busy !== null} onClick={connectCodex} type="button"><Plug aria-hidden="true" size={15} /> Connect ChatGPT</button></div> : null}
           </div>
 
           {selected ? (
@@ -174,7 +183,16 @@ export function ConnectedAgentsSettings({ state, onAgentsChanged }: ConnectedAge
       ) : null}
       {notice ? <p aria-live="polite" className="settings-callout">{notice}</p> : null}
       {disconnecting ? (
-        <div aria-labelledby="disconnect-agent-title" aria-modal="true" className="settings-dialog-backdrop" role="alertdialog"><div className="settings-dialog"><h4 id="disconnect-agent-title">Disconnect {disconnecting.agent.displayName}?</h4><p>{disconnecting.activeChats} active chats will become read-only. {disconnecting.lockedChats} are already locked. Chat history stays visible.</p>{disconnecting.defaultProfileIds.length > 0 ? <p>This agent is still the New Chat default for {disconnecting.defaultProfileIds.length} profile{disconnecting.defaultProfileIds.length === 1 ? '' : 's'}: {disconnecting.defaultProfileIds.join(', ')}.</p> : null}<div><button onClick={() => setDisconnecting(null)} type="button">Keep connected</button><button className="danger" onClick={() => void run('disconnect', async () => { if (!bridge || !snapshot) return; await bridge.disconnect(disconnecting.agent.id, snapshot.registryRevision, operationKey('disconnect-agent')); setDisconnecting(null); await refresh(); await onAgentsChanged?.() })} type="button">Disconnect agent</button></div></div></div>
+        <div aria-labelledby="disconnect-agent-title" aria-modal="true" className="settings-dialog-backdrop" onKeyDown={event => {
+          if (event.key === 'Escape') { setDisconnecting(null); return }
+          if (event.key !== 'Tab') return
+          const controls = [...(disconnectDialog.current?.querySelectorAll<HTMLElement>('button:not(:disabled), select:not(:disabled), [tabindex]:not([tabindex="-1"])') ?? [])]
+          if (!controls.length) return
+          const first = controls[0]!
+          const last = controls.at(-1)!
+          if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus() }
+          else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus() }
+        }} ref={disconnectDialog} role="alertdialog"><div className="settings-dialog"><h4 id="disconnect-agent-title">Disconnect {disconnecting.agent.displayName}?</h4><p>{disconnecting.activeChats} active {disconnecting.activeChats === 1 ? 'chat' : 'chats'} will become read-only. {disconnecting.lockedChats} {disconnecting.lockedChats === 1 ? 'is' : 'are'} already locked. Chat history stays visible.</p>{disconnecting.defaultProfileIds.length > 0 ? <p>This agent is still the New Chat default for {disconnecting.defaultProfileIds.length} profile{disconnecting.defaultProfileIds.length === 1 ? '' : 's'}: {disconnecting.defaultProfileIds.join(', ')}.</p> : null}<div><button onClick={() => setDisconnecting(null)} ref={disconnectCancel} type="button">Keep connected</button><button className="danger" onClick={() => void run('disconnect', async () => { if (!bridge || !snapshot) return; await bridge.disconnect(disconnecting.agent.id, snapshot.registryRevision, operationKey('disconnect-agent')); setDisconnecting(null); await refresh(); await onAgentsChanged?.() })} type="button">Disconnect agent</button></div></div></div>
       ) : null}
     </section>
   )

--- a/apps/desktop/src/renderer/components/ConnectedAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/components/ConnectedAgentsSettings.tsx
@@ -1,0 +1,181 @@
+import { Bot, Check, CircleAlert, LoaderCircle, Plug, RefreshCw, Unplug } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import type { ConnectedAgentSummary } from '../../shared/contracts'
+import type { useConnectedAgents } from '../hooks/useConnectedAgents'
+
+function operationKey(label: string): string {
+  return `${label}-${crypto.randomUUID()}`
+}
+
+export function authTerminalNotice(status: string, errorCode: string | null): string {
+  if (status === 'cleanup_required' || errorCode === 'AUTH_CLEANUP_REQUIRED') {
+    return 'ChatGPT sign in could not be cleaned up safely. Retry sign in before using this agent.'
+  }
+  if (status === 'expired') return 'ChatGPT sign in expired. Start sign in again for a fresh code.'
+  if (status === 'cancelled') return 'ChatGPT sign in was cancelled.'
+  return 'ChatGPT sign in failed. Try again.'
+}
+
+interface ConnectedAgentsSettingsProps {
+  state: ReturnType<typeof useConnectedAgents>
+  onAgentsChanged?: () => Promise<void>
+}
+
+export function ConnectedAgentsSettings({ state, onAgentsChanged }: ConnectedAgentsSettingsProps) {
+  const { bridge, snapshot, models, loading, error, refresh, loadModels } = state
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [modelId, setModelId] = useState('')
+  const [effort, setEffort] = useState('')
+  const [auth, setAuth] = useState<{ transactionId: string; status: string; userCode: string | null; verificationUrl: string | null; errorCode?: string | null } | null>(null)
+  const pendingAuthRef = useRef<string | null>(null)
+  const [disconnecting, setDisconnecting] = useState<{ agent: ConnectedAgentSummary; activeChats: number; lockedChats: number; defaultProfileIds: string[] } | null>(null)
+  const selected = useMemo(() => snapshot?.agents.find(item => item.id === selectedId) ?? snapshot?.agents[0] ?? null, [selectedId, snapshot])
+  const catalog = selected ? models[selected.id] : undefined
+
+  useEffect(() => {
+    if (!selected) return
+    setSelectedId(selected.id)
+    setModelId(selected.defaultModelId ?? '')
+    setEffort(selected.defaultReasoningEffort ?? '')
+    if (selected.lifecycle === 'connected') void loadModels(selected.id).catch(() => undefined)
+  }, [selected?.id])
+
+  useEffect(() => {
+    if (!auth || auth.status !== 'login_pending' || !bridge) return
+    const timer = window.setInterval(() => {
+      void bridge.readAuth(auth.transactionId).then(value => {
+        setAuth(value)
+        if (value.status === 'connected') {
+          pendingAuthRef.current = null
+          setNotice('ChatGPT connected. Models and tools are ready to refresh.')
+          void refresh()
+          void onAgentsChanged?.()
+          if (selected) void loadModels(selected.id, true).catch(() => undefined)
+        } else if (value.status !== 'login_pending') {
+          pendingAuthRef.current = null
+          setNotice(authTerminalNotice(value.status, value.errorCode ?? null))
+        }
+      }).catch(() => undefined)
+    }, 1500)
+    return () => window.clearInterval(timer)
+  }, [auth?.transactionId, auth?.status, bridge, loadModels, onAgentsChanged, refresh, selected?.id])
+
+  useEffect(() => () => {
+    if (pendingAuthRef.current && bridge) void bridge.cancelAuth(pendingAuthRef.current)
+  }, [bridge])
+
+  const run = async (label: string, action: () => Promise<void>) => {
+    setBusy(label)
+    setNotice(null)
+    try { await action() } catch (cause) {
+      setNotice(cause instanceof Error ? cause.message : 'Connected Agent action failed')
+    } finally { setBusy(null) }
+  }
+
+  const connectCodex = () => run('connect', async () => {
+    if (!bridge || !snapshot) return
+    const created = await bridge.createCodex('Codex', 'spark', snapshot.registryRevision, operationKey('connect-codex'))
+    await refresh()
+    setSelectedId(created.id)
+    const transaction = await bridge.startAuth(created.id, 'connect', null)
+    pendingAuthRef.current = transaction.transactionId
+    setAuth(transaction)
+  })
+
+  const saveDefaults = () => run('defaults', async () => {
+    if (!bridge || !snapshot || !selected || !modelId || !effort) return
+    await bridge.update(selected, modelId, effort, snapshot.registryRevision, operationKey('agent-defaults'))
+    await refresh()
+    setNotice('Agent defaults saved. Existing chats keep their original model.')
+  })
+
+  const setProfileDefault = () => run('profile-default', async () => {
+    if (!bridge || !snapshot || !selected) return
+    await bridge.setDefault(snapshot.profileId, selected.id, snapshot.registryRevision, operationKey('profile-default'))
+    await refresh()
+    setNotice(`${selected.displayName} is now the New Chat default for this profile.`)
+  })
+
+  const inspectDisconnect = () => run('impact', async () => {
+    if (!bridge || !selected) return
+    const value = await bridge.impact(selected.id)
+    setDisconnecting({ agent: selected, activeChats: value.activeChats, lockedChats: value.lockedChats, defaultProfileIds: value.defaultProfileIds })
+  })
+
+  if (!bridge) return null
+
+  return (
+    <section aria-labelledby="connected-agents-title" className="settings-section connected-agents-settings">
+      <div className="settings-section-heading">
+        <div>
+          <span className="settings-eyebrow">Connected Agents</span>
+          <h3 id="connected-agents-title">Choose who works each chat</h3>
+          <p>Agents are shared across this JobOS installation. New chats lock their agent and model so history stays honest.</p>
+        </div>
+        <button aria-label="Refresh Connected Agents" className="settings-icon-button" disabled={loading} onClick={() => void (async () => { await refresh(); await onAgentsChanged?.() })()} type="button">
+          <RefreshCw aria-hidden="true" className={loading ? 'spin' : ''} size={16} />
+        </button>
+      </div>
+
+      {error ? <p className="settings-callout error" role="alert"><CircleAlert aria-hidden="true" size={15} />{error}</p> : null}
+      {!loading && snapshot?.agents.length === 0 ? (
+        <div className="connected-agents-onboarding">
+          <span className="connected-agents-orb"><Bot aria-hidden="true" size={28} /></span>
+          <div><strong>Bring another brain into JobOS</strong><p>Connect ChatGPT through Codex, then pick its live model when you start a chat.</p></div>
+          <button disabled={busy !== null} onClick={connectCodex} type="button"><Plug aria-hidden="true" size={15} /> Connect ChatGPT</button>
+        </div>
+      ) : null}
+
+      {snapshot && snapshot.agents.length > 0 ? (
+        <div className="connected-agents-layout">
+          <div aria-label="Connected Agent roster" className="connected-agent-roster" role="list">
+            {snapshot.agents.map(item => (
+              <button aria-current={item.id === selected?.id ? 'true' : undefined} className={item.id === selected?.id ? 'selected' : ''} key={item.id} onClick={() => setSelectedId(item.id)} type="button">
+                <span className={`connected-agent-dot ${item.health.providerAvailable && item.health.toolsAvailable ? 'ready' : 'warning'}`} />
+                <span><strong>{item.displayName}</strong><small>{item.provider === 'codex' ? 'ChatGPT · Codex' : 'Hermes'} · {item.health.label}</small></span>
+                {snapshot.defaultConnectedAgentId === item.id ? <span className="connected-agent-default"><Check aria-hidden="true" size={12} /> Default</span> : null}
+              </button>
+            ))}
+            {!snapshot.agents.some(item => item.provider === 'codex') ? <button className="connected-agent-add" disabled={busy !== null} onClick={connectCodex} type="button"><Plug aria-hidden="true" size={15} /> Connect ChatGPT</button> : null}
+          </div>
+
+          {selected ? (
+            <div className="connected-agent-inspector">
+              <div className="connected-agent-title"><div><span>{selected.provider.toUpperCase()}</span><h4>{selected.displayName}</h4></div><span className={`status-pill ${selected.lifecycle}`}>{selected.lifecycle}</span></div>
+              <p className="connected-agent-health">{selected.health.providerAvailable && selected.health.toolsAvailable ? 'Provider and JobOS tools are ready.' : selected.health.label}</p>
+              {selected.accountSummary ? <p className="connected-agent-account">{Object.values(selected.accountSummary).join(' · ')}</p> : null}
+              {selected.provider === 'codex' && (selected.lifecycle === 'disconnected' || !selected.accountSummary || !selected.health.providerAvailable) ? (
+                <button disabled={busy !== null} onClick={() => void run('auth', async () => {
+                  if (bridge) {
+                    const transaction = await bridge.startAuth(selected.id, selected.lifecycle === 'disconnected' || (selected.accountSummary && !selected.accountFingerprint) ? 'replace' : selected.accountSummary ? 'reconnect' : 'connect', selected.accountFingerprint)
+                    pendingAuthRef.current = transaction.transactionId
+                    setAuth(transaction)
+                  }
+                })} type="button">{selected.lifecycle === 'disconnected' || (selected.accountSummary && !selected.accountFingerprint) ? 'Replace ChatGPT account' : selected.accountSummary ? 'Reconnect ChatGPT' : 'Finish ChatGPT sign in'}</button>
+              ) : null}
+              {selected.provider === 'codex' && selected.lifecycle === 'disconnected' ? <p className="connected-agent-account">JobOS cannot verify the original account. Old provider sessions may stay read-only.</p> : null}
+              {auth?.status === 'login_pending' ? (
+                <div className="connected-agent-auth" role="status"><LoaderCircle aria-hidden="true" className="spin" size={16} /><div><strong>Approve ChatGPT in your browser</strong><p>{auth.verificationUrl}</p><code>{auth.userCode}</code><button onClick={() => void run('cancel-auth', async () => { await bridge.cancelAuth(auth.transactionId); pendingAuthRef.current = null; setAuth(null); setNotice('ChatGPT sign in cancelled.') })} type="button">Cancel sign in</button></div></div>
+              ) : null}
+              <label>Default model<select disabled={!catalog?.live || busy !== null} onChange={event => { setModelId(event.target.value); const option = catalog?.models.find(item => item.modelId === event.target.value); setEffort(option?.reasoningEfforts[0] ?? '') }} value={modelId}><option value="">Choose a live model</option>{catalog?.models.map(item => <option key={item.modelId} value={item.modelId}>{item.displayName}</option>)}</select></label>
+              <label>Reasoning effort<select disabled={!modelId || busy !== null} onChange={event => setEffort(event.target.value)} value={effort}><option value="">Choose effort</option>{catalog?.models.find(item => item.modelId === modelId)?.reasoningEfforts.map(value => <option key={value} value={value}>{value}</option>)}</select></label>
+              <div className="connected-agent-actions">
+                <button disabled={!modelId || !effort || busy !== null} onClick={saveDefaults} type="button">Save defaults</button>
+                <button disabled={snapshot.defaultConnectedAgentId === selected.id || busy !== null} onClick={setProfileDefault} type="button">Use for New Chat</button>
+                <button disabled={busy !== null} onClick={() => void run('test', async () => { if (bridge) { const result = await bridge.test(selected.id); setNotice(result.health.label); await refresh(); await onAgentsChanged?.() } })} type="button">Test</button>
+                <button className="danger-link" disabled={busy !== null} onClick={inspectDisconnect} type="button"><Unplug aria-hidden="true" size={14} /> Disconnect</button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+      {notice ? <p aria-live="polite" className="settings-callout">{notice}</p> : null}
+      {disconnecting ? (
+        <div aria-labelledby="disconnect-agent-title" aria-modal="true" className="settings-dialog-backdrop" role="alertdialog"><div className="settings-dialog"><h4 id="disconnect-agent-title">Disconnect {disconnecting.agent.displayName}?</h4><p>{disconnecting.activeChats} active chats will become read-only. {disconnecting.lockedChats} are already locked. Chat history stays visible.</p>{disconnecting.defaultProfileIds.length > 0 ? <p>This agent is still the New Chat default for {disconnecting.defaultProfileIds.length} profile{disconnecting.defaultProfileIds.length === 1 ? '' : 's'}: {disconnecting.defaultProfileIds.join(', ')}.</p> : null}<div><button onClick={() => setDisconnecting(null)} type="button">Keep connected</button><button className="danger" onClick={() => void run('disconnect', async () => { if (!bridge || !snapshot) return; await bridge.disconnect(disconnecting.agent.id, snapshot.registryRevision, operationKey('disconnect-agent')); setDisconnecting(null); await refresh(); await onAgentsChanged?.() })} type="button">Disconnect agent</button></div></div></div>
+      ) : null}
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/components/NewAgentChatDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/NewAgentChatDialog.test.tsx
@@ -88,13 +88,26 @@ test('switching agents ignores a stale model response from the previous agent', 
   await waitFor(() => expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ connectedAgentId: secondId, modelId: 'hermes-live' })))
 })
 
-test('the five-chat state offers archive recovery instead of hiding New Chat', () => {
+test('the five-chat state offers archive recovery instead of hiding New Chat', async () => {
   const onArchiveCurrent = vi.fn()
   render(<NewAgentChatDialog atMaximum connectedAgents={connectedAgents()} onArchiveCurrent={onArchiveCurrent} onClose={vi.fn()} onCreate={vi.fn()} />)
 
   expect(screen.getByText('Five chats are already open')).toBeTruthy()
+  await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('dialog')))
   fireEvent.click(screen.getByRole('button', { name: 'Archive current chat' }))
   expect(onArchiveCurrent).toHaveBeenCalledOnce()
+})
+
+test('a rejected chat creation stays open and explains the failure', async () => {
+  const onClose = vi.fn()
+  render(<NewAgentChatDialog atMaximum={false} connectedAgents={connectedAgents()} onArchiveCurrent={vi.fn()} onClose={onClose} onCreate={vi.fn().mockRejectedValue(new Error('Provider is restarting'))} />)
+
+  await screen.findByText('GPT Live')
+  fireEvent.click(screen.getByRole('button', { name: 'Start chat' }))
+
+  expect((await screen.findByRole('alert')).textContent).toContain('Provider is restarting')
+  expect(onClose).not.toHaveBeenCalled()
+  expect((screen.getByRole('button', { name: 'Start chat' }) as HTMLButtonElement).disabled).toBe(false)
 })
 
 test('Escape closes and Tab remains trapped in the dialog', () => {

--- a/apps/desktop/src/renderer/components/NewAgentChatDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/NewAgentChatDialog.test.tsx
@@ -1,0 +1,110 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+import type { useConnectedAgents } from '../hooks/useConnectedAgents'
+import { NewAgentChatDialog } from './NewAgentChatDialog'
+
+const agentId = `jagent_${'a'.repeat(32)}`
+
+function connectedAgents(): ReturnType<typeof useConnectedAgents> {
+  const catalog = {
+    live: true,
+    models: [{ modelId: 'gpt-live', displayName: 'GPT Live', reasoningEfforts: ['low', 'medium'] }]
+  }
+  return {
+    bridge: {} as never,
+    snapshot: {
+      registryRevision: 7,
+      profileId: 'default',
+      defaultConnectedAgentId: agentId,
+      agents: [{
+        id: agentId,
+        provider: 'codex',
+        displayName: 'Codex',
+        avatarId: 'spark',
+        defaultModelId: 'gpt-live',
+        defaultReasoningEffort: 'medium',
+        lifecycle: 'connected',
+        accountSummary: null,
+        accountFingerprint: null,
+        health: { state: 'ready', label: 'Ready', providerAvailable: true, toolsAvailable: true, retryAfterSeconds: null },
+        activeChats: 0,
+        lockedChats: 0
+      }]
+    },
+    models: { [agentId]: catalog },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    loadModels: vi.fn().mockResolvedValue(catalog)
+  }
+}
+
+afterEach(cleanup)
+
+test('creates a chat from only live ready choices and seals the exact selection receipt', async () => {
+  const state = connectedAgents()
+  const onCreate = vi.fn().mockResolvedValue(true)
+  const onClose = vi.fn()
+  render(<NewAgentChatDialog atMaximum={false} connectedAgents={state} onArchiveCurrent={vi.fn()} onClose={onClose} onCreate={onCreate} />)
+
+  await screen.findByText('GPT Live')
+  expect(state.loadModels).toHaveBeenCalledWith(agentId, true)
+  expect(screen.getByText(/choice stays locked/i)).toBeTruthy()
+  fireEvent.click(screen.getByRole('button', { name: 'Start chat' }))
+
+  await waitFor(() => expect(onCreate).toHaveBeenCalledOnce())
+  expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({
+    connectedAgentId: agentId,
+    modelId: 'gpt-live',
+    reasoningEffort: 'medium',
+    expectedProfileRevision: 7,
+    expectedAgentRegistryRevision: 7
+  }))
+  expect(onClose).toHaveBeenCalledOnce()
+})
+
+test('switching agents ignores a stale model response from the previous agent', async () => {
+  const state = connectedAgents()
+  const secondId = `jagent_${'c'.repeat(32)}`
+  state.snapshot!.agents.push({
+    ...state.snapshot!.agents[0]!, id: secondId, provider: 'hermes', displayName: 'Hermes',
+    defaultModelId: 'hermes-live'
+  })
+  const first = Promise.withResolvers<{ live: boolean; models: Array<{ modelId: string; displayName: string; reasoningEfforts: string[] }> }>()
+  const second = Promise.withResolvers<{ live: boolean; models: Array<{ modelId: string; displayName: string; reasoningEfforts: string[] }> }>()
+  const catalogA = { live: true, models: [{ modelId: 'gpt-live', displayName: 'GPT Live', reasoningEfforts: ['medium'] }] }
+  const catalogB = { live: true, models: [{ modelId: 'hermes-live', displayName: 'Hermes Live', reasoningEfforts: ['medium'] }] }
+  state.models[secondId] = catalogB
+  state.loadModels = vi.fn((id: string) => id === agentId ? first.promise : second.promise)
+  const onCreate = vi.fn().mockResolvedValue(true)
+  render(<NewAgentChatDialog atMaximum={false} connectedAgents={state} onArchiveCurrent={vi.fn()} onClose={vi.fn()} onCreate={onCreate} />)
+
+  fireEvent.change(screen.getByLabelText('Agent'), { target: { value: secondId } })
+  await act(async () => { first.resolve(catalogA); await first.promise })
+  expect((screen.getByRole('button', { name: 'Start chat' }) as HTMLButtonElement).disabled).toBe(true)
+  await act(async () => { second.resolve(catalogB); await second.promise })
+  fireEvent.click(screen.getByRole('button', { name: 'Start chat' }))
+  await waitFor(() => expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ connectedAgentId: secondId, modelId: 'hermes-live' })))
+})
+
+test('the five-chat state offers archive recovery instead of hiding New Chat', () => {
+  const onArchiveCurrent = vi.fn()
+  render(<NewAgentChatDialog atMaximum connectedAgents={connectedAgents()} onArchiveCurrent={onArchiveCurrent} onClose={vi.fn()} onCreate={vi.fn()} />)
+
+  expect(screen.getByText('Five chats are already open')).toBeTruthy()
+  fireEvent.click(screen.getByRole('button', { name: 'Archive current chat' }))
+  expect(onArchiveCurrent).toHaveBeenCalledOnce()
+})
+
+test('Escape closes and Tab remains trapped in the dialog', () => {
+  const onClose = vi.fn()
+  render(<NewAgentChatDialog atMaximum connectedAgents={connectedAgents()} onArchiveCurrent={vi.fn()} onClose={onClose} onCreate={vi.fn()} />)
+  const close = screen.getByRole('button', { name: 'Close New Chat' })
+  const archive = screen.getByRole('button', { name: 'Archive current chat' })
+  archive.focus()
+  fireEvent.keyDown(archive, { key: 'Tab' })
+  expect(document.activeElement).toBe(close)
+  fireEvent.keyDown(close, { key: 'Escape' })
+  expect(onClose).toHaveBeenCalledOnce()
+})

--- a/apps/desktop/src/renderer/components/NewAgentChatDialog.tsx
+++ b/apps/desktop/src/renderer/components/NewAgentChatDialog.tsx
@@ -31,7 +31,7 @@ export function NewAgentChatDialog({ connectedAgents, atMaximum, onArchiveCurren
       ? snapshot.defaultConnectedAgentId
       : agents[0]?.id ?? ''
     setAgentId(initial)
-    requestAnimationFrame(() => firstControl.current?.focus())
+    requestAnimationFrame(() => (firstControl.current ?? dialog.current)?.focus())
   }, [snapshot?.registryRevision])
 
   useEffect(() => {
@@ -64,6 +64,8 @@ export function NewAgentChatDialog({ connectedAgents, atMaximum, onArchiveCurren
       })
       if (handled) onClose()
       else setError('New chat could not be started. Refresh the agent and try again.')
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'New chat could not be started. Refresh the agent and try again.')
     } finally { setSubmitting(false) }
   }
 
@@ -78,7 +80,7 @@ export function NewAgentChatDialog({ connectedAgents, atMaximum, onArchiveCurren
         const last = controls.at(-1)!
         if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus() }
         else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus() }
-      }} ref={dialog} role="dialog">
+      }} ref={dialog} role="dialog" tabIndex={-1}>
         <header><div><span className="settings-eyebrow">New Chat</span><h2 id="new-chat-title">Pick the agent for this chat</h2><p>This choice stays locked so the conversation never silently changes brains.</p></div><button aria-label="Close New Chat" onClick={onClose} type="button"><X aria-hidden="true" size={16} /></button></header>
         {atMaximum ? <div className="new-chat-limit" role="status"><CircleAlert aria-hidden="true" size={18} /><div><strong>Five chats are already open</strong><p>Archive the current chat first. Its history stays saved.</p><button onClick={onArchiveCurrent} type="button">Archive current chat</button></div></div> : (
           <>

--- a/apps/desktop/src/renderer/components/NewAgentChatDialog.tsx
+++ b/apps/desktop/src/renderer/components/NewAgentChatDialog.tsx
@@ -1,0 +1,97 @@
+import { Bot, CircleAlert, X } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import type { AgentChatSelection } from '../../shared/contracts'
+import type { useConnectedAgents } from '../hooks/useConnectedAgents'
+
+interface NewAgentChatDialogProps {
+  connectedAgents: ReturnType<typeof useConnectedAgents>
+  atMaximum: boolean
+  onArchiveCurrent: () => void
+  onClose: () => void
+  onCreate: (selection: AgentChatSelection) => Promise<boolean>
+}
+
+export function NewAgentChatDialog({ connectedAgents, atMaximum, onArchiveCurrent, onClose, onCreate }: NewAgentChatDialogProps) {
+  const { snapshot, models, loadModels, loading } = connectedAgents
+  const [agentId, setAgentId] = useState('')
+  const [modelId, setModelId] = useState('')
+  const [effort, setEffort] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const firstControl = useRef<HTMLSelectElement>(null)
+  const dialog = useRef<HTMLDivElement>(null)
+  const agents = useMemo(() => snapshot?.agents.filter(agent => agent.lifecycle === 'connected' && agent.health.providerAvailable && agent.health.toolsAvailable) ?? [], [snapshot])
+  const selected = agents.find(agent => agent.id === agentId)
+  const catalog = agentId ? models[agentId] : undefined
+  const option = catalog?.models.find(item => item.modelId === modelId)
+
+  useEffect(() => {
+    const initial = snapshot?.defaultConnectedAgentId && agents.some(agent => agent.id === snapshot.defaultConnectedAgentId)
+      ? snapshot.defaultConnectedAgentId
+      : agents[0]?.id ?? ''
+    setAgentId(initial)
+    requestAnimationFrame(() => firstControl.current?.focus())
+  }, [snapshot?.registryRevision])
+
+  useEffect(() => {
+    if (!selected) return
+    let current = true
+    setModelId('')
+    setEffort('')
+    setError(null)
+    void loadModels(selected.id, true).then(value => {
+      if (!current) return
+      const preferred = value.models.find(item => item.modelId === selected.defaultModelId) ?? value.models[0]
+      setModelId(preferred?.modelId ?? '')
+      setEffort(preferred?.reasoningEfforts.includes(selected.defaultReasoningEffort ?? '') ? selected.defaultReasoningEffort! : preferred?.reasoningEfforts[0] ?? '')
+    }).catch(cause => { if (current) setError(cause instanceof Error ? cause.message : 'Models unavailable') })
+    return () => { current = false }
+  }, [selected?.id])
+
+  const create = async () => {
+    if (!snapshot || !selected || !modelId || !effort) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const handled = await onCreate({
+        connectedAgentId: selected.id,
+        modelId,
+        reasoningEffort: effort,
+        expectedProfileRevision: snapshot.registryRevision,
+        expectedAgentRegistryRevision: snapshot.registryRevision,
+        idempotencyKey: `desktop-new-chat-${crypto.randomUUID()}`
+      })
+      if (handled) onClose()
+      else setError('New chat could not be started. Refresh the agent and try again.')
+    } finally { setSubmitting(false) }
+  }
+
+  return (
+    <div className="new-chat-backdrop" onMouseDown={event => { if (event.target === event.currentTarget) onClose() }}>
+      <div aria-labelledby="new-chat-title" aria-modal="true" className="new-chat-dialog" onKeyDown={event => {
+        if (event.key === 'Escape') { onClose(); return }
+        if (event.key !== 'Tab') return
+        const controls = [...(dialog.current?.querySelectorAll<HTMLElement>('button:not(:disabled), select:not(:disabled), [tabindex]:not([tabindex="-1"])') ?? [])]
+        if (!controls.length) return
+        const first = controls[0]!
+        const last = controls.at(-1)!
+        if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus() }
+        else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus() }
+      }} ref={dialog} role="dialog">
+        <header><div><span className="settings-eyebrow">New Chat</span><h2 id="new-chat-title">Pick the agent for this chat</h2><p>This choice stays locked so the conversation never silently changes brains.</p></div><button aria-label="Close New Chat" onClick={onClose} type="button"><X aria-hidden="true" size={16} /></button></header>
+        {atMaximum ? <div className="new-chat-limit" role="status"><CircleAlert aria-hidden="true" size={18} /><div><strong>Five chats are already open</strong><p>Archive the current chat first. Its history stays saved.</p><button onClick={onArchiveCurrent} type="button">Archive current chat</button></div></div> : (
+          <>
+            <label>Agent<select disabled={loading || agents.length === 0} onChange={event => { setAgentId(event.target.value); setModelId(''); setEffort('') }} ref={firstControl} value={agentId}><option value="">Choose an agent</option>{agents.map(agent => <option key={agent.id} value={agent.id}>{agent.displayName} · {agent.provider === 'codex' ? 'ChatGPT' : 'Hermes'}</option>)}</select></label>
+            <label>Model<select disabled={!catalog?.live} onChange={event => { setModelId(event.target.value); setEffort(catalog?.models.find(item => item.modelId === event.target.value)?.reasoningEfforts[0] ?? '') }} value={modelId}><option value="">Choose a live model</option>{catalog?.models.map(model => <option key={model.modelId} value={model.modelId}>{model.displayName}</option>)}</select></label>
+            <label>Reasoning effort<select disabled={!option} onChange={event => setEffort(event.target.value)} value={effort}><option value="">Choose effort</option>{option?.reasoningEfforts.map(value => <option key={value} value={value}>{value}</option>)}</select></label>
+            {selected ? <div className="new-chat-receipt"><Bot aria-hidden="true" size={18} /><span><strong>{selected.displayName}</strong><small>{modelId || 'Choose a model'}{effort ? ` · ${effort}` : ''}</small></span></div> : null}
+            {agents.length === 0 && !loading ? <p className="settings-callout">No ready agents. Connect or repair one in Settings.</p> : null}
+            {error ? <p className="settings-callout error" role="alert">{error}</p> : null}
+            <footer><button onClick={onClose} type="button">Cancel</button><button disabled={!selected || !modelId || !effort || submitting} onClick={() => void create()} type="button">{submitting ? 'Starting…' : 'Start chat'}</button></footer>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -6,13 +6,17 @@ import { AgentAvatar } from '../agent-avatar/AgentAvatar'
 import { AGENT_AVATARS, type AgentAvatarId } from '../agent-avatar/agentAvatars'
 import { THEMES, type ThemeMode } from '../theme/themes'
 import { DiagnosticsPanel } from '../diagnostics/DiagnosticsPanel'
+import type { useConnectedAgents } from '../hooks/useConnectedAgents'
+import { ConnectedAgentsSettings } from './ConnectedAgentsSettings'
 
 interface SettingsPanelProps {
   activeAgentAvatarId: AgentAvatarId
   activeThemeId: string
   careerProfileBridge?: CareerProfileBridge | null
+  connectedAgentsState?: ReturnType<typeof useConnectedAgents>
   mode: ThemeMode
   onClose: () => void
+  onConnectedAgentsChanged?: () => Promise<void>
   onSelectAgentAvatar: (avatarId: AgentAvatarId) => void
   onSelectTheme: (themeId: string) => void
 }
@@ -23,8 +27,10 @@ export function SettingsPanel({
   activeAgentAvatarId,
   activeThemeId,
   careerProfileBridge = null,
+  connectedAgentsState,
   mode,
   onClose,
+  onConnectedAgentsChanged,
   onSelectAgentAvatar,
   onSelectTheme
 }: SettingsPanelProps) {
@@ -140,6 +146,8 @@ export function SettingsPanel({
             })}
           </div>
         </section>
+
+        {connectedAgentsState ? <ConnectedAgentsSettings onAgentsChanged={onConnectedAgentsChanged} state={connectedAgentsState} /> : null}
 
         {careerProfileBridge ? (
           <section aria-labelledby="settings-agent-editing-heading" className="settings-section settings-section-divided">

--- a/apps/desktop/src/renderer/hooks/useAgentConversation.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useAgentConversation.test.tsx
@@ -24,6 +24,8 @@ const event = (eventId: number, overrides: Partial<ConversationEvent> = {}): Con
 const snapshot = (entries: ConversationEvent[] = []): AgentConversationSnapshot => ({
   conversationId: 'conv-current', position: 1, title: 'Session 1', createdAt: '', entries, activeTurn: null,
   connection: 'online', recoveryState: 'ready', latestEventId: entries.at(-1)?.eventId ?? 0,
+  binding: { connectedAgentId: 'agent-hermes', provider: 'hermes', modelId: 'default', reasoningEffort: 'medium' },
+  availability: { state: 'ready', reason: null },
   jobContext: { selectedJobId: null, activeArtifactId: null, activeArtifactPage: 1, activeArtifactZoom: 1 }
 })
 

--- a/apps/desktop/src/renderer/hooks/useAgentSessions.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useAgentSessions.test.tsx
@@ -9,6 +9,8 @@ afterEach(() => { cleanup(); window.localStorage.clear() })
 const summary = (position: number): AgentSessionSummary => ({
   conversationId: `conv_${position}`, position, title: `Session ${position}`,
   createdAt: '2026-08-16T10:00:00Z', activeTurn: null, connection: 'online', recoveryState: 'ready', latestEventId: 0,
+  binding: { connectedAgentId: 'agent-hermes', provider: 'hermes', modelId: 'default', reasoningEffort: 'medium' },
+  availability: { state: 'ready', reason: null },
   jobContext: { selectedJobId: null, activeArtifactId: null, activeArtifactPage: 1, activeArtifactZoom: 1 }
 })
 const snapshot = (position: number, entries: ConversationEvent[] = []): AgentConversationSnapshot => ({
@@ -48,6 +50,20 @@ test('subscribes before hydration and reconciles early scoped events exactly onc
   await act(async () => pending.resolve(snapshot(1, [event(1), event(2, 'completed')])))
   await waitFor(() => expect(result.current.activeConversation?.restoring).toBe(false))
   expect(result.current.activeConversation?.entries.map(item => item.eventId)).toEqual([1, 2])
+})
+
+test('restore keeps the sealed list binding when detail omits presentation metadata', async () => {
+  const sealed = summary(1)
+  const legacyDetail = {
+    ...snapshot(1),
+    binding: null,
+    availability: { state: 'locked' as const, reason: 'LEGACY_BINDING_UNAVAILABLE' }
+  }
+  install([sealed], [legacyDetail])
+  const { result } = renderHook(() => useAgentSessions())
+  await waitFor(() => expect(result.current.activeConversation?.restoring).toBe(false))
+  expect(result.current.sessions.conv_1?.summary.binding).toEqual(sealed.binding)
+  expect(result.current.sessions.conv_1?.summary.availability).toEqual({ state: 'ready', reason: null })
 })
 
 test('interleaved events and drafts update only their owning sessions', async () => {
@@ -191,9 +207,13 @@ test('browser save creates a fresh session with explicitly empty job context', a
   await waitFor(() => expect(result.current.activeId).toBe('conv_1'))
 
   let createdId: string | null = null
-  await act(async () => { createdId = await result.current.createJobless() })
+  const selection = {
+    connectedAgentId: 'agent-hermes', modelId: 'default', reasoningEffort: 'medium',
+    expectedProfileRevision: 2, expectedAgentRegistryRevision: 2, idempotencyKey: 'desktop-save-chat-test'
+  }
+  await act(async () => { createdId = await result.current.createJobless(selection) })
 
-  expect(agent.create).toHaveBeenCalledWith(null)
+  expect(agent.create).toHaveBeenCalledWith({ ...selection, initialSelectedJobId: null })
   expect(createdId).toBe('conv_2')
   expect(result.current.activeId).toBe('conv_2')
   expect(result.current.sessions.conv_2?.summary.jobContext.selectedJobId).toBeNull()

--- a/apps/desktop/src/renderer/hooks/useAgentSessions.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentSessions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type {
+  AgentChatSelection,
   AgentConversationSnapshot,
   AgentSessionJobContext,
   AgentSessionStreamUpdate,
@@ -38,7 +39,9 @@ interface AgentSessionsState {
 const unavailableSummary: AgentSessionSummary = {
   conversationId: 'conv_unavailable', position: 1, title: 'Session 1', createdAt: '',
   activeTurn: null, connection: 'offline', recoveryState: 'ready', latestEventId: 0,
-  jobContext: { selectedJobId: null, activeArtifactId: null, activeArtifactPage: 1, activeArtifactZoom: 1 }
+  jobContext: { selectedJobId: null, activeArtifactId: null, activeArtifactPage: 1, activeArtifactZoom: 1 },
+  binding: null,
+  availability: { state: 'locked', reason: 'Agent unavailable' }
 }
 
 function identifier(prefix: string): string {
@@ -78,7 +81,9 @@ function summaryFromSnapshot(snapshot: AgentConversationSnapshot): AgentSessionS
     connection: snapshot.connection,
     recoveryState: snapshot.recoveryState ?? 'ready',
     latestEventId: snapshot.latestEventId,
-    jobContext: snapshot.jobContext
+    jobContext: snapshot.jobContext,
+    binding: snapshot.binding,
+    availability: snapshot.availability
   }
 }
 
@@ -201,8 +206,16 @@ export function useAgentSessions() {
       if (activeId) window.localStorage.setItem(ACTIVE_CONVERSATION_KEY, activeId)
       await Promise.all(sorted.map(async summary => {
         try {
-          const snapshot = await bridge.get(summary.conversationId)
-          if (!mounted || snapshot.conversationId !== summary.conversationId) return
+          const response = await bridge.get(summary.conversationId)
+          if (!mounted || response.conversationId !== summary.conversationId) return
+          // The detail endpoint predates Connected Agent presentation metadata.
+          // Preserve the authoritative sealed binding from the list response while
+          // the conversation body hydrates instead of briefly relabelling it legacy.
+          const snapshot = {
+            ...response,
+            binding: response.binding ?? summary.binding,
+            availability: response.binding ? response.availability : summary.availability
+          }
           updateState(current => {
             const session = current.sessions[summary.conversationId]
             if (!session) return current
@@ -270,7 +283,7 @@ export function useAgentSessions() {
     return id ? select(id) : false
   }, [select])
 
-  const createSession = useCallback((initialSelectedJobId?: string | null): Promise<{
+  const createSession = useCallback((selection?: AgentChatSelection, initialSelectedJobId?: string | null): Promise<{
     handled: boolean
     conversationId: string | null
   }> => {
@@ -286,7 +299,7 @@ export function useAgentSessions() {
         const inheritedJobId = initialSelectedJobId === undefined
           ? stateRef.current.sessions[stateRef.current.activeId ?? '']?.summary.jobContext.selectedJobId ?? null
           : initialSelectedJobId
-        const snapshot = await bridge.create(inheritedJobId)
+        const snapshot = await bridge.create(selection ? { ...selection, initialSelectedJobId: inheritedJobId } : undefined)
         let session: AgentSessionViewState = {
           ...sessionFromSummary(summaryFromSnapshot(snapshot)),
           conversation: agentConversationReducer(initialAgentConversationState, { type: 'hydrate', snapshot })
@@ -315,12 +328,12 @@ export function useAgentSessions() {
     return task
   }, [updateState])
 
-  const create = useCallback(async (initialSelectedJobId?: string | null): Promise<boolean> => (
-    await createSession(initialSelectedJobId)
+  const create = useCallback(async (selection?: AgentChatSelection): Promise<boolean> => (
+    await createSession(selection)
   ).handled, [createSession])
 
-  const createJobless = useCallback(async (): Promise<string | null> => (
-    await createSession(null)
+  const createJobless = useCallback(async (selection: AgentChatSelection): Promise<string | null> => (
+    await createSession(selection, null)
   ).conversationId, [createSession])
 
   const setDraft = useCallback((conversationId: string, draft: string) => {
@@ -461,6 +474,20 @@ export function useAgentSessions() {
     })
   }, [updateState])
 
+  const refreshAvailability = useCallback(async () => {
+    const bridge = window.jobos?.agent
+    if (!bridge) return
+    const summaries = await bridge.list()
+    const byId = new Map(summaries.map(summary => [summary.conversationId, summary]))
+    updateState(current => ({
+      ...current,
+      sessions: Object.fromEntries(Object.entries(current.sessions).map(([id, session]) => {
+        const summary = byId.get(id)
+        return [id, summary ? { ...session, summary: { ...session.summary, ...summary } } : session]
+      }))
+    }))
+  }, [updateState])
+
   const activeSession = state.activeId ? state.sessions[state.activeId] ?? null : null
   const activeConversation = useMemo(() => activeSession ? {
     ...activeSession.conversation,
@@ -486,6 +513,7 @@ export function useAgentSessions() {
     send,
     stop,
     retry,
+    refreshAvailability,
     saveScroll,
     updateJobContext
   }

--- a/apps/desktop/src/renderer/hooks/useConnectedAgents.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useConnectedAgents.test.tsx
@@ -1,0 +1,71 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+import type { ConnectedAgentsSnapshot } from '../../shared/contracts'
+import { useConnectedAgents } from './useConnectedAgents'
+
+const agentId = `jagent_${'a'.repeat(32)}`
+
+const snapshot: ConnectedAgentsSnapshot = {
+  registryRevision: 3,
+  profileId: `jprof_${'b'.repeat(32)}`,
+  defaultConnectedAgentId: agentId,
+  agents: [{
+    id: agentId,
+    provider: 'codex',
+    displayName: 'Codex',
+    avatarId: 'spark',
+    defaultModelId: '(FAKE)-live',
+    defaultReasoningEffort: 'medium',
+    lifecycle: 'connected',
+    accountSummary: null,
+    accountFingerprint: null,
+    health: {
+      state: 'ready',
+      label: 'Ready',
+      providerAvailable: true,
+      toolsAvailable: true,
+      retryAfterSeconds: null
+    },
+    activeChats: 0,
+    lockedChats: 0
+  }]
+}
+
+afterEach(cleanup)
+
+test('refresh returns the loaded roster so startup actions can await readiness', async () => {
+  const list = vi.fn().mockResolvedValue(snapshot)
+  Object.defineProperty(window, 'jobos', {
+    configurable: true,
+    value: { connectedAgents: { list, models: vi.fn() } }
+  })
+  const { result } = renderHook(() => useConnectedAgents())
+
+  await waitFor(() => expect(result.current.snapshot).toEqual(snapshot))
+  let refreshed: ConnectedAgentsSnapshot | null | undefined
+  await act(async () => { refreshed = await result.current.refresh() })
+
+  expect(refreshed).toEqual(snapshot)
+  expect(list).toHaveBeenCalledTimes(2)
+})
+
+test('does not pin a failed model probe in the cache', async () => {
+  const unavailable = { live: false, models: [] }
+  const available = {
+    live: true,
+    models: [{ modelId: '(FAKE)-live', displayName: '(FAKE) Live', reasoningEfforts: ['medium'] }]
+  }
+  const models = vi.fn().mockResolvedValueOnce(unavailable).mockResolvedValueOnce(available)
+  Object.defineProperty(window, 'jobos', {
+    configurable: true,
+    value: { connectedAgents: { list: vi.fn().mockResolvedValue(snapshot), models } }
+  })
+  const { result } = renderHook(() => useConnectedAgents())
+  await waitFor(() => expect(result.current.snapshot).toEqual(snapshot))
+
+  await act(async () => { expect(await result.current.loadModels(agentId)).toEqual(unavailable) })
+  await act(async () => { expect(await result.current.loadModels(agentId)).toEqual(available) })
+
+  expect(models).toHaveBeenCalledTimes(2)
+})

--- a/apps/desktop/src/renderer/hooks/useConnectedAgents.ts
+++ b/apps/desktop/src/renderer/hooks/useConnectedAgents.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import type { ConnectedAgentModelsSnapshot, ConnectedAgentsSnapshot } from '../../shared/contracts'
+
+export function useConnectedAgents() {
+  const bridge = window.jobos?.connectedAgents
+  const [snapshot, setSnapshot] = useState<ConnectedAgentsSnapshot | null>(null)
+  const [models, setModels] = useState<Record<string, ConnectedAgentModelsSnapshot>>({})
+  const [loading, setLoading] = useState(Boolean(bridge))
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!bridge) return null
+    setLoading(true)
+    try {
+      const value = await bridge.list()
+      setSnapshot(value)
+      setError(null)
+      return value
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Connected Agents unavailable')
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }, [bridge])
+
+  const loadModels = useCallback(async (agentId: string, force = false) => {
+    if (!bridge) throw new Error('Connected Agents unavailable')
+    if (!force && models[agentId]?.live) return models[agentId]
+    const value = await bridge.models(agentId)
+    setModels(current => ({ ...current, [agentId]: value }))
+    return value
+  }, [bridge, models])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  return { bridge, snapshot, models, loading, error, refresh, loadModels }
+}

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -2072,3 +2072,86 @@ button:focus-visible {
 @media (prefers-reduced-motion: reduce) {
   .career-skeleton { animation: none; }
 }
+
+/* Connected Agents — intentionally compact V1 */
+.settings-section-heading { display: flex; align-items: start; justify-content: space-between; gap: 16px; }
+.settings-section-heading h3 { margin: 3px 0 4px; color: var(--text); font-size: var(--text-lg); }
+.settings-section-heading p { max-width: 620px; margin: 0; color: var(--muted); font-size: var(--text-sm); line-height: 1.5; }
+.settings-eyebrow { color: var(--accent); font-size: 10px; font-weight: var(--weight-bold); letter-spacing: .12em; text-transform: uppercase; }
+.settings-icon-button { display: grid; width: 34px; height: 34px; place-items: center; border: 1px solid var(--border); border-radius: 10px; color: var(--muted); background: var(--surface-raised); }
+.settings-callout { display: flex; align-items: center; gap: 8px; margin: 12px 0 0; padding: 10px 12px; border: 1px solid var(--border); border-radius: 10px; color: var(--muted); background: var(--surface-inset); font-size: var(--text-sm); }
+.settings-callout.error { border-color: var(--danger-border); color: var(--danger-text); background: var(--danger-tint); }
+.connected-agents-settings { border-top: 1px solid var(--border-soft); }
+.connected-agents-onboarding { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 14px; margin-top: 16px; padding: 16px; border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border)); border-radius: 16px; background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 9%, var(--surface-raised)), var(--surface-raised)); }
+.connected-agents-onboarding p { margin: 3px 0 0; color: var(--muted); font-size: var(--text-sm); }
+.connected-agents-orb { display: grid; width: 48px; height: 48px; place-items: center; border-radius: 16px; color: var(--accent); background: var(--accent-soft); }
+.connected-agents-onboarding button,
+.connected-agent-actions button,
+.connected-agent-add,
+.connected-agent-inspector > button { display: inline-flex; align-items: center; justify-content: center; gap: 7px; min-height: 34px; padding: 0 11px; border: 1px solid var(--border-strong); border-radius: 9px; color: var(--text); background: var(--surface-raised); font: inherit; font-size: var(--text-xs); font-weight: var(--weight-bold); }
+.connected-agents-layout { display: grid; grid-template-columns: minmax(190px, .8fr) minmax(260px, 1.2fr); gap: 14px; margin-top: 16px; }
+.connected-agent-roster { display: grid; align-content: start; gap: 6px; }
+.connected-agent-roster > button { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 9px; width: 100%; padding: 11px; border: 1px solid transparent; border-radius: 11px; color: var(--text); text-align: left; background: transparent; }
+.connected-agent-roster > button:hover,
+.connected-agent-roster > button.selected { border-color: var(--border); background: var(--surface-raised); }
+.connected-agent-roster > button span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
+.connected-agent-roster small { overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.connected-agent-dot { width: 8px; height: 8px; border-radius: 999px; background: var(--warn); box-shadow: 0 0 0 3px var(--warn-tint); }
+.connected-agent-dot.ready { background: var(--green); box-shadow: 0 0 0 3px var(--green-tint); }
+.connected-agent-default { display: inline-flex; align-items: center; gap: 3px; color: var(--accent); font-size: 9px; font-weight: var(--weight-bold); }
+.connected-agent-roster .connected-agent-add { grid-template-columns: auto 1fr; border-style: dashed; color: var(--accent); }
+.connected-agent-inspector { display: grid; gap: 11px; padding: 15px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface-raised); }
+.connected-agent-title { display: flex; align-items: start; justify-content: space-between; gap: 12px; }
+.connected-agent-title span:first-child { color: var(--quiet); font-size: 9px; font-weight: var(--weight-bold); letter-spacing: .1em; }
+.connected-agent-title h4 { margin: 2px 0 0; font-size: var(--text-lg); }
+.status-pill { padding: 4px 7px; border-radius: 999px; color: var(--green-text); background: var(--green-tint); font-size: 9px; font-weight: var(--weight-bold); text-transform: capitalize; }
+.status-pill.disconnected { color: var(--danger-text); background: var(--danger-tint); }
+.connected-agent-health,
+.connected-agent-account { margin: 0; color: var(--muted); font-size: var(--text-xs); }
+.connected-agent-inspector label,
+.new-chat-dialog label { display: grid; gap: 5px; color: var(--muted); font-size: var(--text-xs); font-weight: var(--weight-bold); }
+.connected-agent-inspector select,
+.new-chat-dialog select { width: 100%; min-height: 38px; padding: 0 10px; border: 1px solid var(--border); border-radius: 9px; color: var(--text); background: var(--surface-inset); font: inherit; }
+.connected-agent-actions { display: flex; flex-wrap: wrap; gap: 7px; padding-top: 2px; }
+.connected-agent-actions .danger-link { margin-left: auto; color: var(--danger-text); }
+.connected-agent-auth { display: flex; align-items: start; gap: 10px; padding: 11px; border-radius: 10px; background: var(--accent-soft); }
+.connected-agent-auth p { margin: 2px 0; color: var(--muted); font-size: 10px; }
+.connected-agent-auth code { color: var(--text); font-size: var(--text-md); letter-spacing: .08em; }
+.settings-dialog-backdrop,
+.new-chat-backdrop { position: fixed; z-index: 80; inset: 0; display: grid; place-items: center; padding: 20px; background: color-mix(in srgb, var(--bg) 72%, transparent); backdrop-filter: blur(8px); }
+.settings-dialog,
+.new-chat-dialog { width: min(480px, 100%); padding: 20px; border: 1px solid var(--border-strong); border-radius: 18px; background: var(--surface-raised); box-shadow: var(--shadow-lg); }
+.settings-dialog h4 { margin: 0; font-size: var(--text-lg); }
+.settings-dialog p { color: var(--muted); line-height: 1.5; }
+.settings-dialog > div { display: flex; justify-content: end; gap: 8px; }
+.settings-dialog button,
+.new-chat-dialog button { min-height: 36px; padding: 0 12px; border: 1px solid var(--border); border-radius: 9px; color: var(--text); background: var(--surface-inset); font: inherit; }
+.settings-dialog button.danger { border-color: var(--danger-border); color: white; background: var(--danger); }
+.new-chat-dialog { display: grid; gap: 14px; }
+.new-chat-dialog > header { display: flex; align-items: start; justify-content: space-between; gap: 14px; }
+.new-chat-dialog h2 { margin: 3px 0 4px; font-size: 22px; }
+.new-chat-dialog header p { margin: 0; color: var(--muted); font-size: var(--text-sm); line-height: 1.45; }
+.new-chat-dialog header > button { width: 34px; min-height: 34px; padding: 0; }
+.new-chat-dialog footer { display: flex; justify-content: end; gap: 8px; padding-top: 4px; }
+.new-chat-dialog footer button:last-child { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
+.new-chat-limit { display: flex; align-items: start; gap: 11px; padding: 14px; border-radius: 12px; color: var(--warn-text); background: var(--warn-tint); }
+.new-chat-limit p { margin: 3px 0 10px; font-size: var(--text-sm); }
+.new-chat-receipt { display: flex; align-items: center; gap: 10px; padding: 11px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface-inset); }
+.new-chat-receipt span { display: grid; gap: 2px; }
+.new-chat-receipt small { color: var(--muted); }
+.agent-binding { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 7px; padding: 6px 10px; border-bottom: 1px solid var(--border-soft); color: var(--muted); background: var(--surface-inset); font-size: 10px; }
+.agent-binding strong { color: var(--text); }
+.agent-binding span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-binding small { color: var(--quiet); }
+
+@media (max-width: 720px) {
+  .connected-agents-layout { grid-template-columns: minmax(0, 1fr); }
+  .connected-agents-onboarding { grid-template-columns: auto minmax(0, 1fr); }
+  .connected-agents-onboarding button { grid-column: 1 / -1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .connected-agent-dot { box-shadow: none; }
+  .settings-dialog-backdrop,
+  .new-chat-backdrop { backdrop-filter: none; }
+}

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -2091,10 +2091,10 @@ button:focus-visible {
 .connected-agent-inspector > button { display: inline-flex; align-items: center; justify-content: center; gap: 7px; min-height: 34px; padding: 0 11px; border: 1px solid var(--border-strong); border-radius: 9px; color: var(--text); background: var(--surface-raised); font: inherit; font-size: var(--text-xs); font-weight: var(--weight-bold); }
 .connected-agents-layout { display: grid; grid-template-columns: minmax(190px, .8fr) minmax(260px, 1.2fr); gap: 14px; margin-top: 16px; }
 .connected-agent-roster { display: grid; align-content: start; gap: 6px; }
-.connected-agent-roster > button { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 9px; width: 100%; padding: 11px; border: 1px solid transparent; border-radius: 11px; color: var(--text); text-align: left; background: transparent; }
-.connected-agent-roster > button:hover,
-.connected-agent-roster > button.selected { border-color: var(--border); background: var(--surface-raised); }
-.connected-agent-roster > button span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
+.connected-agent-roster > [role="listitem"] > button { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 9px; width: 100%; padding: 11px; border: 1px solid transparent; border-radius: 11px; color: var(--text); text-align: left; background: transparent; }
+.connected-agent-roster > [role="listitem"] > button:hover,
+.connected-agent-roster > [role="listitem"] > button.selected { border-color: var(--border); background: var(--surface-raised); }
+.connected-agent-roster > [role="listitem"] > button span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
 .connected-agent-roster small { overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .connected-agent-dot { width: 8px; height: 8px; border-radius: 999px; background: var(--warn); box-shadow: 0 0 0 3px var(--warn-tint); }
 .connected-agent-dot.ready { background: var(--green); box-shadow: 0 0 0 3px var(--green-tint); }

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -604,6 +604,65 @@ export interface DiagnosticsSnapshot {
 
 export type AgentConnectionState = 'online' | 'connecting' | 'offline' | 'reconnecting'
 export type AgentRecoveryState = 'ready' | 'recovering' | 'quarantined'
+export type ConnectedAgentProvider = 'hermes' | 'codex'
+
+export interface ConnectedAgentHealth {
+  state: string
+  label: string
+  providerAvailable: boolean
+  toolsAvailable: boolean
+  retryAfterSeconds: number | null
+}
+
+export interface ConnectedAgentSummary {
+  id: string
+  provider: ConnectedAgentProvider
+  displayName: string
+  avatarId: string
+  defaultModelId: string | null
+  defaultReasoningEffort: string | null
+  lifecycle: 'connected' | 'disconnected'
+  accountSummary: Record<string, string> | null
+  accountFingerprint: string | null
+  health: ConnectedAgentHealth
+  activeChats: number
+  lockedChats: number
+}
+
+export interface ConnectedAgentsSnapshot {
+  registryRevision: number
+  profileId: string
+  defaultConnectedAgentId: string | null
+  agents: ConnectedAgentSummary[]
+}
+
+export interface ConnectedAgentModelOption {
+  modelId: string
+  displayName: string
+  reasoningEfforts: string[]
+}
+
+export interface ConnectedAgentModelsSnapshot {
+  live: boolean
+  models: ConnectedAgentModelOption[]
+}
+
+export interface AgentChatSelection {
+  connectedAgentId: string
+  modelId: string
+  reasoningEffort: string
+  expectedProfileRevision: number
+  expectedAgentRegistryRevision: number
+  idempotencyKey: string
+  initialSelectedJobId?: string | null
+}
+
+export interface AgentConversationBinding {
+  connectedAgentId: string
+  provider: ConnectedAgentProvider
+  modelId: string
+  reasoningEffort: string
+}
 export type ConversationEntryType = 'user_message' | 'turn' | 'activity' | 'assistant_message' | 'status' | 'error'
 export type ConversationEntryState = 'queued' | 'working' | 'waiting' | 'completed' | 'failed' | 'interrupted'
 
@@ -646,6 +705,8 @@ export interface AgentConversationSnapshot {
   recoveryState: AgentRecoveryState
   latestEventId: number
   jobContext: AgentSessionJobContext
+  binding: AgentConversationBinding | null
+  availability: { state: 'ready' | 'locked'; reason: string | null }
 }
 
 export interface AgentSessionSummary {
@@ -658,6 +719,8 @@ export interface AgentSessionSummary {
   recoveryState: AgentRecoveryState
   latestEventId: number
   jobContext: AgentSessionJobContext
+  binding: AgentConversationBinding | null
+  availability: { state: 'ready' | 'locked'; reason: string | null }
 }
 
 export interface AgentTurnMutation {
@@ -713,13 +776,26 @@ export interface JobOsRendererBridge {
   careerProfile: CareerProfileBridge
   agent: {
     list: () => Promise<AgentSessionSummary[]>
-    create: (initialSelectedJobId?: string | null) => Promise<AgentConversationSnapshot>
+    create: (selection?: AgentChatSelection) => Promise<AgentConversationSnapshot>
     get: (conversationId: string) => Promise<AgentConversationSnapshot>
     archive: (conversationId: string) => Promise<void>
     send: (conversationId: string, text: string, idempotencyKey: string) => Promise<AgentTurnMutation>
     cancel: (conversationId: string, turnId: string) => Promise<AgentTurnMutation>
     retry: (conversationId: string, turnId: string, idempotencyKey: string) => Promise<AgentTurnMutation>
     subscribe: (listener: (update: AgentSessionStreamUpdate) => void) => () => void
+  }
+  connectedAgents: {
+    list: () => Promise<ConnectedAgentsSnapshot>
+    models: (agentId: string) => Promise<ConnectedAgentModelsSnapshot>
+    test: (agentId: string) => Promise<ConnectedAgentSummary>
+    createCodex: (displayName: string, avatarId: string, expectedRegistryRevision: number, idempotencyKey: string) => Promise<ConnectedAgentSummary>
+    update: (agent: ConnectedAgentSummary, modelId: string | null, reasoningEffort: string | null, expectedRegistryRevision: number, idempotencyKey: string) => Promise<ConnectedAgentSummary>
+    setDefault: (profileId: string, agentId: string | null, expectedRevision: number, idempotencyKey: string) => Promise<number>
+    impact: (agentId: string) => Promise<{ activeChats: number; lockedChats: number; defaultProfileIds: string[] }>
+    disconnect: (agentId: string, expectedRegistryRevision: number, idempotencyKey: string) => Promise<ConnectedAgentSummary>
+    startAuth: (agentId: string, mode: 'connect' | 'reconnect' | 'replace', expectedAccountFingerprint: string | null) => Promise<{ transactionId: string; status: string; userCode: string | null; verificationUrl: string | null; expiresAt: string }>
+    readAuth: (transactionId: string) => Promise<{ transactionId: string; status: string; userCode: string | null; verificationUrl: string | null; expiresAt: string; errorCode: string | null }>
+    cancelAuth: (transactionId: string) => Promise<void>
   }
   jobs: {
     getState: () => Promise<JobWorkspaceSnapshot>

--- a/docs/implementation/connected-agents-codex-plan.md
+++ b/docs/implementation/connected-agents-codex-plan.md
@@ -1,9 +1,11 @@
 # Connected Agents and ChatGPT/Codex Implementation Plan
 
-- **Status:** Build-ready specification
+- **Status:** Active implementation — Phases 0–5 delivered; Phase 6 verified and awaiting merge; Phases 7–8 remain
 - **Wayfinder:** [#100](https://github.com/cobibean/job-os/issues/100)
 - **Planning ticket:** [#109](https://github.com/cobibean/job-os/issues/109)
 - **Verified source baseline:** `ee542e9d7c19d5c5a16bb15cb9e1072121415ff1` on `origin/main`, verified 2026-08-23
+- **Progress update (2026-08-25):** Phases 0–5 are merged and verified. Phase 6 adds the Connected Agents roster/inspector, live provider model defaults, device-code and disconnect flows, immutable New Chat selection, readable locked history, and five-chat archive recovery. Shipment receipts remain on Issues [#111–#117](https://github.com/cobibean/job-os/issues/117).
+
 **Goal:** Let a JobOS user connect and manage multiple agent identities, choose a profile default, and create a chat permanently owned by a selected Hermes or ChatGPT/Codex agent and supported model—without weakening JobOS context, tools, recovery, privacy, or existing Hermes behavior.
 
 **Architecture:** JobOS owns installation-global Connected Agent identities, per-profile defaults, immutable chat bindings, trusted turn envelopes, normalized events, and local conversation history. Thin provider adapters connect the API-owned runtime router to Hermes or a host-local, version-pinned Codex App Server. Device-code authentication and credentials remain on the runtime host behind replaceable auth/vault interfaces.

--- a/packages/contracts/openapi.json
+++ b/packages/contracts/openapi.json
@@ -2537,6 +2537,21 @@
             "title": "Agents",
             "type": "array"
           },
+          "default_connected_agent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Connected Agent Id"
+          },
+          "profile_id": {
+            "title": "Profile Id",
+            "type": "string"
+          },
           "registry_revision": {
             "title": "Registry Revision",
             "type": "integer"
@@ -2544,6 +2559,8 @@
         },
         "required": [
           "registry_revision",
+          "profile_id",
+          "default_connected_agent_id",
           "agents"
         ],
         "title": "ConnectedAgentListResponse",
@@ -3069,6 +3086,19 @@
             ],
             "title": "Active Turn"
           },
+          "availability": {
+            "$ref": "#/components/schemas/ConversationAvailabilityResponse"
+          },
+          "binding": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConversationBindingResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "connection": {
             "$ref": "#/components/schemas/ConnectionResponse"
           },
@@ -3114,7 +3144,9 @@
           "recovery_state",
           "latest_event_id",
           "created_at",
-          "job_context"
+          "job_context",
+          "binding",
+          "availability"
         ],
         "title": "ConversationSummary",
         "type": "object"

--- a/packages/contracts/src/generated/types.gen.ts
+++ b/packages/contracts/src/generated/types.gen.ts
@@ -1343,6 +1343,14 @@ export type ConnectedAgentListResponse = {
      */
     agents: Array<ConnectedAgentPublic>;
     /**
+     * Default Connected Agent Id
+     */
+    default_connected_agent_id: string | null;
+    /**
+     * Profile Id
+     */
+    profile_id: string;
+    /**
      * Registry Revision
      */
     registry_revision: number;
@@ -1638,6 +1646,8 @@ export type ConversationSummary = {
     active_turn: {
         [key: string]: unknown;
     } | null;
+    availability: ConversationAvailabilityResponse;
+    binding: ConversationBindingResponse | null;
     connection: ConnectionResponse;
     /**
      * Conversation Id

--- a/services/api/jobos_api/agent_gateway.py
+++ b/services/api/jobos_api/agent_gateway.py
@@ -178,12 +178,14 @@ class AgentRuntimeRouter:
             if isinstance(raw_sequences, dict)
             else {}
         )
-        provider = binding.provider or self._compatibility_provider
+        provider = cast(
+            ConnectedAgentProvider, binding.provider or self._compatibility_provider
+        )
         factory = (
             self._adapters.get((provider, binding.connected_agent_id))
             if binding.connected_agent_id is not None
-            else self._adapters.get(provider)
-        )
+            else None
+        ) or self._adapters.get(provider)
         if factory is None:
             raise ConnectionError("Connected Agent provider is unavailable")
         return _RoutedAgentGateway(

--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -168,9 +168,10 @@ from jobos_api.connected_agents import (
     ConnectedAgentService,
     CreateConnectedAgentRequest,
     DisconnectConnectedAgentRequest,
+    HermesConnectedAgentRuntime,
+    ProviderConnectedAgentRuntime,
     SetDefaultConnectedAgentRequest,
     SetDefaultConnectedAgentResponse,
-    UnavailableConnectedAgentRuntime,
     UpdateConnectedAgentRequest,
 )
 from jobos_api.conversation_manager import ConversationListResponse, ConversationManager
@@ -616,6 +617,7 @@ def create_app(
     )
     installation_profiles = InstallationProfileRegistry(settings.installation_registry_path)
     codex_client: CodexAppServerProcess | None = None
+    codex_vault: CodexCredentialVault | None = None
     selected_connected_agent_runtime = connected_agent_runtime
     selected_auth_broker = connected_agent_auth_broker
     if settings.codex_app_server_path is not None:
@@ -637,13 +639,33 @@ def create_app(
             selected_connected_agent_runtime = CodexConnectedAgentRuntime(
                 codex_client, codex_vault
             )
-        if selected_auth_broker is None:
-            selected_auth_broker = CodexAuthFlowBroker(
-                codex_client, codex_vault, installation_profiles
+
+    if selected_connected_agent_runtime is None:
+        provider_controls: dict[str, ConnectedAgentRuntimeControl] = {
+            "hermes": HermesConnectedAgentRuntime(
+                configured=(
+                    agent_gateway is not None
+                    or agent_gateway_factory is not None
+                    or all(
+                        (
+                            settings.hermes_dashboard_url,
+                            settings.hermes_dashboard_token,
+                            settings.hermes_job_hunter_cwd,
+                        )
+                    )
+                )
             )
+        }
+        if codex_client is not None and codex_vault is not None:
+            provider_controls["codex"] = CodexConnectedAgentRuntime(
+                codex_client, codex_vault
+            )
+        selected_connected_agent_runtime = ProviderConnectedAgentRuntime(
+            cast(dict[Any, ConnectedAgentRuntimeControl], provider_controls)
+        )
     connected_agents = ConnectedAgentService(
         installation_profiles,
-        selected_connected_agent_runtime or UnavailableConnectedAgentRuntime(),
+        selected_connected_agent_runtime,
         profile_id=settings.installation_profile_id,
         state_store=state_store,
     )
@@ -752,6 +774,22 @@ def create_app(
         runtime_adapters,
         profile_id=settings.installation_profile_id,
     )
+
+    async def connected_agent_binding_unavailability(
+        agent_id: str,
+        provider: str,
+        model_id: str,
+        effort: str,
+        fingerprint: str | None,
+    ) -> str | None:
+        return await connected_agents.binding_unavailability_reason(
+            agent_id=agent_id,
+            provider=provider,
+            model_id=model_id,
+            reasoning_effort=effort,
+            account_fingerprint=fingerprint,
+        )
+
     conversation_manager = ConversationManager(
         state_store,
         runtime_router,
@@ -765,7 +803,19 @@ def create_app(
         career_profile_agent_id=(
             settings.career_profile_agent_id if settings.career_profile_enabled else None
         ),
+        connected_agent_binding_unavailability=connected_agent_binding_unavailability,
     )
+    if codex_client is not None and codex_vault is not None and selected_auth_broker is None:
+        async def lock_replaced_account_chats(agent_id: str) -> None:
+            connected_agents.lock_chats_for_account_replacement(agent_id)
+            await conversation_manager.detach_connected_agent(agent_id)
+
+        selected_auth_broker = CodexAuthFlowBroker(
+            codex_client,
+            codex_vault,
+            installation_profiles,
+            on_account_replaced=lock_replaced_account_chats,
+        )
     browser_capabilities = capability_broker or CapabilityBroker()
     browser_command_locks: dict[tuple[str, str], asyncio.Lock] = {}
     browser_command_lock_references: dict[tuple[str, str], int] = {}
@@ -2865,6 +2915,51 @@ def create_app(
         except ConversationNotFound as error:
             raise HTTPException(status_code=404, detail=str(error)) from error
 
+    async def ready_conversation_service(conversation_id: str, identity: DeviceIdentity):
+        service = conversation_service(conversation_id, identity)
+        binding = service.store.binding()
+        if binding["binding_state"] != "sealed":
+            return service
+        if binding["creation_state"] != "ready":
+            reason = str(binding["lock_reason"] or "AGENT_PROVIDER_UNAVAILABLE")
+            raise HTTPException(
+                status_code=409,
+                detail={"code": reason, "message": reason, "retryable": False},
+            )
+        reason = await connected_agents.binding_unavailability_reason(
+            agent_id=str(binding["connected_agent_id"]),
+            provider=str(binding["provider"]),
+            model_id=str(binding["model_id"]),
+            reasoning_effort=str(binding["reasoning_effort"]),
+            account_fingerprint=(
+                str(binding["connection_account_fingerprint"])
+                if binding["connection_account_fingerprint"] is not None
+                else None
+            ),
+        )
+        if reason is not None:
+            raise HTTPException(
+                status_code=409,
+                detail={"code": reason, "message": reason, "retryable": False},
+            )
+        return await conversation_manager.ensure_started(conversation_id)
+
+    async def mutation_ready_conversation_service(
+        conversation_id: str,
+        identity: DeviceIdentity,
+        *,
+        command_name: str,
+        idempotency_key: str,
+    ):
+        service = conversation_service(conversation_id, identity)
+        if service.store.has_turn_idempotency_record(
+            actor_id=identity.device_id,
+            command_name=command_name,
+            idempotency_key=idempotency_key,
+        ):
+            return service
+        return await ready_conversation_service(conversation_id, identity)
+
     def validated_turn_id(turn_id: str) -> str:
         if not re.fullmatch(r"turn_[A-Za-z0-9_-]{1,128}", turn_id):
             raise HTTPException(status_code=422, detail="Invalid turn ID")
@@ -3098,10 +3193,10 @@ def create_app(
             raise HTTPException(status_code=409, detail=str(error)) from error
 
     @app.get("/v1/conversations", tags=["agent"])
-    def conversations_list(
+    async def conversations_list(
         identity: Annotated[DeviceIdentity, Depends(authenticated_device)],
     ) -> ConversationListResponse:
-        return conversation_manager.list(owner_device_id=identity.device_id)
+        return await conversation_manager.list(owner_device_id=identity.device_id)
 
     @app.post("/v1/conversations", tags=["agent"], status_code=201)
     async def conversation_create(
@@ -3346,7 +3441,13 @@ def create_app(
         if settings.career_profile_enabled:
             require_career_profile_owner(identity)
         try:
-            return await conversation_service(conversation_id, identity).send(
+            service = await mutation_ready_conversation_service(
+                conversation_id,
+                identity,
+                command_name="conversation.message.submit",
+                idempotency_key=command.idempotency_key,
+            )
+            return await service.send(
                 command,
                 actor_id=identity.device_id,
                 context=conversation_context(conversation_id, identity),
@@ -3383,7 +3484,13 @@ def create_app(
         if settings.career_profile_enabled:
             require_career_profile_owner(identity)
         try:
-            result = await conversation_service(conversation_id, identity).retry(
+            service = await mutation_ready_conversation_service(
+                conversation_id,
+                identity,
+                command_name="conversation.turn.retry",
+                idempotency_key=command.idempotency_key,
+            )
+            result = await service.retry(
                 validated_turn_id(turn_id), command, actor_id=identity.device_id
             )
         except ConversationBusy as error:

--- a/services/api/jobos_api/connected_agent_auth.py
+++ b/services/api/jobos_api/connected_agent_auth.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Literal, Protocol
@@ -244,11 +244,13 @@ class CodexAuthFlowBroker:
         registry: InstallationProfileRegistry,
         *,
         now: Callable[[], datetime] = lambda: datetime.now(UTC),
+        on_account_replaced: Callable[[str], Awaitable[None] | None] | None = None,
     ) -> None:
         self.client = client
         self.vault = vault
         self.registry = registry
         self.now = now
+        self.on_account_replaced = on_account_replaced or (lambda _agent_id: None)
         self._transactions: dict[str, _PendingAuth] = {}
         self._lock = asyncio.Lock()
         self.client.subscribe(self._notification)
@@ -452,6 +454,10 @@ class CodexAuthFlowBroker:
                 status="failed",
                 error_code="AGENT_PROVIDER_UNAVAILABLE",
             )
+        if pending.mode == "replace":
+            replacement = self.on_account_replaced(pending.public.agent_id)
+            if replacement is not None:
+                await replacement
         plan_type = account.get("planType")
         summary = {
             "display_name": "ChatGPT",
@@ -463,7 +469,8 @@ class CodexAuthFlowBroker:
             runtime_namespace=pending.runtime_namespace,
             credential_reference=vault_ref,
             account_summary=summary,
-            # Codex v0.144.4 exposes no stable opaque account ID. Never fingerprint email.
+            # Codex exposes no stable opaque account ID. Persist null and keep
+            # replacement safety through explicit confirmation plus durable chat locks.
             account_fingerprint=None,
             idempotency_key=pending.public.transaction_id,
             now=self.now(),

--- a/services/api/jobos_api/connected_agents.py
+++ b/services/api/jobos_api/connected_agents.py
@@ -45,6 +45,71 @@ class UnavailableConnectedAgentRuntime:
         return {"verified": False}
 
 
+class HermesConnectedAgentRuntime:
+    """Expose the fixed model owned by the configured Hermes profile."""
+
+    def __init__(self, *, configured: bool) -> None:
+        self.configured = configured
+
+    async def inspect_connection(self, agent: ConnectedAgentRecord) -> dict[str, object]:
+        available = (
+            self.configured
+            and agent.provider == "hermes"
+            and agent.connection_config is not None
+        )
+        return {
+            "state": "connected" if available else "unavailable",
+            "label": "Connected" if available else "Runtime unavailable",
+            "provider_available": available,
+            "tools_available": available,
+            "retry_after_seconds": None,
+        }
+
+    async def list_models(self, agent: ConnectedAgentRecord) -> dict[str, object]:
+        if (
+            not self.configured
+            or agent.provider != "hermes"
+            or agent.default_model_id is None
+            or agent.default_reasoning_effort is None
+        ):
+            return {"live": False, "models": []}
+        return {
+            "live": True,
+            "models": [
+                {
+                    "model_id": agent.default_model_id,
+                    "display_name": agent.default_model_id,
+                    "reasoning_efforts": [agent.default_reasoning_effort],
+                }
+            ],
+        }
+
+    async def disconnect(self, agent: ConnectedAgentRecord) -> dict[str, object]:
+        return {"verified": agent.provider == "hermes"}
+
+
+class ProviderConnectedAgentRuntime:
+    """Route agent health and model operations to the owning provider control."""
+
+    def __init__(
+        self,
+        controls: dict[Literal["hermes", "codex"], ConnectedAgentRuntimeControl],
+    ) -> None:
+        self.controls = dict(controls)
+
+    def _control(self, agent: ConnectedAgentRecord) -> ConnectedAgentRuntimeControl:
+        return self.controls.get(agent.provider, UnavailableConnectedAgentRuntime())
+
+    async def inspect_connection(self, agent: ConnectedAgentRecord) -> dict[str, object]:
+        return await self._control(agent).inspect_connection(agent)
+
+    async def list_models(self, agent: ConnectedAgentRecord) -> dict[str, object]:
+        return await self._control(agent).list_models(agent)
+
+    async def disconnect(self, agent: ConnectedAgentRecord) -> dict[str, object]:
+        return await self._control(agent).disconnect(agent)
+
+
 class ConnectedAgentModel(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -76,6 +141,8 @@ class ConnectedAgentPublic(ConnectedAgentModel):
 
 class ConnectedAgentListResponse(ConnectedAgentModel):
     registry_revision: int
+    profile_id: str
+    default_connected_agent_id: str | None
     agents: list[ConnectedAgentPublic]
 
 
@@ -213,8 +280,11 @@ class ConnectedAgentService:
 
     async def list(self) -> ConnectedAgentListResponse:
         data = self.registry.load()
+        profile = next(item for item in data.profiles if item.profile_id == self.profile_id)
         return ConnectedAgentListResponse(
             registry_revision=data.registry_revision,
+            profile_id=profile.profile_id,
+            default_connected_agent_id=profile.default_connected_agent_id,
             agents=[await self.public(record) for record in data.connected_agents],
         )
 
@@ -226,6 +296,48 @@ class ConnectedAgentService:
         if record.lifecycle == "disconnected":
             return ConnectedAgentModelsResponse(live=False, models=[])
         return ConnectedAgentModelsResponse.model_validate(await self.runtime.list_models(record))
+
+    async def binding_unavailability_reason(
+        self,
+        *,
+        agent_id: str,
+        provider: str,
+        model_id: str,
+        reasoning_effort: str,
+        account_fingerprint: str | None,
+    ) -> str | None:
+        """Fail closed when a sealed chat no longer matches its live agent binding."""
+        try:
+            record = self._record(agent_id)
+        except InstallationProfileNotFound:
+            return "AGENT_NOT_CONFIGURED"
+        if record.lifecycle != "connected":
+            return "AGENT_DISCONNECTED"
+        if record.provider != provider:
+            return "AGENT_PROVIDER_CHANGED"
+        if record.account_fingerprint != account_fingerprint:
+            return "AUTH_ACCOUNT_REPLACEMENT_REQUIRED"
+        try:
+            health = ConnectedAgentHealth.model_validate(
+                await self.runtime.inspect_connection(record)
+            )
+            if not health.provider_available:
+                return "AGENT_PROVIDER_UNAVAILABLE"
+            if not health.tools_available:
+                return "AGENT_TOOLS_UNAVAILABLE"
+            catalog = ConnectedAgentModelsResponse.model_validate(
+                await self.runtime.list_models(record)
+            )
+        except Exception:
+            return "AGENT_PROVIDER_UNAVAILABLE"
+        option = next((item for item in catalog.models if item.model_id == model_id), None)
+        if (
+            not catalog.live
+            or option is None
+            or reasoning_effort not in option.reasoning_efforts
+        ):
+            return "MODEL_UNAVAILABLE"
+        return None
 
     async def _validate_defaults(
         self,
@@ -345,6 +457,20 @@ class ConnectedAgentService:
             ],
             **totals,
         )
+
+    def lock_chats_for_account_replacement(self, agent_id: str) -> None:
+        data = self.registry.load()
+        for profile in data.profiles:
+            path = (
+                profile.anchored_runtime.state_db_path
+                if profile.anchored_runtime is not None
+                else managed_profile_paths(
+                    self.registry.installation_root, profile.profile_id
+                ).state_db_path
+            )
+            JobOsStateStore.lock_connected_agent_chats_at(
+                path, agent_id, "AUTH_ACCOUNT_REPLACEMENT_REQUIRED"
+            )
 
     async def disconnect(
         self, agent_id: str, command: DisconnectConnectedAgentRequest

--- a/services/api/jobos_api/conversation_manager.py
+++ b/services/api/jobos_api/conversation_manager.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
-from typing import Literal
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from typing import Any, Literal
 
 from pydantic import Field
 
@@ -11,9 +13,12 @@ from .agent_gateway import (
     DefinitiveSessionCreationError,
 )
 from .career_profile_context import CareerProfileContextStore
+from .conversation_store import ConversationStore
 from .conversations import (
     BoundConversationResponse,
     ConnectionResponse,
+    ConversationAvailabilityResponse,
+    ConversationBindingResponse,
     ConversationJobContext,
     ConversationModel,
     ConversationResponse,
@@ -38,6 +43,8 @@ class ConversationSummary(ConversationModel):
     latest_event_id: int
     created_at: str
     job_context: ConversationJobContext
+    binding: ConversationBindingResponse | None
+    availability: ConversationAvailabilityResponse
 
 
 class ConversationListResponse(ConversationModel):
@@ -54,6 +61,10 @@ class ConversationManager:
         career_profile_principal: str | None = None,
         career_profile_context: CareerProfileContextStore | None = None,
         career_profile_agent_id: str | None = None,
+        connected_agent_binding_unavailability: Callable[
+            [str, str, str, str, str | None], Awaitable[str | None]
+        ]
+        | None = None,
     ) -> None:
         self.store = store
         self.gateway_factory = gateway_factory
@@ -61,12 +72,21 @@ class ConversationManager:
         self.career_profile_principal = career_profile_principal
         self.career_profile_context = career_profile_context
         self.career_profile_agent_id = career_profile_agent_id
+        self.connected_agent_binding_unavailability = connected_agent_binding_unavailability
         self._services: dict[str, ConversationService] = {}
+        self._started_services: set[str] = set()
         self._lifecycle_lock = asyncio.Lock()
 
     async def start(self) -> None:
         async with self._lifecycle_lock:
             pending: list[tuple[dict[str, object], ConversationService]] = []
+            availability_checks: list[
+                tuple[
+                    dict[str, object],
+                    ConversationService,
+                    tuple[str, str, str, str, str | None],
+                ]
+            ] = []
             for summary in self.store.list_active_conversations():
                 conversation_id = str(summary["conversation_id"])
                 try:
@@ -74,23 +94,64 @@ class ConversationManager:
                 except Exception:
                     continue
                 self._services[conversation_id] = service
+                binding = service.store.binding()
+                if binding["binding_state"] == "sealed":
+                    if binding["creation_state"] != "ready":
+                        continue
+                    if self.connected_agent_binding_unavailability is not None:
+                        availability_checks.append(
+                            (
+                                summary,
+                                service,
+                                (
+                                    str(binding["connected_agent_id"]),
+                                    str(binding["provider"]),
+                                    str(binding["model_id"]),
+                                    str(binding["reasoning_effort"]),
+                                    (
+                                        str(binding["connection_account_fingerprint"])
+                                        if binding["connection_account_fingerprint"] is not None
+                                        else None
+                                    ),
+                                ),
+                            )
+                        )
+                        continue
                 pending.append((summary, service))
+        if availability_checks and self.connected_agent_binding_unavailability is not None:
+            reasons = await asyncio.gather(
+                *(
+                    self.connected_agent_binding_unavailability(*arguments)
+                    for _, _, arguments in availability_checks
+                ),
+                return_exceptions=True,
+            )
+            pending.extend(
+                (summary, service)
+                for (summary, service, _), reason in zip(
+                    availability_checks, reasons, strict=True
+                )
+                if reason is None
+            )
         if pending:
             results = await asyncio.gather(
                 *(service.start() for _, service in pending), return_exceptions=True
             )
             async with self._lifecycle_lock:
                 for (summary, service), result in zip(pending, results, strict=True):
-                    if not isinstance(result, BaseException):
-                        continue
                     conversation_id = str(summary["conversation_id"])
+                    if not isinstance(result, BaseException):
+                        self._started_services.add(conversation_id)
+                        continue
                     self._services.pop(conversation_id, None)
+                    self._started_services.discard(conversation_id)
                     await asyncio.gather(service.close(), return_exceptions=True)
 
     async def close(self) -> None:
         async with self._lifecycle_lock:
             services = list(self._services.values())
             self._services.clear()
+            self._started_services.clear()
         if services:
             results = await asyncio.gather(
                 *(service.close() for service in services), return_exceptions=True
@@ -98,6 +159,34 @@ class ConversationManager:
             for result in results:
                 if isinstance(result, BaseException):
                     raise result
+
+    async def detach_connected_agent(self, agent_id: str) -> None:
+        """Stop active work and detach services before an account replacement."""
+        async with self._lifecycle_lock:
+            affected = [
+                (conversation_id, service)
+                for conversation_id, service in self._services.items()
+                if service.store.binding().get("connected_agent_id") == agent_id
+            ]
+            for conversation_id, _ in affected:
+                self._started_services.discard(conversation_id)
+        for _, service in affected:
+            active_turn = service.snapshot().active_turn
+            if active_turn is not None:
+                with suppress(Exception):
+                    await service.cancel(str(active_turn["turn_id"]))
+            with suppress(Exception):
+                await service.close()
+
+    async def ensure_started(self, conversation_id: str) -> ConversationService:
+        async with self._lifecycle_lock:
+            service = self._services.get(conversation_id)
+            if service is None:
+                raise ConversationNotFound("Conversation not found")
+            if conversation_id not in self._started_services:
+                await service.start()
+                self._started_services.add(conversation_id)
+            return service
 
     def _make_service(self, conversation_id: str) -> ConversationService:
         scoped_store = self.store.conversation_store(conversation_id)
@@ -118,13 +207,95 @@ class ConversationManager:
             career_profile_agent_id=self.career_profile_agent_id,
         )
 
-    def list(self, *, owner_device_id: str) -> ConversationListResponse:
+    async def list(self, *, owner_device_id: str) -> ConversationListResponse:
         conversations: list[ConversationSummary] = []
+        prepared: list[tuple[dict[str, Any], ConversationStore, dict[str, object]]] = []
+        probe_inputs: dict[tuple[str, str, str, str, str | None], None] = {}
         for value in self.store.list_active_conversations(owner_device_id=owner_device_id):
+            scoped = self.store.conversation_store(str(value["conversation_id"]))
+            durable_binding = scoped.binding()
+            prepared.append((value, scoped, durable_binding))
+            if (
+                durable_binding["binding_state"] == "sealed"
+                and self.connected_agent_binding_unavailability is not None
+            ):
+                probe_inputs[
+                    (
+                        str(durable_binding["connected_agent_id"]),
+                        str(durable_binding["provider"]),
+                        str(durable_binding["model_id"]),
+                        str(durable_binding["reasoning_effort"]),
+                        (
+                            str(durable_binding["connection_account_fingerprint"])
+                            if durable_binding["connection_account_fingerprint"] is not None
+                            else None
+                        ),
+                    )
+                ] = None
+        probe_keys = list(probe_inputs)
+        probe_reasons = (
+            await asyncio.gather(
+                *(self.connected_agent_binding_unavailability(*key) for key in probe_keys)
+            )
+            if probe_keys and self.connected_agent_binding_unavailability is not None
+            else []
+        )
+        reason_by_binding = dict(zip(probe_keys, probe_reasons, strict=True))
+
+        for value, scoped, durable_binding in prepared:
             conversation_id = str(value["conversation_id"])
             service = self._services.get(conversation_id)
+            sealed = durable_binding["binding_state"] == "sealed"
+            binding_key = (
+                str(durable_binding["connected_agent_id"]),
+                str(durable_binding["provider"]),
+                str(durable_binding["model_id"]),
+                str(durable_binding["reasoning_effort"]),
+                (
+                    str(durable_binding["connection_account_fingerprint"])
+                    if durable_binding["connection_account_fingerprint"] is not None
+                    else None
+                ),
+            )
+            binding = (
+                ConversationBindingResponse.model_validate(
+                    {
+                        key: durable_binding[key]
+                        for key in (
+                            "connected_agent_id",
+                            "provider",
+                            "model_id",
+                            "reasoning_effort",
+                            "binding_state",
+                        )
+                    }
+                )
+                if sealed
+                else None
+            )
+            live_reason = reason_by_binding.get(binding_key) if sealed else None
+            availability = ConversationAvailabilityResponse(
+                state=(
+                    "ready"
+                    if (
+                        sealed
+                        and durable_binding["creation_state"] == "ready"
+                        and live_reason is None
+                    )
+                    else "locked"
+                ),
+                reason=(
+                    live_reason
+                    if sealed and live_reason is not None
+                    else
+                    str(durable_binding["lock_reason"])
+                    if durable_binding["lock_reason"] is not None
+                    else None
+                    if sealed
+                    else "LEGACY_BINDING_UNAVAILABLE"
+                ),
+            )
             if service is None:
-                scoped = self.store.conversation_store(conversation_id)
                 durable = scoped.conversation_snapshot()
                 recovery_turn_id = scoped.recovery_turn_id()
                 active_turn = durable.get("active_turn")
@@ -145,6 +316,8 @@ class ConversationManager:
                         latest_event_id=int(durable["latest_event_id"]),
                         created_at=str(durable["created_at"]),
                         job_context=ConversationJobContext.model_validate(durable["job_context"]),
+                        binding=binding,
+                        availability=availability,
                     )
                 )
                 continue
@@ -160,6 +333,8 @@ class ConversationManager:
                     latest_event_id=snapshot.latest_event_id,
                     created_at=snapshot.created_at,
                     job_context=snapshot.job_context,
+                    binding=binding,
+                    availability=availability,
                 )
             )
         return ConversationListResponse(conversations=conversations)
@@ -177,8 +352,10 @@ class ConversationManager:
                 service = self._make_service(conversation_id)
                 self._services[conversation_id] = service
                 await service.start()
+                self._started_services.add(conversation_id)
             except Exception:
                 self._services.pop(conversation_id, None)
+                self._started_services.discard(conversation_id)
                 if service is not None:
                     await asyncio.gather(service.close(), return_exceptions=True)
                 self.store.discard_failed_conversation(conversation_id, actor_id=actor_id)
@@ -219,11 +396,13 @@ class ConversationManager:
                     service = self._make_service(conversation_id)
                     self._services[conversation_id] = service
                     await service.start()
+                    self._started_services.add(conversation_id)
                 return self._bound_snapshot(service, agent_summary), False
             try:
                 service = self._make_service(conversation_id)
                 self._services[conversation_id] = service
                 await service.start()
+                self._started_services.add(conversation_id)
                 provider_session_id, _ = await service.gateway.create_or_resume_conversation(None)
                 service.store.complete_provisioning(provider_session_id)
             except AmbiguousDeliveryError:
@@ -232,6 +411,7 @@ class ConversationManager:
                 service.store.lock_provisioning()
             except DefinitiveSessionCreationError as error:
                 self._services.pop(conversation_id, None)
+                self._started_services.discard(conversation_id)
                 if service is not None:
                     await asyncio.gather(service.close(), return_exceptions=True)
                 self.store.discard_provisioning_conversation(
@@ -271,8 +451,14 @@ class ConversationManager:
             service = self._services.get(conversation_id)
             if service is None:
                 service = self._make_service(conversation_id)
+                binding = service.store.binding()
+                if binding["creation_state"] != "ready":
+                    response = self._bound_snapshot(service, agent_summary)
+                    await service.close()
+                    return response
                 self._services[conversation_id] = service
                 await service.start()
+                self._started_services.add(conversation_id)
         return self._bound_snapshot(service, agent_summary)
 
     @staticmethod
@@ -306,6 +492,7 @@ class ConversationManager:
             service = self.get(conversation_id, owner_device_id=actor_id)
             self.store.archive_conversation(conversation_id, actor_id=actor_id)
             self._services.pop(conversation_id, None)
+            self._started_services.discard(conversation_id)
             await service.close()
 
     def get(

--- a/services/api/jobos_api/conversation_manager.py
+++ b/services/api/jobos_api/conversation_manager.py
@@ -235,12 +235,16 @@ class ConversationManager:
         probe_keys = list(probe_inputs)
         probe_reasons = (
             await asyncio.gather(
-                *(self.connected_agent_binding_unavailability(*key) for key in probe_keys)
+                *(self.connected_agent_binding_unavailability(*key) for key in probe_keys),
+                return_exceptions=True,
             )
             if probe_keys and self.connected_agent_binding_unavailability is not None
             else []
         )
-        reason_by_binding = dict(zip(probe_keys, probe_reasons, strict=True))
+        reason_by_binding = {
+            key: "AGENT_PROVIDER_UNAVAILABLE" if isinstance(reason, BaseException) else reason
+            for key, reason in zip(probe_keys, probe_reasons, strict=True)
+        }
 
         for value, scoped, durable_binding in prepared:
             conversation_id = str(value["conversation_id"])
@@ -274,24 +278,18 @@ class ConversationManager:
                 else None
             )
             live_reason = reason_by_binding.get(binding_key) if sealed else None
+            creation_ready = durable_binding["creation_state"] == "ready"
+            availability_ready = creation_ready and (not sealed or live_reason is None)
             availability = ConversationAvailabilityResponse(
-                state=(
-                    "ready"
-                    if (
-                        sealed
-                        and durable_binding["creation_state"] == "ready"
-                        and live_reason is None
-                    )
-                    else "locked"
-                ),
+                state="ready" if availability_ready else "locked",
                 reason=(
-                    live_reason
+                    None
+                    if availability_ready
+                    else live_reason
                     if sealed and live_reason is not None
                     else
                     str(durable_binding["lock_reason"])
                     if durable_binding["lock_reason"] is not None
-                    else None
-                    if sealed
                     else "LEGACY_BINDING_UNAVAILABLE"
                 ),
             )

--- a/services/api/jobos_api/conversation_store.py
+++ b/services/api/jobos_api/conversation_store.py
@@ -302,19 +302,6 @@ class ConversationStore:
         with connect_sqlite(self._path) as connection:
             connection.execute("BEGIN IMMEDIATE")
             conversation = self._require_active(connection)
-            is_legacy_compatibility_chat = (
-                conversation["connected_agent_id"] is None
-                and conversation["creation_state"] == "locked"
-                and conversation["lock_reason"] is None
-            )
-            if not is_legacy_compatibility_chat and (
-                conversation["creation_state"] != "ready"
-                or conversation["lock_reason"] is not None
-            ):
-                connection.rollback()
-                raise ConversationBusy(
-                    str(conversation["lock_reason"] or "Connected Agent provisioning is incomplete")
-                )
             prior = connection.execute(
                 "SELECT request_hash, result_json FROM job_events WHERE actor_id = ? AND target_resource = ? AND command_name = ? AND idempotency_key = ?",
                 (actor_id, target, command, idempotency_key),
@@ -328,6 +315,19 @@ class ConversationStore:
                 result = json.loads(str(prior[1]))
                 connection.rollback()
                 return {**result, "created": False}
+            is_legacy_compatibility_chat = (
+                conversation["connected_agent_id"] is None
+                and conversation["creation_state"] == "locked"
+                and conversation["lock_reason"] is None
+            )
+            if not is_legacy_compatibility_chat and (
+                conversation["creation_state"] != "ready"
+                or conversation["lock_reason"] is not None
+            ):
+                connection.rollback()
+                raise ConversationBusy(
+                    str(conversation["lock_reason"] or "Connected Agent provisioning is incomplete")
+                )
             source = None
             if source_turn_id:
                 source = connection.execute(
@@ -514,6 +514,21 @@ class ConversationStore:
         return {**result, "created": True}
 
     create_conversation_turn = create_turn
+
+    def has_turn_idempotency_record(
+        self, *, actor_id: str, command_name: str, idempotency_key: str
+    ) -> bool:
+        with connect_sqlite(f"file:{self._path}?mode=ro", uri=True) as connection:
+            row = connection.execute(
+                "SELECT 1 FROM job_events WHERE actor_id = ? AND target_resource = ? AND command_name = ? AND idempotency_key = ? LIMIT 1",
+                (
+                    actor_id,
+                    f"conversation/{self.conversation_id}",
+                    command_name,
+                    idempotency_key,
+                ),
+            ).fetchone()
+        return row is not None
 
     def bound_career_profile_snapshot(
         self, turn_id: str, *, principal: str

--- a/services/api/jobos_api/state_store.py
+++ b/services/api/jobos_api/state_store.py
@@ -2263,6 +2263,9 @@ class JobOsStateStore:
     def connected_agent_chat_impact(self, agent_id: str) -> dict[str, int]:
         return self.connected_agent_chat_impact_at(self._path, agent_id)
 
+    def lock_connected_agent_chats(self, agent_id: str, reason: str) -> int:
+        return self.lock_connected_agent_chats_at(self._path, agent_id, reason)
+
     @staticmethod
     def connected_agent_chat_impact_at(path: Path, agent_id: str) -> dict[str, int]:
         if not path.exists():
@@ -2285,6 +2288,29 @@ class JobOsStateStore:
                 raise
             return {"active_chats": 0, "locked_chats": 0}
         return {"active_chats": int(row[0]), "locked_chats": int(row[1] or 0)}
+
+    @staticmethod
+    def lock_connected_agent_chats_at(path: Path, agent_id: str, reason: str) -> int:
+        if not path.exists():
+            return 0
+        try:
+            with connect_sqlite(path) as connection:
+                cursor = connection.execute(
+                    """
+                    UPDATE conversations
+                    SET creation_state = 'locked', lock_reason = ?,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE archived_at IS NULL AND connected_agent_id = ?
+                      AND binding_state = 'sealed'
+                    """,
+                    (reason, agent_id),
+                )
+                connection.commit()
+        except sqlite3.OperationalError as error:
+            if "no such table" not in str(error) and "no such column" not in str(error):
+                raise
+            return 0
+        return cursor.rowcount
 
     def create_conversation(
         self,

--- a/services/api/tests/test_agent_contract.py
+++ b/services/api/tests/test_agent_contract.py
@@ -1573,6 +1573,54 @@ def test_manager_list_deduplicates_and_parallelizes_binding_health_probes(tmp_pa
     asyncio.run(scenario())
 
 
+def test_manager_list_isolates_failed_health_probe_and_keeps_unbound_chat_ready(tmp_path):
+    async def scenario():
+        store = JobOsStateStore(tmp_path / "manager-list-probe-failure.db")
+        store.initialize(owner_device_id="device-a")
+        bound = store.create_conversation(
+            actor_id="device-a",
+            connected_agent_id=f"jagent_{'c' * 32}",
+            provider="codex",
+            model_id="(FAKE)-model",
+            reasoning_effort="medium",
+        )
+        store.conversation_store(str(bound["conversation_id"])).complete_provisioning(
+            "(FAKE)-session-bound"
+        )
+
+        async def probe(*_args):
+            raise RuntimeError("controlled provider probe failure")
+
+        class Factory:
+            def create(self, conversation_id):
+                del conversation_id
+                return FakeGateway()
+
+        manager = ConversationManager(
+            store,
+            Factory(),
+            connected_agent_binding_unavailability=probe,
+        )
+        unbound = await manager.create(actor_id="device-a")
+        summaries = (await manager.list(owner_device_id="device-a")).conversations
+        assert len(summaries) == 3
+        unbound_summary = next(
+            item for item in summaries if item.conversation_id == unbound.conversation_id
+        )
+        bound_summary = next(
+            item
+            for item in summaries
+            if item.conversation_id == str(bound["conversation_id"])
+        )
+        assert unbound_summary.binding is None
+        assert unbound_summary.availability.state == "ready"
+        assert unbound_summary.availability.reason is None
+        assert bound_summary.availability.state == "locked"
+        assert bound_summary.availability.reason == "AGENT_PROVIDER_UNAVAILABLE"
+
+    asyncio.run(scenario())
+
+
 def test_replay_uses_transaction_flag_when_other_conversation_advances_cursor(tmp_path):
     async def scenario():
         store = JobOsStateStore(tmp_path / "explicit-replay.db")

--- a/services/api/tests/test_agent_contract.py
+++ b/services/api/tests/test_agent_contract.py
@@ -1511,6 +1511,68 @@ def test_manager_starts_all_services_concurrently_with_a_barrier(tmp_path):
     asyncio.run(scenario())
 
 
+def test_manager_list_deduplicates_and_parallelizes_binding_health_probes(tmp_path):
+    async def scenario():
+        store = JobOsStateStore(tmp_path / "manager-list-probes.db")
+        store.initialize(owner_device_id="device-a")
+        first = store.create_conversation(
+            actor_id="device-a",
+            connected_agent_id=f"jagent_{'a' * 32}",
+            provider="hermes",
+            model_id="(FAKE)-shared-model",
+            reasoning_effort="medium",
+        )
+        duplicate = store.create_conversation(
+            actor_id="device-a",
+            connected_agent_id=f"jagent_{'a' * 32}",
+            provider="hermes",
+            model_id="(FAKE)-shared-model",
+            reasoning_effort="medium",
+        )
+        unique = store.create_conversation(
+            actor_id="device-a",
+            connected_agent_id=f"jagent_{'b' * 32}",
+            provider="codex",
+            model_id="(FAKE)-unique-model",
+            reasoning_effort="high",
+        )
+        for value in (first, duplicate, unique):
+            store.conversation_store(str(value["conversation_id"])).complete_provisioning(
+                f"(FAKE)-session-{value['conversation_id']}"
+            )
+
+        calls: list[tuple[str, str, str, str, str | None]] = []
+        both_entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def probe(agent_id, provider, model_id, effort, fingerprint):
+            calls.append((agent_id, provider, model_id, effort, fingerprint))
+            if len(calls) == 2:
+                both_entered.set()
+            await release.wait()
+            return None
+
+        class Factory:
+            def create(self, conversation_id):
+                del conversation_id
+                return FakeGateway()
+
+        manager = ConversationManager(
+            store,
+            Factory(),
+            connected_agent_binding_unavailability=probe,
+        )
+        listing = asyncio.create_task(manager.list(owner_device_id="device-a"))
+        await asyncio.wait_for(both_entered.wait(), timeout=1)
+        assert len(calls) == 2
+        release.set()
+        summaries = (await asyncio.wait_for(listing, timeout=1)).conversations
+        assert len(summaries) == 4
+        assert [item.availability.state for item in summaries[1:]] == ["ready"] * 3
+
+    asyncio.run(scenario())
+
+
 def test_replay_uses_transaction_flag_when_other_conversation_advances_cursor(tmp_path):
     async def scenario():
         store = JobOsStateStore(tmp_path / "explicit-replay.db")
@@ -1560,7 +1622,7 @@ def test_failed_gateway_construction_archives_row_and_releases_cap(tmp_path):
         assert len(store.list_active_conversations()) == 1
         recovered = await manager.create(actor_id="primary-device")
         assert recovered.position == 2
-        assert len(manager.list(owner_device_id="primary-device").conversations) == 2
+        assert len((await manager.list(owner_device_id="primary-device")).conversations) == 2
         await manager.close()
 
     asyncio.run(scenario())
@@ -1586,7 +1648,7 @@ def test_startup_factory_failure_preserves_durable_row_and_starts_sibling(tmp_pa
             for item in store.list_active_conversations(owner_device_id="device-a")
         ] == [broken_id, sibling_id]
         assert manager.get(sibling_id, owner_device_id="device-a").gateway.started is True
-        listed = manager.list(owner_device_id="device-a").conversations
+        listed = (await manager.list(owner_device_id="device-a")).conversations
         assert [item.conversation_id for item in listed] == [broken_id, sibling_id]
         assert listed[0].connection.state == "offline"
         assert listed[1].connection.state == "online"
@@ -1859,6 +1921,104 @@ def test_manager_runs_conversations_concurrently_and_shuts_each_gateway(tmp_path
 
     gateways = asyncio.run(scenario())
     assert all(gateway.closed for gateway in gateways)
+
+
+def test_manager_detaches_active_agent_turn_before_account_replacement(tmp_path):
+    async def scenario():
+        agent_id = f"jagent_{'d' * 32}"
+        store = JobOsStateStore(tmp_path / "manager-account-replacement.db")
+        store.initialize(owner_device_id="device-a")
+        created = store.create_conversation(
+            actor_id="device-a",
+            connected_agent_id=agent_id,
+            provider="codex",
+            model_id="(FAKE)-replacement-model",
+            reasoning_effort="medium",
+        )
+        conversation_id = str(created["conversation_id"])
+        scoped = store.conversation_store(conversation_id)
+        scoped.complete_provisioning("(FAKE)-replacement-provider-session")
+        class CancellationFailureFactory(RecordingGatewayFactory):
+            def create(self, conversation_id):
+                gateway = InterruptFailureGateway(
+                    session_scope=f"-{conversation_id}"
+                )
+                self.gateways[conversation_id] = gateway
+                return gateway
+
+        factory = CancellationFailureFactory()
+        manager = ConversationManager(store, factory)
+        await manager.start()
+        turn = scoped.create_turn(
+            text="Stop before replacing credentials",
+            context={},
+            idempotency_key="(FAKE)-replacement-active-turn",
+            actor_id="device-a",
+        )
+
+        original_gateway = factory.gateways[conversation_id]
+        assert store.lock_connected_agent_chats(
+            agent_id, "AUTH_ACCOUNT_REPLACEMENT_REQUIRED"
+        ) == 1
+        await manager.detach_connected_agent(agent_id)
+        replay = await manager.replay_bound(
+            conversation_id=conversation_id,
+            actor_id="device-a",
+            agent_summary={
+                "id": agent_id,
+                "provider": "codex",
+                "display_name": "Codex",
+                "avatar_id": "spark",
+            },
+        )
+
+        assert original_gateway.interruptions == [turn["turn_id"]]
+        assert original_gateway.closed is True
+        assert replay.availability.state == "locked"
+        assert manager.get(conversation_id).snapshot().conversation_id == conversation_id
+
+    asyncio.run(scenario())
+
+
+def test_manager_does_not_start_locked_provider_sessions_but_keeps_history_readable(tmp_path):
+    async def scenario():
+        store = JobOsStateStore(tmp_path / "manager-locked-recovery.db")
+        store.initialize(owner_device_id="device-a")
+        created = store.create_conversation(
+            actor_id="device-a",
+            connected_agent_id=f"jagent_{'c' * 32}",
+            provider="codex",
+            model_id="(FAKE)-locked-model",
+            reasoning_effort="medium",
+        )
+        conversation_id = str(created["conversation_id"])
+        scoped = store.conversation_store(conversation_id)
+        scoped.complete_provisioning("(FAKE)-locked-provider-session")
+        turn = scoped.create_turn(
+            text="Do not recover under replacement credentials",
+            context={},
+            idempotency_key="(FAKE)-locked-recovery-turn",
+            actor_id="device-a",
+        )
+        scoped.save_stored_session_id("(FAKE)-locked-provider-session")
+        assert store.lock_connected_agent_chats(
+            f"jagent_{'c' * 32}", "AUTH_ACCOUNT_REPLACEMENT_REQUIRED"
+        ) == 1
+
+        factory = RecordingGatewayFactory()
+        manager = ConversationManager(store, factory)
+        await manager.start()
+        try:
+            service = manager.get(conversation_id, owner_device_id="device-a")
+            active_turn = service.snapshot().active_turn
+            assert active_turn is not None
+            assert active_turn["turn_id"] == turn["turn_id"]
+            assert factory.gateways[conversation_id].started is False
+            assert factory.gateways[conversation_id].interruptions == []
+        finally:
+            await manager.close()
+
+    asyncio.run(scenario())
 
 
 def test_manager_recovers_each_persisted_active_turn_independently(tmp_path):

--- a/services/api/tests/test_agent_runtime_router.py
+++ b/services/api/tests/test_agent_runtime_router.py
@@ -109,6 +109,16 @@ def test_router_fails_closed_for_unregistered_provider_and_incomplete_binding():
         )
 
 
+def test_router_uses_provider_factory_for_agent_created_after_startup():
+    factory = QueueFactory()
+    router = AgentRuntimeRouter({"codex": factory}, profile_id=PROFILE_ID)
+
+    routed = router.create("conv_new_codex", sealed_binding(provider="codex"))
+
+    assert routed is not None
+    assert "conv_new_codex" in factory.gateways
+
+
 def test_router_rejects_cross_chat_session_reuse_and_wrong_turn_envelope():
     async def scenario() -> None:
         factory = QueueFactory(shared_session="(FAKE)-shared-session")

--- a/services/api/tests/test_connected_agent_auth.py
+++ b/services/api/tests/test_connected_agent_auth.py
@@ -362,9 +362,10 @@ async def test_replace_waits_for_completion_and_cancel_preserves_existing_vault(
     )
     await client.complete_login()
     assert (await broker.read(initial.transaction_id)).status == "connected"
+    fingerprint = registry.load().connected_agents[0].account_fingerprint
 
     replacement = await broker.start_device_code(
-        AGENT_ID, "replace", None, allow_host_callback=False
+        AGENT_ID, "replace", fingerprint, allow_host_callback=False
     )
     model_calls_before_poll = sum(
         method == "model/list" for method, _params in client.calls
@@ -379,6 +380,45 @@ async def test_replace_waits_for_completion_and_cancel_preserves_existing_vault(
     assert cancelled.status == "cancelled"
     assert vault.removed is False
     assert registry.load().connected_agents[0].lifecycle == "connected"
+
+
+@pytest.mark.anyio
+async def test_successful_replacement_locks_prior_chats_without_fabricating_identity(
+    tmp_path: Path,
+) -> None:
+    registry = registry_with_codex_agent(tmp_path)
+    client = FakeCodexClient()
+    locked: list[str] = []
+    broker = CodexAuthFlowBroker(
+        client,
+        FakeVault(),
+        registry,
+        now=lambda: NOW,
+        on_account_replaced=locked.append,
+    )
+    initial = await broker.start_device_code(
+        AGENT_ID, "connect", None, allow_host_callback=False
+    )
+    await client.complete_login()
+    assert (await broker.read(initial.transaction_id)).status == "connected"
+
+    snapshot = registry.load()
+    registry.disconnect_connected_agent(
+        AGENT_ID,
+        expected_registry_revision=snapshot.registry_revision,
+        idempotency_key="(FAKE)-disconnect-before-replacement",
+        now=NOW,
+    )
+
+    replacement = await broker.start_device_code(
+        AGENT_ID, "replace", None, allow_host_callback=False
+    )
+    assert locked == []
+    await client.complete_login()
+    assert (await broker.read(replacement.transaction_id)).status == "connected"
+
+    assert locked == [AGENT_ID]
+    assert registry.load().connected_agents[0].account_fingerprint is None
 
 
 @pytest.mark.anyio
@@ -401,9 +441,10 @@ async def test_completed_replacement_cleanup_disconnects_and_auth_is_single_flig
 
     await client.complete_login()
     assert (await broker.read(initial.transaction_id)).status == "connected"
+    fingerprint = registry.load().connected_agents[0].account_fingerprint
 
     replacement = await broker.start_device_code(
-        AGENT_ID, "replace", None, allow_host_callback=False
+        AGENT_ID, "replace", fingerprint, allow_host_callback=False
     )
     await client.complete_login()
     vault.isolation_error = AuthFlowError(

--- a/services/api/tests/test_connected_agents_api.py
+++ b/services/api/tests/test_connected_agents_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -11,6 +12,10 @@ from jobos_api.agent_gateway import (
 )
 from jobos_api.app import create_app
 from jobos_api.connected_agent_auth import SafeAuthTransaction
+from jobos_api.connected_agents import (
+    HermesConnectedAgentRuntime,
+    ProviderConnectedAgentRuntime,
+)
 from jobos_api.conversation_store import ConversationStore
 from jobos_api.installation_profiles import (
     AnchoredRuntime,
@@ -217,6 +222,7 @@ def setup_app(
         now=NOW,
     )
     state_store = JobOsStateStore(state_path)
+
     gateway_factory = ReadyGatewayFactory(gateway_type)
     settings = Settings(
         device_token=TOKEN,
@@ -259,12 +265,38 @@ def chat_payload(revision: int, key: str, **overrides):
     }
 
 
+def test_provider_runtime_routes_hermes_to_its_fixed_profile_model(tmp_path):
+    _, registry, _, _, _ = setup_app(tmp_path)
+    record = registry.load().connected_agents[0]
+    runtime = ProviderConnectedAgentRuntime(
+        {"hermes": HermesConnectedAgentRuntime(configured=True)}
+    )
+
+    health = asyncio.run(runtime.inspect_connection(record))
+    models = asyncio.run(runtime.list_models(record))
+
+    assert health["provider_available"] is True
+    assert health["tools_available"] is True
+    assert models == {
+        "live": True,
+        "models": [
+            {
+                "model_id": "(FAKE)-model-stable",
+                "display_name": "(FAKE)-model-stable",
+                "reasoning_efforts": ["medium"],
+            }
+        ],
+    }
+
+
 def test_connected_agent_api_resolves_default_and_provisions_immutable_chat(tmp_path):
     app, registry, state_store, gateway_factory, _ = setup_app(tmp_path)
 
     with TestClient(app) as client:
         agents = client.get("/v1/connected-agents", headers=auth())
         assert agents.status_code == 200
+        assert agents.json()["profile_id"] == PROFILE_ID
+        assert agents.json()["default_connected_agent_id"] == AGENT_ID
         assert agents.json()["agents"][0]["id"] == AGENT_ID
         assert agents.json()["agents"][0]["health"]["state"] == "connected"
 
@@ -282,6 +314,15 @@ def test_connected_agent_api_resolves_default_and_provisions_immutable_chat(tmp_
         }
         assert body["availability"]["state"] == "ready"
         assert body["agent"]["display_name"] == "(FAKE) Hermes"
+        summaries = client.get("/v1/conversations", headers=auth())
+        assert summaries.status_code == 200
+        summary = next(
+            item
+            for item in summaries.json()["conversations"]
+            if item["conversation_id"] == body["conversation_id"]
+        )
+        assert summary["binding"] == body["binding"]
+        assert summary["availability"] == body["availability"]
         assert state_store.conversation_store(body["conversation_id"]).binding() == {
             "connected_agent_id": AGENT_ID,
             "provider": "hermes",
@@ -440,12 +481,55 @@ def test_profile_wide_five_chat_limit_and_archive_release(tmp_path):
     assert replacement.status_code == 201
 
 
+def test_account_replacement_durably_locks_prior_agent_chats(tmp_path):
+    app, registry, state_store, _, _ = setup_app(tmp_path)
+    with TestClient(app) as client:
+        created = client.post(
+            "/v1/conversations",
+            headers=auth(),
+            json=chat_payload(
+                registry.load().registry_revision,
+                "(FAKE)-account-replacement-chat",
+            ),
+        )
+        assert created.status_code == 201, created.text
+        assert state_store.lock_connected_agent_chats(
+            AGENT_ID, "AUTH_ACCOUNT_REPLACEMENT_REQUIRED"
+        ) == 1
+        summaries = client.get("/v1/conversations", headers=auth())
+
+    locked = next(
+        item
+        for item in summaries.json()["conversations"]
+        if item["conversation_id"] == created.json()["conversation_id"]
+    )
+    assert locked["availability"] == {
+        "state": "locked",
+        "reason": "AUTH_ACCOUNT_REPLACEMENT_REQUIRED",
+    }
+
+
 def test_agent_api_update_models_impact_default_and_disconnect(tmp_path):
     app, registry, _, _, _ = setup_app(tmp_path)
     with TestClient(app) as client:
         models = client.get(f"/v1/connected-agents/{AGENT_ID}/models", headers=auth())
         impact = client.get(f"/v1/connected-agents/{AGENT_ID}/disconnect-impact", headers=auth())
         revision = registry.load().registry_revision
+        created = client.post(
+            "/v1/conversations",
+            headers=auth(),
+            json=chat_payload(revision, "(FAKE)-disconnect-chat"),
+        )
+        assert created.status_code == 201, created.text
+        delivered = client.post(
+            f"/v1/conversations/{created.json()['conversation_id']}/messages",
+            headers=auth(),
+            json={
+                "text": "(FAKE) ambiguous delivery",
+                "idempotency_key": "(FAKE)-ambiguous-send",
+            },
+        )
+        assert delivered.status_code == 201, delivered.text
         updated = client.patch(
             f"/v1/connected-agents/{AGENT_ID}",
             headers=auth(),
@@ -479,6 +563,23 @@ def test_agent_api_update_models_impact_default_and_disconnect(tmp_path):
                 "idempotency_key": "(FAKE)-disconnect-agent",
             },
         )
+        summaries = client.get("/v1/conversations", headers=auth())
+        replayed = client.post(
+            f"/v1/conversations/{created.json()['conversation_id']}/messages",
+            headers=auth(),
+            json={
+                "text": "(FAKE) ambiguous delivery",
+                "idempotency_key": "(FAKE)-ambiguous-send",
+            },
+        )
+        blocked_send = client.post(
+            f"/v1/conversations/{created.json()['conversation_id']}/messages",
+            headers=auth(),
+            json={
+                "text": "This must stay read-only",
+                "idempotency_key": "(FAKE)-locked-chat-send",
+            },
+        )
 
     assert models.status_code == 200
     assert models.json()["models"][0]["model_id"] == "(FAKE)-model-stable"
@@ -486,6 +587,19 @@ def test_agent_api_update_models_impact_default_and_disconnect(tmp_path):
     assert updated.json()["display_name"] == "(FAKE) Renamed Hermes"
     assert cleared.json()["default_connected_agent_id"] is None
     assert disconnected.json()["lifecycle"] == "disconnected"
+    assert replayed.status_code == 201
+    assert replayed.json() == {**delivered.json(), "created": False}
+    disconnected_chat = next(
+        item
+        for item in summaries.json()["conversations"]
+        if item["conversation_id"] == created.json()["conversation_id"]
+    )
+    assert disconnected_chat["availability"] == {
+        "state": "locked",
+        "reason": "AGENT_DISCONNECTED",
+    }
+    assert blocked_send.status_code == 409
+    assert blocked_send.json()["code"] == "AGENT_DISCONNECTED"
     persisted = next(item for item in registry.load().connected_agents if item.id == AGENT_ID)
     assert persisted.connection_config is None
     assert persisted.credential_reference is None

--- a/services/api/tests/test_jobs_contract.py
+++ b/services/api/tests/test_jobs_contract.py
@@ -18,6 +18,7 @@ from jobos_api.documents import ArtifactPublishRequest
 from jobos_api.editable_documents import blank_content, default_settings
 from jobos_api.installation_profiles import (
     AnchoredRuntime,
+    ConnectedAgentRecord,
     InstallationProfileRecord,
     InstallationProfileRegistry,
     InstallationProfileRegistryData,
@@ -307,6 +308,34 @@ class PendingGateway:
 class PendingGatewayFactory:
     def create(self, conversation_id):
         return PendingGateway(conversation_id)
+
+
+class ReadyConnectedAgentRuntime:
+    async def inspect_connection(self, agent: ConnectedAgentRecord) -> dict[str, object]:
+        del agent
+        return {
+            "state": "connected",
+            "label": "Connected",
+            "provider_available": True,
+            "tools_available": True,
+            "retry_after_seconds": None,
+        }
+
+    async def list_models(self, agent: ConnectedAgentRecord) -> dict[str, object]:
+        return {
+            "live": True,
+            "models": [
+                {
+                    "model_id": agent.default_model_id,
+                    "display_name": agent.default_model_id,
+                    "reasoning_efforts": [agent.default_reasoning_effort],
+                }
+            ],
+        }
+
+    async def disconnect(self, agent: ConnectedAgentRecord) -> dict[str, object]:
+        del agent
+        return {"verified": True}
 
 
 def start_active_turn(client, conversation_id, *, headers=None, key="mcp-scope-active-turn"):
@@ -1120,6 +1149,7 @@ def test_provider_bound_mcp_publication_records_exactly_once_turn_attribution(
         artifact_gateway=artifact_gateway,
         state_store=state_store,
         agent_gateway_factory=PendingGatewayFactory(),
+        connected_agent_runtime=ReadyConnectedAgentRuntime(),
     )
     payload = {
         "document_key": "resume",


### PR DESCRIPTION
## What changed

Ships Phase 6 / Issue #117 with the smallest complete Connected Agents desktop slice:

- adds Settings → Connected Agents roster and focused inspector
- adds live health, model/default, device-code auth, test, disconnect, and replacement UX
- adds one New Chat dialog shared by chat creation paths with exact agent/model/effort selection
- preserves immutable chat ownership across reloads and shows readable locked history without silent fallback
- keeps the profile-wide five-chat limit recoverable through explicit archive
- routes Hermes and Codex health/model checks through their owning provider controls
- makes newly created Codex agents immediately routable without restarting JobOS
- keeps cancelled/failed replacement auth from prematurely locking old chats
- updates the authoritative implementation plan with Phase 6 progress

## Product scope

This intentionally does **not** absorb Phase 7 concurrency/recovery/privacy hardening or Phase 8 installed-product acceptance. It follows the accepted directory + focused inspector UX and keeps provider details behind the existing provider-neutral bridge and API boundaries.

## Verification

- `pnpm check`
  - 578 desktop tests passed
  - 1,000 Python tests passed, 4 skipped
  - lint, typecheck, generated contracts, public tree, fixture manifest, licensing, MacBook updater tests, Electron/renderer builds passed
- focused Connected Agents/runtime/auth/router suites: 93 passed
- Ruff: passed
- `pnpm contracts:check`: passed
- `git diff --check`: passed
- independent Codex review findings resolved
- exact-head clean clone:
  - commit `a08337e78dccdc1e63313b0b03d49ae82096d09e`
  - platform `darwin`
  - status `passed`

## Visual evidence

Reviewed at desktop sizes with no visible clipping or layout breakage:

- Connected Agents roster/inspector: `jobos-phase6-connected-agents-1440x900.png`
- Settings integration: `jobos-phase6-settings-1280x800.png`

## Safety

- no raw access tokens, refresh tokens, authorization headers, or device codes are persisted
- device-code polling supports cancellation and unmount cleanup
- provider/model/effort bindings remain immutable
- replacement locks happen only after successful credential and model validation
- no production deployment or installed-profile migration was performed

Closes #117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Connect and manage supported AI agents from Settings, including authentication, model selection, defaults, health checks, and disconnection.
  - Choose an agent, model, and reasoning level when starting a new chat.
  - View the agent configuration and availability status for each conversation.
- **Bug Fixes**
  - Chats now clearly indicate when an agent is unavailable or locked.
  - Replaced agent accounts safely detach affected chats while preserving conversation history.
- **Improvements**
  - New-chat flows support archiving when the five-chat limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->