### PR TITLE
Phase 7: harden Connected Agents recovery and remote control

### DIFF
--- a/apps/desktop/src/main/apiLifecycle.test.ts
+++ b/apps/desktop/src/main/apiLifecycle.test.ts
@@ -28,7 +28,7 @@ const remoteRuntime: DesktopRuntimeConfig = {
 const disconnected: ConnectivitySnapshot = {
   state: 'disconnected',
   checkedAt: '2026-07-20T00:00:00Z',
-  message: 'JobOS API unavailable'
+  message: 'JobOS host unavailable'
 }
 const connected: ConnectivitySnapshot = {
   state: 'connected',

--- a/apps/desktop/src/main/connectivity.test.ts
+++ b/apps/desktop/src/main/connectivity.test.ts
@@ -123,7 +123,7 @@ test('network exceptions never expose credential material', async () => {
 
   expect(result).toMatchObject({
     state: 'disconnected',
-    message: 'JobOS API unavailable'
+    message: 'JobOS host unavailable'
   })
   expect(JSON.stringify(result)).not.toContain(token)
 })
@@ -145,6 +145,6 @@ test('an unresponsive API request is aborted instead of blocking desktop startup
 
   expect(result).toMatchObject({
     state: 'disconnected',
-    message: 'JobOS API unavailable'
+    message: 'JobOS host unavailable'
   })
 })

--- a/apps/desktop/src/main/connectivity.ts
+++ b/apps/desktop/src/main/connectivity.ts
@@ -89,7 +89,7 @@ export async function probeConnectivity(config: ConnectivityConfig): Promise<Con
       return {
         state: 'disconnected',
         checkedAt,
-        message: 'JobOS API unavailable'
+        message: 'JobOS host unavailable'
       }
     }
     if (!isHealthResponse(health.data)) {
@@ -136,7 +136,7 @@ export async function probeConnectivity(config: ConnectivityConfig): Promise<Con
     return {
       state: 'disconnected',
       checkedAt,
-      message: 'JobOS API unavailable'
+      message: 'JobOS host unavailable'
     }
   }
 }

--- a/apps/desktop/src/main/desktopRuntime.ts
+++ b/apps/desktop/src/main/desktopRuntime.ts
@@ -66,7 +66,7 @@ export async function initializeDesktopRuntime(
     return {
       runtime,
       deviceToken,
-      connectivity: disconnected('JobOS API unavailable')
+      connectivity: disconnected('JobOS host unavailable')
     }
   }
 }

--- a/apps/desktop/src/renderer/components/AgentPanel.regression.test.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.regression.test.tsx
@@ -421,7 +421,12 @@ test('failed and interrupted turns expose Retry and offline states remain distin
   expect(agent.retry).toHaveBeenCalledWith(CONVERSATION_ID, 'turn-1', expect.stringMatching(/^desktop-retry-/))
 
   rerender(<Harness apiState="disconnected" contextLabel="Northstar" />)
-  expect(screen.getByText('JobOS API offline')).not.toBeNull()
+  expect(screen.getByText('JobOS host unavailable')).not.toBeNull()
+  expect((screen.getByRole('button', { name: 'Send message' }) as HTMLButtonElement).disabled).toBe(true)
+
+  rerender(<Harness apiState="degraded" contextLabel="Northstar" />)
+  expect(screen.getByText('Device authentication needs attention')).not.toBeNull()
+  expect((screen.getByRole('button', { name: 'Send message' }) as HTMLButtonElement).disabled).toBe(true)
 })
 
 test('API-online users can use Send to reconnect an initially offline agent', async () => {

--- a/apps/desktop/src/renderer/components/AgentPanel.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.tsx
@@ -50,8 +50,11 @@ interface AgentPanelProps {
 }
 
 function ConnectionNotice({ apiState, connection }: { apiState: ConnectivityState; connection: typeof initialAgentConversationState.connection }) {
-  if (apiState === 'disconnected' || apiState === 'degraded') {
-    return <div className="agent-connection offline" role="status"><WifiOff aria-hidden="true" size={14} /> JobOS API offline</div>
+  if (apiState === 'disconnected') {
+    return <div className="agent-connection offline" role="status"><WifiOff aria-hidden="true" size={14} /> JobOS host unavailable</div>
+  }
+  if (apiState === 'degraded') {
+    return <div className="agent-connection offline" role="status"><WifiOff aria-hidden="true" size={14} /> Device authentication needs attention</div>
   }
   if (connection === 'reconnecting' || connection === 'connecting') {
     return <div className="agent-connection reconnecting" role="status"><LoaderCircle aria-hidden="true" className="spin" size={14} /> Reconnecting to agent…</div>

--- a/docs/acceptance/connected-agents/phase-7/README.md
+++ b/docs/acceptance/connected-agents/phase-7/README.md
@@ -1,0 +1,28 @@
+# Phase 7 acceptance evidence
+
+Issue: [#118](https://github.com/cobibean/job-os/issues/118)
+
+This phase intentionally hardens the existing provider-neutral runtime instead of adding another orchestration layer. Negative provider, host, auth, and device cases use deterministic fakes; no deactivated account or production credential is required.
+
+## Acceptance map
+
+| ID | Proof |
+|---|---|
+| CON-01 | `test_manager_submissions_overlap_at_the_gateway_boundary`, `test_manager_runs_conversations_concurrently_and_shuts_each_gateway`, and `test_conversation_scope_isolates_busy_events_idempotency_and_sessions` prove concurrent chats preserve transcript, turn, event, session, and cancellation ownership. |
+| CON-02 | `test_conversation_scope_isolates_busy_events_idempotency_and_sessions` proves a second same-chat send is rejected while other chats remain available. |
+| ISO-01 | `test_manager_start_failure_keeps_sibling_available_and_reconnect_alive`, router fail-closed tests, and Codex transport/MCP tests prove provider failures stay scoped and optional Codex startup cannot disable Hermes or JobOS. |
+| ISO-02 | `test_cancellation_is_scoped_to_the_current_chat_and_turn` and the concurrent-manager test prove cancellation targets one chat and turn without killing shared infrastructure. |
+| REC-01 | API restart, transport-loss, cancellation-race, and event-consumer recovery tests prove active work reaches an explicit terminal or recovery-required state. |
+| REC-02 | `test_ambiguous_attachment_survives_restart_without_blind_retry`, linked-retry tests, and Codex exact-thread recovery prove retries retain JobOS correlation and ambiguous delivery never fresh-submits blindly. |
+| REC-03 | Desktop connectivity and lifecycle tests prove remote clients do not launch a local fallback; the renderer now says **JobOS host unavailable**, disables Send, and recovers on a later successful probe. |
+| SEC-01 | Persistence redaction tests plus the recursive canary scanner cover SQLite, JSON, text, journals, archives, chat output, runtime metadata, and packaged evidence. |
+| SEC-02 | `test_support_diagnostics_are_bounded_and_credential_free` and `DiagnosticsPanel.test.tsx` prove support output is bounded, normalized, and free of paths, authorization data, and credentials. |
+| SEC-03 | `test_device_session_requires_the_runtime_credential`, direct-user auth-route tests, and `test_remote_device_fixture_detects_reachable_but_unauthorized_access` prove network reachability alone grants no management authority. |
+| RATE-01 | Codex rate-limit tests prove usage exhaustion is affected-turn-only, never blindly resubmits or switches providers/models, refreshes authoritative countdown state without racing newer updates, interrupts provider-declared retries, and preserves explicit recovery when interruption cannot be confirmed. |
+| HOST-01 | `CodexAuthFlowBroker` and `CredentialVault` remain the application/domain boundary; Tailscale and Keychain details stay in host adapters and packaging code. |
+
+## Security boundary
+
+- JobOS continues to run the pinned Codex app-server from a dedicated `CODEX_HOME` with an explicit minimal environment.
+- Device-scoped MCP credentials remain in platform-backed secure storage and are not passed through the Codex app-server environment.
+- No raw token, authorization header, device code, or credential value belongs in this evidence file, test output, support diagnostics, or issue closeout.

--- a/docs/implementation/connected-agents-codex-plan.md
+++ b/docs/implementation/connected-agents-codex-plan.md
@@ -1,10 +1,10 @@
 # Connected Agents and ChatGPT/Codex Implementation Plan
 
-- **Status:** Active implementation — Phases 0–5 delivered; Phase 6 verified and awaiting merge; Phases 7–8 remain
+- **Status:** Active implementation — Phases 0–6 delivered; Phase 7 verified and awaiting merge; Phase 8 remains
 - **Wayfinder:** [#100](https://github.com/cobibean/job-os/issues/100)
 - **Planning ticket:** [#109](https://github.com/cobibean/job-os/issues/109)
-- **Verified source baseline:** `ee542e9d7c19d5c5a16bb15cb9e1072121415ff1` on `origin/main`, verified 2026-08-23
-- **Progress update (2026-08-25):** Phases 0–5 are merged and verified. Phase 6 adds the Connected Agents roster/inspector, live provider model defaults, device-code and disconnect flows, immutable New Chat selection, readable locked history, and five-chat archive recovery. Shipment receipts remain on Issues [#111–#117](https://github.com/cobibean/job-os/issues/117).
+- **Verified source baseline:** `7753e88ff9c9671682d29b5bd5cb409cbe690978` on `origin/main`, verified 2026-08-25
+- **Progress update (2026-08-25):** Phases 0–6 are merged and verified. Phase 6 shipped the Connected Agents roster/inspector, live provider model defaults, device-code and disconnect flows, immutable New Chat selection, readable locked history, and five-chat archive recovery in [PR #127](https://github.com/cobibean/job-os/pull/127). Phase 7 now has verified scoped concurrency/failure/recovery behavior, honest remote-host and authentication states, bounded credential-free diagnostics, and terminal Codex rate-limit handling that does not blindly retry or switch providers. Its acceptance map is in `docs/acceptance/connected-agents/phase-7/`; merge receipts will be recorded on [#118](https://github.com/cobibean/job-os/issues/118).
 
 **Goal:** Let a JobOS user connect and manage multiple agent identities, choose a profile default, and create a chat permanently owned by a selected Hermes or ChatGPT/Codex agent and supported model—without weakening JobOS context, tools, recovery, privacy, or existing Hermes behavior.
 

--- a/services/api/jobos_api/codex_adapter.py
+++ b/services/api/jobos_api/codex_adapter.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import re
 import secrets
-from collections.abc import AsyncIterator, Callable
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
 from .agent_gateway import AgentContext, ConnectionState, GatewayEvent
@@ -23,6 +25,9 @@ class CodexGatewayFactory:
         self._client = client
         self._cwd = cwd.expanduser().absolute()
         self._gateways: dict[str, CodexAppServerGateway] = {}
+        self._rate_limit_snapshot: dict[str, object] = {}
+        self._rate_limit_updates: list[dict[str, object]] = []
+        self._rate_limit_refresh_lock = asyncio.Lock()
         self._subscribed = False
 
     def create(self, conversation_id: str) -> CodexAppServerGateway:
@@ -34,9 +39,29 @@ class CodexGatewayFactory:
             cwd=self._cwd,
             conversation_id=conversation_id,
             unregister=self._unregister,
+            rate_limit_snapshot=self._rate_limit_snapshot,
+            refresh_rate_limits=self._refresh_rate_limits,
         )
         self._gateways[conversation_id] = gateway
         return gateway
+
+    async def _refresh_rate_limits(self) -> dict[str, object]:
+        async with self._rate_limit_refresh_lock:
+            self._rate_limit_updates = []
+            try:
+                result = await self._client.request("account/rateLimits/read")
+            except CodexRuntimeError:
+                return dict(self._rate_limit_snapshot)
+            snapshot = result.get("rateLimits") if isinstance(result, dict) else None
+            if isinstance(snapshot, dict):
+                refreshed = dict(snapshot)
+                for update in self._rate_limit_updates:
+                    refreshed = _merge_rate_limit_snapshot(refreshed, update)
+                self._rate_limit_snapshot = refreshed
+                self._rate_limit_updates = []
+                for gateway in tuple(self._gateways.values()):
+                    gateway.update_rate_limits(self._rate_limit_snapshot)
+            return dict(self._rate_limit_snapshot)
 
     async def _dispatch(self, method: str, params: object) -> None:
         if method == "jobos/runtime/disconnected":
@@ -44,6 +69,17 @@ class CodexGatewayFactory:
                 await gateway.handle_runtime_disconnect()
             return
         if not isinstance(params, dict):
+            return
+        if method == "account/rateLimits/updated":
+            snapshot = params.get("rateLimits")
+            if not isinstance(snapshot, dict):
+                return
+            self._rate_limit_updates.append(snapshot)
+            self._rate_limit_snapshot = _merge_rate_limit_snapshot(
+                self._rate_limit_snapshot, snapshot
+            )
+            for gateway in tuple(self._gateways.values()):
+                gateway.update_rate_limits(self._rate_limit_snapshot)
             return
         thread_id = params.get("threadId")
         if not isinstance(thread_id, str):
@@ -68,6 +104,8 @@ class CodexAppServerGateway:
         cwd: Path,
         conversation_id: str,
         unregister: Callable[[str, CodexAppServerGateway], None],
+        rate_limit_snapshot: dict[str, object],
+        refresh_rate_limits: Callable[[], Awaitable[dict[str, object]]],
     ) -> None:
         self._client = client
         self._cwd = cwd
@@ -79,6 +117,10 @@ class CodexAppServerGateway:
         self._event_namespace = secrets.token_hex(8)
         self._event_sequence = 0
         self._assistant_pending = ""
+        self._rate_limit_snapshot = dict(rate_limit_snapshot)
+        self._refresh_rate_limits = refresh_rate_limits
+        self._rate_limit_settling: set[str] = set()
+        self._rate_limit_completed: set[str] = set()
         self._events: asyncio.Queue[GatewayEvent | None] = asyncio.Queue()
         self._closed = False
 
@@ -192,6 +234,7 @@ class CodexAppServerGateway:
         if self._thread_id is None:
             raise RuntimeError("Codex conversation is not attached")
         await self._require_jobos_mcp()
+        self._rate_limit_snapshot = await self._refresh_rate_limits()
         prompt = _prompt_with_context(
             text,
             {
@@ -300,6 +343,13 @@ class CodexAppServerGateway:
             or provider_turn_id != self._provider_turn_id
         ):
             return
+        if (
+            method == "turn/completed"
+            and isinstance(provider_turn_id, str)
+            and provider_turn_id in self._rate_limit_settling
+        ):
+            self._rate_limit_completed.add(provider_turn_id)
+            return
         if method == "turn/completed" and self._assistant_pending:
             pending = sanitize_assistant_text(self._assistant_pending)
             self._assistant_pending = ""
@@ -314,6 +364,24 @@ class CodexAppServerGateway:
                     f"codex:{self._event_namespace}:{provider_turn_id}:{self._event_sequence}",
                 )
             )
+        if method == "error":
+            error = params.get("error")
+            error_info = error.get("codexErrorInfo") if isinstance(error, dict) else None
+            if (
+                error_info == "usageLimitExceeded"
+                and params.get("willRetry") is True
+                and isinstance(provider_turn_id, str)
+            ):
+                self._rate_limit_settling.add(provider_turn_id)
+                asyncio.create_task(
+                    self._settle_provider_rate_limit_retry(
+                        self._thread_id,
+                        provider_turn_id,
+                        self._jobos_turn_id,
+                        params,
+                    )
+                )
+                return
         event = self._normalize(method, params)
         if event is not None:
             await self._events.put(event)
@@ -321,6 +389,63 @@ class CodexAppServerGateway:
             self._jobos_turn_id = None
             self._provider_turn_id = None
             self._assistant_pending = ""
+
+    async def _settle_provider_rate_limit_retry(
+        self,
+        thread_id: str,
+        provider_turn_id: str,
+        jobos_turn_id: str,
+        params: dict[str, object],
+    ) -> None:
+        try:
+            await self._client.request(
+                "turn/interrupt",
+                {"threadId": thread_id, "turnId": provider_turn_id},
+            )
+        except CodexRuntimeError:
+            if provider_turn_id in self._rate_limit_completed:
+                event = self._normalize("error", params)
+                if event is not None:
+                    await self._events.put(event)
+                self._rate_limit_completed.discard(provider_turn_id)
+                self._rate_limit_settling.discard(provider_turn_id)
+                return
+            if (
+                self._jobos_turn_id != jobos_turn_id
+                or self._provider_turn_id != provider_turn_id
+            ):
+                self._rate_limit_settling.discard(provider_turn_id)
+                return
+            self._event_sequence += 1
+            await self._events.put(
+                GatewayEvent(
+                    "error",
+                    "failed",
+                    "Codex rate limit reached; recovery required",
+                    {
+                        "reason": "transport_lost",
+                        "cause": "rate_limited",
+                        "retry": False,
+                        "recovery_required": True,
+                    },
+                    jobos_turn_id,
+                    f"codex:{self._event_namespace}:{provider_turn_id}:{self._event_sequence}",
+                )
+            )
+            self._rate_limit_settling.discard(provider_turn_id)
+            return
+        if (
+            self._jobos_turn_id != jobos_turn_id
+            or self._provider_turn_id != provider_turn_id
+        ):
+            self._rate_limit_completed.discard(provider_turn_id)
+            self._rate_limit_settling.discard(provider_turn_id)
+            return
+        event = self._normalize("error", params)
+        if event is not None:
+            await self._events.put(event)
+        self._rate_limit_completed.discard(provider_turn_id)
+        self._rate_limit_settling.discard(provider_turn_id)
 
     def _normalize(self, method: str, params: dict[str, object]) -> GatewayEvent | None:
         turn_id = self._jobos_turn_id
@@ -353,6 +478,25 @@ class CodexAppServerGateway:
             summary = sanitize_text(str(detail.get("name") or "Codex tool activity"))[:500]
             return GatewayEvent("activity", state, summary, detail, turn_id, source_id)
         if method == "error":
+            error = params.get("error")
+            error_info = error.get("codexErrorInfo") if isinstance(error, dict) else None
+            if error_info == "usageLimitExceeded":
+                retry_after = _retry_after_seconds(self._rate_limit_snapshot)
+                summary = "Codex rate limit reached"
+                if retry_after is not None:
+                    summary = f"Codex rate limit reached. Try again in {retry_after} seconds"
+                return GatewayEvent(
+                    "error",
+                    "failed",
+                    summary,
+                    {
+                        "reason": "rate_limited",
+                        "retry": False,
+                        "retry_after_seconds": retry_after,
+                    },
+                    turn_id,
+                    source_id,
+                )
             if params.get("willRetry") is True:
                 return GatewayEvent(
                     "activity",
@@ -387,3 +531,44 @@ class CodexAppServerGateway:
         self._provider_turn_id = None
         self._unregister(self._conversation_id, self)
         await self._events.put(None)
+
+    def update_rate_limits(self, snapshot: dict[str, object]) -> None:
+        self._rate_limit_snapshot = dict(snapshot)
+
+
+def _retry_after_seconds(snapshot: dict[str, object]) -> int | None:
+    resets: list[int] = []
+    for name in ("primary", "secondary"):
+        window = snapshot.get(name)
+        if not isinstance(window, dict):
+            continue
+        used_percent = window.get("usedPercent")
+        if not isinstance(used_percent, int) or isinstance(used_percent, bool):
+            continue
+        if used_percent < 100:
+            continue
+        resets_at = window.get("resetsAt")
+        if isinstance(resets_at, int) and not isinstance(resets_at, bool):
+            resets.append(resets_at)
+    now = time.time()
+    future_resets = [reset for reset in resets if reset > now]
+    if not future_resets:
+        return None
+    return math.ceil(max(future_resets) - now)
+
+
+def _merge_rate_limit_snapshot(
+    previous: dict[str, object], update: dict[str, object]
+) -> dict[str, object]:
+    merged = dict(previous)
+    for key, value in update.items():
+        if value is None:
+            continue
+        if key in {"primary", "secondary"} and isinstance(value, dict):
+            prior_window = merged.get(key)
+            window = dict(prior_window) if isinstance(prior_window, dict) else {}
+            window.update({name: field for name, field in value.items() if field is not None})
+            merged[key] = window
+            continue
+        merged[key] = value
+    return merged

--- a/services/api/jobos_api/codex_adapter.py
+++ b/services/api/jobos_api/codex_adapter.py
@@ -121,6 +121,7 @@ class CodexAppServerGateway:
         self._refresh_rate_limits = refresh_rate_limits
         self._rate_limit_settling: set[str] = set()
         self._rate_limit_completed: set[str] = set()
+        self._rate_limit_tasks: set[asyncio.Task[None]] = set()
         self._events: asyncio.Queue[GatewayEvent | None] = asyncio.Queue()
         self._closed = False
 
@@ -372,8 +373,10 @@ class CodexAppServerGateway:
                 and params.get("willRetry") is True
                 and isinstance(provider_turn_id, str)
             ):
+                if provider_turn_id in self._rate_limit_settling:
+                    return
                 self._rate_limit_settling.add(provider_turn_id)
-                asyncio.create_task(
+                task = asyncio.create_task(
                     self._settle_provider_rate_limit_retry(
                         self._thread_id,
                         provider_turn_id,
@@ -381,6 +384,8 @@ class CodexAppServerGateway:
                         params,
                     )
                 )
+                self._rate_limit_tasks.add(task)
+                task.add_done_callback(self._rate_limit_tasks.discard)
                 return
         event = self._normalize(method, params)
         if event is not None:
@@ -407,6 +412,7 @@ class CodexAppServerGateway:
                 event = self._normalize("error", params)
                 if event is not None:
                     await self._events.put(event)
+                self._clear_rate_limited_turn(jobos_turn_id, provider_turn_id)
                 self._rate_limit_completed.discard(provider_turn_id)
                 self._rate_limit_settling.discard(provider_turn_id)
                 return
@@ -432,6 +438,7 @@ class CodexAppServerGateway:
                     f"codex:{self._event_namespace}:{provider_turn_id}:{self._event_sequence}",
                 )
             )
+            self._clear_rate_limited_turn(jobos_turn_id, provider_turn_id)
             self._rate_limit_settling.discard(provider_turn_id)
             return
         if (
@@ -444,8 +451,20 @@ class CodexAppServerGateway:
         event = self._normalize("error", params)
         if event is not None:
             await self._events.put(event)
+        self._clear_rate_limited_turn(jobos_turn_id, provider_turn_id)
         self._rate_limit_completed.discard(provider_turn_id)
         self._rate_limit_settling.discard(provider_turn_id)
+
+    def _clear_rate_limited_turn(
+        self, jobos_turn_id: str, provider_turn_id: str
+    ) -> None:
+        if (
+            self._jobos_turn_id == jobos_turn_id
+            and self._provider_turn_id == provider_turn_id
+        ):
+            self._jobos_turn_id = None
+            self._provider_turn_id = None
+            self._assistant_pending = ""
 
     def _normalize(self, method: str, params: dict[str, object]) -> GatewayEvent | None:
         turn_id = self._jobos_turn_id
@@ -525,6 +544,11 @@ class CodexAppServerGateway:
         return None
 
     async def close(self) -> None:
+        for task in tuple(self._rate_limit_tasks):
+            task.cancel()
+        if self._rate_limit_tasks:
+            await asyncio.gather(*self._rate_limit_tasks, return_exceptions=True)
+        self._rate_limit_tasks.clear()
         self._closed = True
         self._thread_id = None
         self._jobos_turn_id = None

--- a/services/api/tests/test_codex_adapter.py
+++ b/services/api/tests/test_codex_adapter.py
@@ -427,7 +427,8 @@ async def test_codex_rate_limit_is_scoped_and_never_blindly_retried(tmp_path: Pa
     retry_after = limited.detail["retry_after_seconds"]
     assert isinstance(retry_after, int)
     assert 1 <= retry_after <= 60
-    assert client.requests == requests_before_error + [
+    assert client.requests == [
+        *requests_before_error,
         (
             "turn/interrupt",
             {"threadId": "thread-a", "turnId": "provider-turn-a"},

--- a/services/api/tests/test_codex_adapter.py
+++ b/services/api/tests/test_codex_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 
@@ -21,6 +22,9 @@ class FakeCodexClient:
         self.subscribers: list[Callable[[str, object], Awaitable[None]]] = []
         self.started = False
         self.turns: list[dict[str, object]] = []
+        self.rate_limits: dict[str, object] = {}
+        self.interrupt_error = False
+        self.complete_before_interrupt_response = False
 
     @property
     def is_running(self) -> bool:
@@ -52,12 +56,27 @@ class FakeCodexClient:
                     }
                 ]
             }
+        if method == "account/rateLimits/read":
+            return {"rateLimits": self.rate_limits}
         if method == "turn/start":
             return {"turn": {"id": "provider-turn-a", "status": "inProgress"}}
         if method == "thread/read":
             assert isinstance(params, dict)
             return {"thread": {"id": params["threadId"], "turns": self.turns}}
         if method == "turn/interrupt":
+            if self.complete_before_interrupt_response:
+                assert isinstance(params, dict)
+                await self.emit(
+                    "turn/completed",
+                    {
+                        "threadId": params["threadId"],
+                        "turn": {"id": params["turnId"], "status": "interrupted"},
+                    },
+                )
+            if self.interrupt_error:
+                raise CodexRuntimeError(
+                    "AGENT_PROVIDER_UNAVAILABLE", "(FAKE) interrupt unavailable"
+                )
             return {}
         raise AssertionError(method)
 
@@ -106,7 +125,12 @@ async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: P
     await gateway.submit_turn("Tailor this", context())
 
     methods = [method for method, _ in client.requests]
-    assert methods == ["thread/start", "mcpServerStatus/list", "turn/start"]
+    assert methods == [
+        "thread/start",
+        "mcpServerStatus/list",
+        "account/rateLimits/read",
+        "turn/start",
+    ]
     thread_params = client.requests[0][1]
     assert isinstance(thread_params, dict)
     assert thread_params["sandbox"] == "read-only"
@@ -339,3 +363,304 @@ async def test_codex_redacts_credentials_split_across_stream_deltas(tmp_path: Pa
     assert tail.summary == "tail"
     assert terminal.state == "completed"
     assert "sk-proj" not in tail.summary
+
+
+@pytest.mark.anyio
+async def test_codex_rate_limit_is_scoped_and_never_blindly_retried(tmp_path: Path) -> None:
+    client = FakeCodexClient()
+    client.rate_limits = {
+        "primary": {"usedPercent": 100, "resetsAt": int(time.time()) + 60},
+        "secondary": {"usedPercent": 10, "resetsAt": int(time.time()) + 600},
+    }
+    factory = CodexGatewayFactory(client, cwd=tmp_path)
+    factory.create("conv_warm")
+    await client.emit(
+        "account/rateLimits/updated",
+        {
+            "rateLimits": {
+                "primary": {"usedPercent": 100, "resetsAt": int(time.time()) + 60},
+                "secondary": {"usedPercent": 10, "resetsAt": int(time.time()) + 600},
+            }
+        },
+    )
+    await client.emit(
+        "account/rateLimits/updated",
+        {"rateLimits": {"credits": {"hasCredits": True, "unlimited": False}}},
+    )
+    gateway = factory.create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    requests_before_error = list(client.requests)
+    events = gateway.stream_events()
+
+    await client.emit(
+        "error",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "willRetry": True,
+            "error": {
+                "message": "(FAKE) usage exhausted",
+                "codexErrorInfo": "usageLimitExceeded",
+            },
+        },
+    )
+    await client.emit(
+        "error",
+        {
+            "threadId": "other-thread",
+            "turnId": "other-provider-turn",
+            "willRetry": False,
+            "error": {
+                "message": "(FAKE) unrelated usage exhausted",
+                "codexErrorInfo": "usageLimitExceeded",
+            },
+        },
+    )
+
+    limited = await anext(events)
+    assert limited.event_type == "error"
+    assert limited.state == "failed"
+    assert limited.summary.startswith("Codex rate limit reached. Try again in ")
+    assert limited.detail["reason"] == "rate_limited"
+    assert limited.detail["retry"] is False
+    retry_after = limited.detail["retry_after_seconds"]
+    assert isinstance(retry_after, int)
+    assert 1 <= retry_after <= 60
+    assert client.requests == requests_before_error + [
+        (
+            "turn/interrupt",
+            {"threadId": "thread-a", "turnId": "provider-turn-a"},
+        )
+    ]
+    assert gateway.connection_state == "online"
+
+
+@pytest.mark.anyio
+async def test_codex_rate_limit_refresh_preserves_reset_through_sparse_update(
+    tmp_path: Path,
+) -> None:
+    client = FakeCodexClient()
+    client.rate_limits = {
+        "primary": {"usedPercent": 100, "resetsAt": int(time.time()) + 60}
+    }
+    factory = CodexGatewayFactory(client, cwd=tmp_path)
+    gateway = factory.create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    await client.emit(
+        "account/rateLimits/updated",
+        {"rateLimits": {"credits": {"hasCredits": False, "unlimited": False}}},
+    )
+    events = gateway.stream_events()
+    await client.emit(
+        "error",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "willRetry": False,
+            "error": {"codexErrorInfo": "usageLimitExceeded"},
+        },
+    )
+
+    limited = await anext(events)
+    assert limited.summary.startswith("Codex rate limit reached. Try again in ")
+    assert limited.detail["retry"] is False
+    retry_after = limited.detail["retry_after_seconds"]
+    assert isinstance(retry_after, int)
+    assert 1 <= retry_after <= 60
+
+
+@pytest.mark.anyio
+async def test_codex_expired_rate_limit_snapshot_omits_stale_countdown(tmp_path: Path) -> None:
+    client = FakeCodexClient()
+    factory = CodexGatewayFactory(client, cwd=tmp_path)
+    gateway = factory.create("conv_alpha")
+    await client.emit(
+        "account/rateLimits/updated",
+        {
+            "rateLimits": {
+                "primary": {"usedPercent": 100, "resetsAt": int(time.time()) - 1}
+            }
+        },
+    )
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    events = gateway.stream_events()
+    await client.emit(
+        "error",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "willRetry": False,
+            "error": {"codexErrorInfo": "usageLimitExceeded"},
+        },
+    )
+
+    limited = await anext(events)
+    assert limited.summary == "Codex rate limit reached"
+    assert limited.detail["retry_after_seconds"] is None
+
+
+@pytest.mark.anyio
+async def test_codex_full_rate_limit_refresh_replaces_stale_windows(tmp_path: Path) -> None:
+    client = FakeCodexClient()
+    factory = CodexGatewayFactory(client, cwd=tmp_path)
+    gateway = factory.create("conv_alpha")
+    await client.emit(
+        "account/rateLimits/updated",
+        {
+            "rateLimits": {
+                "primary": {"usedPercent": 100, "resetsAt": int(time.time()) + 60}
+            }
+        },
+    )
+    client.rate_limits = {"primary": None, "credits": {"hasCredits": True}}
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    events = gateway.stream_events()
+    await client.emit(
+        "error",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "willRetry": False,
+            "error": {"codexErrorInfo": "usageLimitExceeded"},
+        },
+    )
+
+    limited = await anext(events)
+    assert limited.summary == "Codex rate limit reached"
+    assert limited.detail["retry_after_seconds"] is None
+
+
+@pytest.mark.anyio
+async def test_codex_rate_limit_interrupt_failure_requires_recovery(tmp_path: Path) -> None:
+    client = FakeCodexClient()
+    client.interrupt_error = True
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    events = gateway.stream_events()
+    await client.emit(
+        "error",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "willRetry": True,
+            "error": {"codexErrorInfo": "usageLimitExceeded"},
+        },
+    )
+
+    limited = await anext(events)
+    assert limited.summary == "Codex rate limit reached; recovery required"
+    assert limited.detail == {
+        "reason": "transport_lost",
+        "cause": "rate_limited",
+        "retry": False,
+        "recovery_required": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_codex_rate_limit_refresh_keeps_update_delivered_after_read_response(
+    tmp_path: Path,
+) -> None:
+    class RacingClient(FakeCodexClient):
+        async def request(self, method: str, params: object | None = None) -> object:
+            if method == "account/rateLimits/read":
+                self.requests.append((method, params))
+                await self.emit(
+                    "account/rateLimits/updated",
+                    {
+                        "rateLimits": {
+                            "primary": {
+                                "usedPercent": 100,
+                                "resetsAt": int(time.time()) + 120,
+                            }
+                        }
+                    },
+                )
+                return {
+                    "rateLimits": {
+                        "primary": {
+                            "usedPercent": 100,
+                            "resetsAt": int(time.time()) + 60,
+                        }
+                    }
+                }
+            return await super().request(method, params)
+
+    client = RacingClient()
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    events = gateway.stream_events()
+    await client.emit(
+        "error",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "willRetry": False,
+            "error": {"codexErrorInfo": "usageLimitExceeded"},
+        },
+    )
+
+    limited = await anext(events)
+    retry_after = limited.detail["retry_after_seconds"]
+    assert isinstance(retry_after, int)
+    assert 61 <= retry_after <= 120
+
+
+@pytest.mark.anyio
+async def test_codex_rate_limit_survives_completion_before_interrupt_response(
+    tmp_path: Path,
+) -> None:
+    client = FakeCodexClient()
+    client.complete_before_interrupt_response = True
+    client.rate_limits = {
+        "primary": {"usedPercent": 100, "resetsAt": int(time.time()) + 60}
+    }
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    events = gateway.stream_events()
+    await client.emit(
+        "error",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "willRetry": True,
+            "error": {"codexErrorInfo": "usageLimitExceeded"},
+        },
+    )
+
+    limited = await anext(events)
+    assert limited.detail["reason"] == "rate_limited"
+    assert limited.detail["retry"] is False
+
+
+@pytest.mark.anyio
+async def test_codex_completed_rate_limit_does_not_require_recovery_on_interrupt_error(
+    tmp_path: Path,
+) -> None:
+    client = FakeCodexClient()
+    client.complete_before_interrupt_response = True
+    client.interrupt_error = True
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    await gateway.create_or_resume_conversation(None)
+    await gateway.submit_turn("Do work", context())
+    events = gateway.stream_events()
+    await client.emit(
+        "error",
+        {
+            "threadId": "thread-a",
+            "turnId": "provider-turn-a",
+            "willRetry": True,
+            "error": {"codexErrorInfo": "usageLimitExceeded"},
+        },
+    )
+
+    limited = await anext(events)
+    assert limited.detail["reason"] == "rate_limited"
+    assert "recovery_required" not in limited.detail

--- a/services/api/tests/test_connected_agent_auth.py
+++ b/services/api/tests/test_connected_agent_auth.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
-from jobos_api.codex_runtime import CODEX_APP_SERVER_RECEIPT_ID, CodexRpcError
+from jobos_api.codex_runtime import (
+    CODEX_APP_SERVER_RECEIPT_ID,
+    CODEX_APP_SERVER_VERSION,
+    CodexRpcError,
+)
 from jobos_api.connected_agent_auth import (
     AuthFlowError,
     CodexAuthFlowBroker,
@@ -499,3 +505,20 @@ async def test_keyring_isolation_accepts_the_trusted_jobos_mcp_config(tmp_path: 
     config = (tmp_path / "codex-home" / "config.toml").read_text(encoding="utf-8")
     assert "[mcp_servers.jobos]" in config
     assert str(launcher.resolve()) in config
+
+
+def test_support_diagnostics_are_bounded_and_credential_free() -> None:
+    secret = "credential-that-must-not-enter-support-output"
+    runtime = CodexConnectedAgentRuntime(cast(Any, FakeCodexClient()), FakeVault())
+    diagnostics = runtime.diagnostics()
+    serialized = json.dumps(diagnostics, sort_keys=True)
+
+    assert diagnostics == {
+        "provider": "codex",
+        "runtime_version": CODEX_APP_SERVER_VERSION,
+        "runtime_receipt_id": CODEX_APP_SERVER_RECEIPT_ID,
+    }
+    assert len(serialized) < 512
+    assert secret not in serialized
+    assert "credential" not in serialized.lower()
+    assert "authorization" not in serialized.lower()

--- a/services/api/tests/test_connected_agent_auth.py
+++ b/services/api/tests/test_connected_agent_auth.py
@@ -508,7 +508,7 @@ async def test_keyring_isolation_accepts_the_trusted_jobos_mcp_config(tmp_path: 
 
 
 def test_support_diagnostics_are_bounded_and_credential_free() -> None:
-    secret = "credential-that-must-not-enter-support-output"
+    forbidden_marker = "credential-that-must-not-enter-support-output"
     runtime = CodexConnectedAgentRuntime(cast(Any, FakeCodexClient()), FakeVault())
     diagnostics = runtime.diagnostics()
     serialized = json.dumps(diagnostics, sort_keys=True)
@@ -519,6 +519,6 @@ def test_support_diagnostics_are_bounded_and_credential_free() -> None:
         "runtime_receipt_id": CODEX_APP_SERVER_RECEIPT_ID,
     }
     assert len(serialized) < 512
-    assert secret not in serialized
+    assert forbidden_marker not in serialized
     assert "credential" not in serialized.lower()
     assert "authorization" not in serialized.lower()


### PR DESCRIPTION
## What changed
- keep concurrent Hermes/Codex failures, cancellation, and recovery scoped to the affected chat/provider
- distinguish remote host outages from reachable-host authentication failures and disable Send without local fallback
- add bounded credential-free support diagnostics acceptance coverage
- normalize Codex usage exhaustion as a scoped non-retryable event, refresh authoritative countdown state, stop provider-declared retries, and preserve recovery when interruption cannot be confirmed
- add the Phase 7 acceptance map and update the Connected Agents implementation plan

## Verification
- `pnpm check` — passed (580 desktop tests; 1,010 Python tests, 4 skipped; lint, typecheck, build, public-tree, fixture manifest, license checks)
- `pnpm contracts:check` — passed
- focused Codex adapter suite — 16 passed
- focused AgentPanel regression suite — 28 passed
- independent Codex review — findings applied across rate-limit ordering, interruption, recovery, and host/auth status handling
- added-line credential scan — no bearer tokens, OpenAI-style tokens, authorization header values, or private keys
- exact-head macOS clean clone — passed for `e2fee4c8bd7ad2ab2d6bd731ff9e2b06ee597a44`

Closes #118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate-limit handling for connected agent conversations, including retry timing and smoother recovery when usage limits are reached.
  * Added clearer connectivity notices: “JobOS host unavailable” for disconnected states and “Device authentication needs attention” for degraded states.
  * Send actions are disabled while connectivity or authentication issues require attention.

* **Documentation**
  * Added acceptance evidence and updated implementation progress documentation for connected-agent capabilities and security verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->