### PR TITLE
Fix migrated Hermes agent missing from New Chat

### DIFF
--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -14,7 +14,7 @@ from functools import wraps
 from pathlib import Path
 from threading import Lock
 from typing import Annotated, Any, Literal, ParamSpec, TypeVar, cast
-from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
 from uuid import uuid4
 
 from fastapi import (
@@ -307,6 +307,14 @@ from jobos_api.state_store import (
 )
 from jobos_api.synthetic_demo import DEMO_JOB_ID
 from jobos_api.workspace import WorkspaceSnapshotCommand, WorkspaceSnapshotResponse
+
+
+def _hermes_registry_endpoint(dashboard_url: str) -> str:
+    """Persist only the non-secret dashboard origin, never its WebSocket path."""
+    parsed = urlsplit(dashboard_url)
+    scheme = {"ws": "http", "wss": "https"}.get(parsed.scheme, parsed.scheme)
+    return urlunsplit((scheme, parsed.netloc, "", "", ""))
+
 
 ConversationId = Annotated[
     str, PathParameter(pattern=r"^conv_[A-Za-z0-9_-]{1,128}$", max_length=133)
@@ -693,16 +701,17 @@ def create_app(
         }
         if (
             registry_data.connected_agent_migration is not None
-            and any(
-                item.status != "complete"
-                for item in registry_data.connected_agent_migration.profiles
-            )
+            and installation_profiles.legacy_hermes_configuration_required()
             and settings.hermes_dashboard_url
             and settings.hermes_dashboard_token
             and settings.hermes_job_hunter_cwd
+            and settings.hermes_default_model_id
+            and settings.hermes_default_reasoning_effort
         ):
             installation_profiles.apply_legacy_hermes_configuration(
-                endpoint_url=settings.hermes_dashboard_url
+                endpoint_url=_hermes_registry_endpoint(settings.hermes_dashboard_url),
+                default_model_id=settings.hermes_default_model_id,
+                default_reasoning_effort=settings.hermes_default_reasoning_effort,
             )
         installation_profiles.resume_connected_agent_migration(
             migration_runtime, owner_device_id=settings.device_id

--- a/services/api/jobos_api/installation_profiles.py
+++ b/services/api/jobos_api/installation_profiles.py
@@ -9,7 +9,7 @@ import secrets
 import stat
 import unicodedata
 from contextlib import contextmanager
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from threading import Lock
 from typing import Literal
@@ -890,8 +890,7 @@ class InstallationProfileRegistry:
             journal = data.connected_agent_migration
             if journal is None:
                 raise InstallationProfileConflict("No legacy Hermes migration is active")
-            if all(item.status == "complete" for item in journal.profiles):
-                raise InstallationProfileConflict("Legacy Hermes migration is already complete")
+            migration_complete = all(item.status == "complete" for item in journal.profiles)
             target = next(
                 item for item in data.connected_agents if item.id == journal.connected_agent_id
             )
@@ -909,6 +908,13 @@ class InstallationProfileRegistry:
                 and target.disconnected_at is None
             ):
                 return target
+            if not self._legacy_hermes_configuration_required(data, target):
+                message = (
+                    "Legacy Hermes migration is already complete"
+                    if migration_complete
+                    else "Legacy Hermes migration target was modified"
+                )
+                raise InstallationProfileConflict(message)
             timestamp = now or utc_now()
             changed = target.model_copy(
                 update={
@@ -934,6 +940,50 @@ class InstallationProfileRegistry:
             )
             self._write_unlocked(updated)
             return changed
+
+    @staticmethod
+    def _legacy_hermes_configuration_required(
+        data: InstallationProfileRegistryData,
+        target: ConnectedAgentRecord,
+    ) -> bool:
+        """Recognize only the untouched provider-offline migration placeholder."""
+        if (
+            target.lifecycle != "disconnected"
+            or target.connection_config is not None
+            or target.credential_reference is not None
+            or target.default_model_id is not None
+            or target.default_reasoning_effort is not None
+            or target.account_summary is not None
+            or target.account_fingerprint is not None
+            or target.disconnected_at is None
+            or target.created_at != target.updated_at
+            or target.updated_at != target.disconnected_at
+        ):
+            return False
+        for replay in data.idempotency_replays:
+            if replay.operation != "agent_disconnect":
+                continue
+            try:
+                disconnected = ConnectedAgentRecord.model_validate_json(replay.response_json)
+            except ValidationError as error:
+                raise InstallationProfileRegistryError(
+                    "Connected Agent disconnect replay is invalid"
+                ) from error
+            if disconnected.id == target.id:
+                return False
+        return True
+
+    def legacy_hermes_configuration_required(self) -> bool:
+        """Allow late runtime hydration without overriding a user disconnect."""
+        with self.locked():
+            data = self.load()
+            journal = data.connected_agent_migration
+            if journal is None:
+                return False
+            target = next(
+                item for item in data.connected_agents if item.id == journal.connected_agent_id
+            )
+            return self._legacy_hermes_configuration_required(data, target)
 
     def mark_profile_migration(
         self,
@@ -1433,6 +1483,8 @@ class InstallationProfileRegistry:
             if target is None:
                 raise InstallationProfileNotFound("Connected Agent was not found")
             timestamp = now or utc_now()
+            if timestamp <= target.updated_at:
+                timestamp = target.updated_at + timedelta(microseconds=1)
             changed = target.model_copy(
                 update={
                     "lifecycle": "disconnected",

--- a/services/api/jobos_api/macos_runtime.py
+++ b/services/api/jobos_api/macos_runtime.py
@@ -55,6 +55,8 @@ _CONFIG_FIELDS = {
     "artifact_roots",
     "hermes_dashboard_url",
     "hermes_job_hunter_cwd",
+    "hermes_default_model_id",
+    "hermes_default_reasoning_effort",
     "keychain_helper_path",
     "keychain_helper_sha256",
     "codex_app_server_path",
@@ -130,6 +132,8 @@ class RuntimeServiceConfig:
     artifact_roots: tuple[Path, ...]
     hermes_dashboard_url: str | None
     hermes_job_hunter_cwd: Path | None
+    hermes_default_model_id: str | None
+    hermes_default_reasoning_effort: str | None
     keychain_helper_path: Path | None
     keychain_helper_sha256: str | None
     codex_app_server_path: Path | None
@@ -220,6 +224,22 @@ class RuntimeServiceConfig:
             value.get("job_hunter_db_path"), "job_hunter_db_path"
         )
         hermes_cwd = value.get("hermes_job_hunter_cwd")
+        hermes_default_model_id = value.get("hermes_default_model_id")
+        hermes_default_reasoning_effort = value.get("hermes_default_reasoning_effort")
+        if (hermes_default_model_id is None) != (hermes_default_reasoning_effort is None):
+            raise ValueError("Hermes defaults require model and reasoning effort")
+        if hermes_default_model_id is not None and (
+            not isinstance(hermes_default_model_id, str)
+            or not 1 <= len(hermes_default_model_id) <= 256
+            or any(char in hermes_default_model_id for char in "\r\n\0")
+        ):
+            raise ValueError("Hermes default model is invalid")
+        if hermes_default_reasoning_effort is not None and (
+            not isinstance(hermes_default_reasoning_effort, str)
+            or not 1 <= len(hermes_default_reasoning_effort) <= 64
+            or any(char in hermes_default_reasoning_effort for char in "\r\n\0")
+        ):
+            raise ValueError("Hermes default reasoning effort is invalid")
         if (job_provider == "job-hunter" or artifact_provider == "gateway") and (
             facade_source is None or job_hunter_db is None
         ):
@@ -268,6 +288,8 @@ class RuntimeServiceConfig:
                 if hermes_cwd is not None
                 else None
             ),
+            hermes_default_model_id=hermes_default_model_id,
+            hermes_default_reasoning_effort=hermes_default_reasoning_effort,
             keychain_helper_path=keychain_helper,
             keychain_helper_sha256=keychain_helper_sha256,
             codex_app_server_path=codex_app_server,
@@ -383,6 +405,11 @@ def build_service_environment(
         environment["JOBOS_HERMES_DASHBOARD_TOKEN"] = hermes_dashboard_token
     if config.hermes_job_hunter_cwd:
         environment["JOBOS_HERMES_JOB_HUNTER_CWD"] = str(config.hermes_job_hunter_cwd)
+    if config.hermes_default_model_id and config.hermes_default_reasoning_effort:
+        environment["JOBOS_HERMES_DEFAULT_MODEL_ID"] = config.hermes_default_model_id
+        environment["JOBOS_HERMES_DEFAULT_REASONING_EFFORT"] = (
+            config.hermes_default_reasoning_effort
+        )
     if config.codex_app_server_path:
         if service_config_path is None:
             raise ValueError("installed Codex runtime requires the service config path")
@@ -581,6 +608,8 @@ def build_local_runtime_config(
             "artifact_roots": [],
             "hermes_dashboard_url": None,
             "hermes_job_hunter_cwd": None,
+            "hermes_default_model_id": None,
+            "hermes_default_reasoning_effort": None,
             "keychain_helper_path": codex_paths.get("keychain_helper_path"),
             "keychain_helper_sha256": codex_paths.get("keychain_helper_sha256"),
             "codex_app_server_path": codex_paths.get("codex_app_server_path"),

--- a/services/api/jobos_api/main.py
+++ b/services/api/jobos_api/main.py
@@ -89,6 +89,10 @@ def settings_from_environment() -> Settings:
         hermes_dashboard_url=hermes_url,
         hermes_dashboard_token=hermes_token,
         hermes_job_hunter_cwd=Path(hermes_cwd) if hermes_cwd else None,
+        hermes_default_model_id=os.environ.get("JOBOS_HERMES_DEFAULT_MODEL_ID"),
+        hermes_default_reasoning_effort=os.environ.get(
+            "JOBOS_HERMES_DEFAULT_REASONING_EFFORT"
+        ),
         hermes_request_timeout=float(os.environ.get("JOBOS_HERMES_REQUEST_TIMEOUT", "5")),
         codex_app_server_path=(
             Path(value) if (value := os.environ.get("JOBOS_CODEX_APP_SERVER_PATH")) else None

--- a/services/api/jobos_api/settings.py
+++ b/services/api/jobos_api/settings.py
@@ -80,6 +80,10 @@ class Settings(BaseModel):
     hermes_dashboard_url: str | None = None
     hermes_dashboard_token: str | None = Field(default=None, min_length=16, repr=False)
     hermes_job_hunter_cwd: Path | None = None
+    hermes_default_model_id: str | None = Field(default=None, min_length=1, max_length=256)
+    hermes_default_reasoning_effort: str | None = Field(
+        default=None, min_length=1, max_length=64
+    )
     hermes_request_timeout: float = Field(default=5.0, gt=0, le=30)
     codex_app_server_path: Path | None = None
     codex_home_path: Path | None = None
@@ -141,6 +145,10 @@ class Settings(BaseModel):
 
     @model_validator(mode="after")
     def validate_unique_device_credentials(self) -> "Settings":
+        if (self.hermes_default_model_id is None) != (
+            self.hermes_default_reasoning_effort is None
+        ):
+            raise ValueError("Hermes defaults require model and reasoning effort")
         device_ids = [
             self.device_id,
             MCP_RUNTIME_DEVICE_ID,

--- a/services/api/tests/test_connected_agent_persistence.py
+++ b/services/api/tests/test_connected_agent_persistence.py
@@ -447,6 +447,40 @@ def test_offline_v1_v31_migration_is_exact_idempotent_and_unknown_model_stays_lo
     assert registry.resume_connected_agent_migration(runtime) == completed
 
 
+def test_completed_provider_offline_migration_accepts_late_hermes_runtime_configuration(
+    tmp_path,
+):
+    root = tmp_path / "installation"
+    runtime = anchored_runtime(root)
+    JobOsStateStore(runtime.state_db_path).initialize(installation_profile_id=PROFILE_A)
+    registry = InstallationProfileRegistry(root / "installation-profiles.json")
+    registry.write(registry_data(root, runtime).model_copy(update={"schema_version": 1}))
+    registry.load_or_bootstrap(runtime, now=NOW)
+
+    completed = registry.resume_connected_agent_migration(runtime)
+    assert completed.connected_agent_migration is not None
+    assert completed.connected_agents[0].lifecycle == "disconnected"
+    assert registry.legacy_hermes_configuration_required() is True
+
+    repaired = registry.apply_legacy_hermes_configuration(
+        endpoint_url="http://127.0.0.1:9120",
+        default_model_id="gpt-5.6-sol-900k",
+        default_reasoning_effort="medium",
+        now=NOW,
+    )
+
+    assert repaired.lifecycle == "connected"
+    assert repaired.connection_config is not None
+    assert repaired.connection_config.model_dump() == {
+        "endpoint_url": "http://127.0.0.1:9120",
+        "runtime_profile": None,
+    }
+    assert repaired.disconnected_at is None
+    assert repaired.default_model_id == "gpt-5.6-sol-900k"
+    assert repaired.default_reasoning_effort == "medium"
+    assert registry.legacy_hermes_configuration_required() is False
+
+
 def test_completed_legacy_migration_cannot_reconnect_disconnected_agent_on_restart(tmp_path):
     root = tmp_path / "installation"
     runtime = anchored_runtime(root)
@@ -465,6 +499,7 @@ def test_completed_legacy_migration_cannot_reconnect_disconnected_agent_on_resta
         now=NOW,
     )
     assert disconnected.lifecycle == "disconnected"
+    assert registry.legacy_hermes_configuration_required() is False
 
     with pytest.raises(InstallationProfileConflict, match="already complete"):
         registry.apply_legacy_hermes_configuration(endpoint_url="http://127.0.0.1:9120")
@@ -474,6 +509,33 @@ def test_completed_legacy_migration_cannot_reconnect_disconnected_agent_on_resta
     )
     assert migrated.lifecycle == "disconnected"
     assert migrated.connection_config is None
+
+
+def test_pending_legacy_migration_cannot_reconnect_explicitly_disconnected_agent(tmp_path):
+    root = tmp_path / "installation"
+    runtime = anchored_runtime(root)
+    JobOsStateStore(runtime.state_db_path).initialize(installation_profile_id=PROFILE_A)
+    registry = InstallationProfileRegistry(root / "installation-profiles.json")
+    registry.write(registry_data(root, runtime).model_copy(update={"schema_version": 1}))
+    pending = registry.load_or_bootstrap(runtime, now=NOW)
+    journal = pending.connected_agent_migration
+    assert journal is not None
+    assert {item.status for item in journal.profiles} == {"pending"}
+
+    disconnected = registry.disconnect_connected_agent(
+        journal.connected_agent_id,
+        expected_registry_revision=pending.registry_revision,
+        idempotency_key="disconnect-during-migration",
+        now=NOW,
+    )
+
+    assert disconnected.lifecycle == "disconnected"
+    assert disconnected.updated_at > disconnected.created_at
+    persisted = registry.load()
+    registry.write(persisted.model_copy(update={"idempotency_replays": ()}))
+    assert registry.legacy_hermes_configuration_required() is False
+    with pytest.raises(InstallationProfileConflict, match="target was modified"):
+        registry.apply_legacy_hermes_configuration(endpoint_url="http://127.0.0.1:9120")
 
 
 def test_known_legacy_defaults_seal_exact_model_and_binding_is_immutable(tmp_path):

--- a/services/api/tests/test_connected_agents_api.py
+++ b/services/api/tests/test_connected_agents_api.py
@@ -289,6 +289,82 @@ def test_provider_runtime_routes_hermes_to_its_fixed_profile_model(tmp_path):
     }
 
 
+def test_app_startup_repairs_completed_offline_hermes_migration_for_new_chat(tmp_path):
+    registry_path = tmp_path / "installation-profiles.json"
+    state_path = (tmp_path / "state" / "jobos.db").absolute()
+    runtime = AnchoredRuntime(
+        job_provider="sqlite",
+        artifact_provider="local",
+        state_db_path=state_path,
+        jobs_db_path=(tmp_path / "jobs" / "jobs.db").absolute(),
+        local_artifact_root=(tmp_path / "artifacts").absolute(),
+    )
+    JobOsStateStore(state_path).initialize(installation_profile_id=PROFILE_ID)
+    registry = InstallationProfileRegistry(registry_path)
+    registry.write(
+        InstallationProfileRegistryData(
+            schema_version=1,
+            registry_revision=1,
+            active_profile_id=PROFILE_ID,
+            profiles=(
+                InstallationProfileRecord(
+                    profile_id=PROFILE_ID,
+                    display_name="(FAKE) Personal",
+                    storage_mode="anchored",
+                    created_at=NOW,
+                    updated_at=NOW,
+                    anchored_runtime=runtime,
+                ),
+            ),
+        )
+    )
+    registry.load_or_bootstrap(runtime, now=NOW)
+    registry.resume_connected_agent_migration(runtime)
+    assert registry.load().connected_agents[0].lifecycle == "disconnected"
+
+    app = create_app(
+        Settings(
+            device_token=TOKEN,
+            mcp_token="(FAKE)-mcp-token",
+            device_id="primary-device",
+            state_db_path=state_path,
+            jobs_db_path=runtime.jobs_db_path,
+            local_artifact_root=runtime.local_artifact_root,
+            installation_registry_path=registry_path,
+            installation_profile_id=PROFILE_ID,
+            installation_profile_name="(FAKE) Personal",
+            hermes_dashboard_url="ws://127.0.0.1:9120/api/ws",
+            hermes_dashboard_token="(FAKE)-hermes-dashboard-token",
+            hermes_job_hunter_cwd=tmp_path,
+            hermes_default_model_id="gpt-5.6-sol-900k",
+            hermes_default_reasoning_effort="medium",
+        ),
+        agent_gateway_factory=ReadyGatewayFactory(),  # type: ignore[arg-type]
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/v1/connected-agents", headers=auth())
+        assert response.status_code == 200
+        hermes = response.json()["agents"][0]
+        assert hermes["provider"] == "hermes"
+        assert hermes["lifecycle"] == "connected"
+        assert hermes["default_model_id"] == "gpt-5.6-sol-900k"
+        assert hermes["default_reasoning_effort"] == "medium"
+        assert hermes["health"]["provider_available"] is True
+        models = client.get(f"/v1/connected-agents/{hermes['id']}/models", headers=auth())
+        assert models.status_code == 200
+        assert models.json() == {
+            "live": True,
+            "models": [
+                {
+                    "model_id": "gpt-5.6-sol-900k",
+                    "display_name": "gpt-5.6-sol-900k",
+                    "reasoning_efforts": ["medium"],
+                }
+            ],
+        }
+
+
 def test_connected_agent_api_resolves_default_and_provisions_immutable_chat(tmp_path):
     app, registry, state_store, gateway_factory, _ = setup_app(tmp_path)
 

--- a/services/api/tests/test_macos_runtime.py
+++ b/services/api/tests/test_macos_runtime.py
@@ -43,6 +43,8 @@ def runtime_mapping(tmp_path: Path) -> dict[str, object]:
         "artifact_roots": [str(tmp_path / "job-hunter/resume/exports")],
         "hermes_dashboard_url": "ws://127.0.0.1:9119/api/ws",
         "hermes_job_hunter_cwd": str(tmp_path / "job-hunter"),
+        "hermes_default_model_id": "gpt-5.6-sol-900k",
+        "hermes_default_reasoning_effort": "medium",
         "device_id": "mini-device",
         "remote_device_ids": [],
         "host": "127.0.0.1",
@@ -61,6 +63,8 @@ def local_runtime_mapping(tmp_path: Path) -> dict[str, object]:
             "artifact_roots": [],
             "hermes_dashboard_url": None,
             "hermes_job_hunter_cwd": None,
+            "hermes_default_model_id": None,
+            "hermes_default_reasoning_effort": None,
         }
     )
     return value
@@ -313,6 +317,8 @@ def test_service_environment_and_uvicorn_command_are_fixed_and_loopback_only(tmp
         "JOBOS_HERMES_DASHBOARD_URL": "ws://127.0.0.1:9119/api/ws",
         "JOBOS_HERMES_DASHBOARD_TOKEN": "hermes-secret-value",
         "JOBOS_HERMES_JOB_HUNTER_CWD": str(tmp_path / "job-hunter"),
+        "JOBOS_HERMES_DEFAULT_MODEL_ID": "gpt-5.6-sol-900k",
+        "JOBOS_HERMES_DEFAULT_REASONING_EFFORT": "medium",
         "JOBOS_CAREER_PROFILE_ENABLED": "1",
         "JOBOS_CAREER_PROFILE_AGENT_ID": "trusted-local-mcp",
         "JOBOS_CAREER_PROFILE_AGENT_DISPLAY_NAME": "JobOS Agent",

--- a/services/api/tests/test_real_job_hunter_adapter.py
+++ b/services/api/tests/test_real_job_hunter_adapter.py
@@ -20,6 +20,43 @@ from job_hunter.facade import JobHunterFacade
 from job_hunter.storage import JobStorage
 
 
+class ActiveTurnGateway:
+    connection_state = "online"
+
+    async def start(self):
+        return None
+
+    async def create_or_resume_conversation(self, stored_session_id):
+        return "stored-real-adapter-test", "live-real-adapter-test"
+
+    async def submit_turn(self, text, context):
+        return None
+
+    async def detach_conversation(self):
+        return None
+
+    async def stream_events(self):
+        if False:
+            yield None
+
+    async def interrupt_turn(self, turn_id):
+        return None
+
+    async def respond_to_review(self, turn_id, approval_id, *, approved):
+        return None
+
+    async def recover_active_turn(self, stored_session_id, turn_id):
+        return None
+
+    async def close(self):
+        return None
+
+
+class ActiveTurnGatewayFactory:
+    def create(self, conversation_id):
+        return ActiveTurnGateway()
+
+
 def test_real_job_hunter_adapter_reports_ready_while_jobos_owns_publication(tmp_path):
     workspace = tmp_path / "job-hunter"
     workspace.mkdir()
@@ -66,11 +103,26 @@ def test_real_job_hunter_adapter_reports_ready_while_jobos_owns_publication(tmp_
         "idempotency_key": "real-adapter-publish",
     }
 
-    with TestClient(create_app(configured)) as client:
+    with TestClient(
+        create_app(configured, agent_gateway_factory=ActiveTurnGatewayFactory())
+    ) as client:
         health = client.get("/v1/health")
+        created_conversation = client.post(
+            "/v1/conversations",
+            headers=owner_headers,
+            json={"selected_job_id": job_id},
+        )
+        conversation_id = created_conversation.json()["conversation_id"]
+        started = client.post(
+            f"/v1/conversations/{conversation_id}/messages",
+            headers=owner_headers,
+            json={"text": "Keep publication correlation active", "idempotency_key": "publish-turn"},
+        )
+        turn_id = started.json()["turn_id"]
         published = client.post(
             f"/v1/jobs/{job_id}/artifacts/publish",
             headers=mcp_headers,
+            params={"conversation_id": conversation_id, "turn_id": turn_id},
             json=payload,
         )
         listed = client.get(
@@ -85,6 +137,7 @@ def test_real_job_hunter_adapter_reports_ready_while_jobos_owns_publication(tmp_
 
     assert health.status_code == 200
     assert health.json()["artifact_gateway"] == "available"
+    assert started.status_code == 201
     assert published.status_code == 200
     assert listed.status_code == 200
     assert downloaded.status_code == 200


### PR DESCRIPTION
## What changed
- hydrate an untouched provider-offline Hermes migration after installed runtime configuration becomes available
- preserve explicit user disconnects, including interrupted migrations and replay-history eviction
- persist Hermes model/reasoning defaults through the installed macOS runtime
- normalize the persisted Hermes endpoint to a secret-free HTTP origin
- update the real JobHunter publication proof for active-turn and selected-job correlation

## Product result
The previously connected Hermes / JobHunter agent becomes selectable beside Codex in New Chat without silently reconnecting an agent the user intentionally disconnected.

## Verification
- `pnpm check` — passed
- 44 focused persistence/API/real-adapter tests — passed
- Ruff and `git diff --check` — passed
- independent Codex review (medium reasoning) — passed with no security or logic findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional default Hermes model and reasoning settings.
  - Added support for configuring these values through environment-based settings.
  - Improved legacy Hermes migration and reconnection behavior.

- **Bug Fixes**
  - Preserved explicit agent disconnections during migration.
  - Improved connection timestamp ordering for reliable state tracking.
  - Corrected dashboard URL normalization during configuration migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->