### PR TITLE
Fix Hermes availability when Codex is connected

### DIFF
--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -644,10 +644,6 @@ def create_app(
             mcp_command=settings.codex_mcp_command,
             mcp_args=settings.codex_mcp_args,
         )
-        if selected_connected_agent_runtime is None:
-            selected_connected_agent_runtime = CodexConnectedAgentRuntime(
-                codex_client, codex_vault
-            )
 
     if selected_connected_agent_runtime is None:
         provider_controls: dict[str, ConnectedAgentRuntimeControl] = {

--- a/services/api/tests/test_connected_agents_api.py
+++ b/services/api/tests/test_connected_agents_api.py
@@ -338,6 +338,8 @@ def test_app_startup_repairs_completed_offline_hermes_migration_for_new_chat(tmp
             hermes_job_hunter_cwd=tmp_path,
             hermes_default_model_id="gpt-5.6-sol-900k",
             hermes_default_reasoning_effort="medium",
+            codex_app_server_path=tmp_path / "(FAKE)-codex-app-server",
+            codex_home_path=tmp_path / "(FAKE)-codex-home",
         ),
         agent_gateway_factory=ReadyGatewayFactory(),  # type: ignore[arg-type]
     )


### PR DESCRIPTION
## What changed
- compose Hermes and Codex provider controls instead of selecting Codex-only control
- extend the Hermes migration regression to run with Codex configured

## Root cause
Codex initialization preselected a Codex-only Connected Agent runtime, preventing the provider router from registering Hermes. Hermes remained durably connected but reported runtime unavailable and exposed no live models.

## Verification
- focused dual-provider regression passes
- full Python suite passes (2 expected skips)
- 581 desktop tests pass
- lint, typecheck, contracts, updater tests, and production build pass
- live reproduction confirmed before fix: lifecycle connected + provider unavailable
