### PR TITLE
Fix Codex turns after dual-provider routing

### DIFF
--- a/services/api/jobos_api/codex_adapter.py
+++ b/services/api/jobos_api/codex_adapter.py
@@ -191,6 +191,8 @@ class CodexAppServerGateway:
         self, stored_session_id: str | None
     ) -> tuple[str, str]:
         await self.start()
+        if stored_session_id is not None and stored_session_id == self._thread_id:
+            return stored_session_id, stored_session_id
         params: dict[str, object] = {
             "cwd": str(self._cwd),
             "approvalPolicy": "never",

--- a/services/api/tests/test_codex_adapter.py
+++ b/services/api/tests/test_codex_adapter.py
@@ -167,6 +167,19 @@ async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: P
 
 
 @pytest.mark.anyio
+async def test_codex_attachment_is_idempotent_for_the_current_live_thread(
+    tmp_path: Path,
+) -> None:
+    client = FakeCodexClient()
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+
+    stored_id, _ = await gateway.create_or_resume_conversation(None)
+    assert await gateway.create_or_resume_conversation(stored_id) == (stored_id, stored_id)
+
+    assert [method for method, _ in client.requests] == ["thread/start"]
+
+
+@pytest.mark.anyio
 async def test_codex_rejects_turn_when_canonical_jobos_mcp_is_not_ready(tmp_path: Path) -> None:
     client = FakeCodexClient(ready=False)
     gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")


### PR DESCRIPTION
## What changed
- reuse the already-attached live Codex thread instead of issuing a duplicate `thread/resume` before each turn
- add regression coverage for idempotent attachment

## Root cause
JobOS provisions a Codex thread when a bound chat is created. The first message then asked the same live gateway to resume that already-attached thread, which the live Codex App Server rejected. Hermes tolerated its equivalent lifecycle path, hiding the issue until both providers were exercised together.

## Verification
- regression test failed before the fix and passed after
- full `test_codex_adapter.py` passed
- Connected Agents API, runtime router, and agent contract suites passed
- full `pnpm check` passed
- real pinned Codex runtime acceptance passed: live thread reuse, completed assistant turn, exact `CODEX_MIC_CHECK_OK` response
- Hermes remained operational through the shared API path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation resumption so an already active thread is reused without starting a duplicate thread.
  * Prevented unnecessary provider requests when continuing an existing conversation. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->