### PR TITLE
Recover Codex chats missing their first rollout

### DIFF
--- a/services/api/jobos_api/codex_adapter.py
+++ b/services/api/jobos_api/codex_adapter.py
@@ -10,7 +10,12 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
 from .agent_gateway import AgentContext, ConnectionState, GatewayEvent
-from .codex_runtime import CodexRpcClient, CodexRuntimeError, jobos_mcp_ready
+from .codex_runtime import (
+    CodexRpcClient,
+    CodexRpcError,
+    CodexRuntimeError,
+    jobos_mcp_ready,
+)
 from .hermes_adapter import _prompt_with_context
 from .redaction import redact_detail, sanitize_assistant_text, sanitize_text
 
@@ -204,14 +209,33 @@ class CodexAppServerGateway:
         else:
             method = "thread/resume"
             params["threadId"] = stored_session_id
-        result = await self._client.request(method, params)
+        replaced_missing_rollout = False
+        try:
+            result = await self._client.request(method, params)
+        except CodexRpcError as error:
+            missing_rollout_message = (
+                f"no rollout found for thread id {stored_session_id}"
+            )
+            if (
+                stored_session_id is None
+                or error.rpc_code != -32600
+                or error.safe_message != missing_rollout_message
+            ):
+                raise
+            replaced_missing_rollout = True
+            params.pop("threadId", None)
+            result = await self._client.request("thread/start", params)
         thread = result.get("thread") if isinstance(result, dict) else None
         thread_id = thread.get("id") if isinstance(thread, dict) else None
         if not isinstance(thread_id, str) or not thread_id:
             raise CodexRuntimeError(
                 "AGENT_PROVIDER_UNAVAILABLE", "Codex conversation lifecycle failed"
             )
-        if stored_session_id is not None and thread_id != stored_session_id:
+        if (
+            stored_session_id is not None
+            and not replaced_missing_rollout
+            and thread_id != stored_session_id
+        ):
             raise CodexRuntimeError(
                 "AGENT_PROVIDER_UNAVAILABLE", "Codex resumed the wrong conversation"
             )

--- a/services/api/tests/test_codex_adapter.py
+++ b/services/api/tests/test_codex_adapter.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from jobos_api.agent_gateway import AgentContext
 from jobos_api.codex_adapter import CodexGatewayFactory
-from jobos_api.codex_runtime import CodexRuntimeError
+from jobos_api.codex_runtime import CodexRpcError, CodexRuntimeError
 
 
 @pytest.fixture
@@ -26,6 +26,7 @@ class FakeCodexClient:
         self.rate_limits: dict[str, object] = {}
         self.interrupt_error = False
         self.complete_before_interrupt_response = False
+        self.resume_error: CodexRpcError | None = None
         self.server_request_handler: Callable[[str, object], Awaitable[object]] | None = None
 
     @property
@@ -40,6 +41,8 @@ class FakeCodexClient:
         if method == "thread/start":
             return {"thread": {"id": "thread-a", "turns": []}}
         if method == "thread/resume":
+            if self.resume_error is not None:
+                raise self.resume_error
             assert isinstance(params, dict)
             return {"thread": {"id": params["threadId"], "turns": self.turns}}
         if method == "mcpServerStatus/list":
@@ -177,6 +180,38 @@ async def test_codex_attachment_is_idempotent_for_the_current_live_thread(
     assert await gateway.create_or_resume_conversation(stored_id) == (stored_id, stored_id)
 
     assert [method for method, _ in client.requests] == ["thread/start"]
+
+
+@pytest.mark.anyio
+async def test_codex_replaces_a_missing_pre_turn_rollout(tmp_path: Path) -> None:
+    client = FakeCodexClient()
+    client.resume_error = CodexRpcError(
+        -32600, "no rollout found for thread id thread-missing"
+    )
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+
+    assert await gateway.create_or_resume_conversation("thread-missing") == (
+        "thread-a",
+        "thread-a",
+    )
+    assert [method for method, _ in client.requests] == [
+        "thread/resume",
+        "thread/start",
+    ]
+
+
+@pytest.mark.anyio
+async def test_codex_does_not_replace_a_thread_for_unrelated_resume_errors(
+    tmp_path: Path,
+) -> None:
+    client = FakeCodexClient()
+    client.resume_error = CodexRpcError(-32600, "another request was rejected")
+    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+
+    with pytest.raises(CodexRpcError, match="Codex App Server rejected"):
+        await gateway.create_or_resume_conversation("thread-missing")
+
+    assert [method for method, _ in client.requests] == ["thread/resume"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## What changed
- recover only the exact Codex `no rollout found` pre-turn lifecycle state by starting a replacement provider thread
- preserve all unrelated resume failures as hard failures
- add regression coverage for recovery, strict error handling, and live-thread idempotence

## Verification
- `services/api/tests/test_codex_adapter.py`: 20 passed
- connected-agent/runtime-router/contract suites: 78 passed
- Ruff and `git diff --check`: passed
- full `pnpm check`: passed

## Why
A chat can store its initial Codex thread ID before Codex persists a rollout. If the API restarts before the first successful turn, that exact ID cannot be resumed. This bounded recovery replaces only that known empty pre-turn thread and lets JobOS persist the replacement ID.