### PR TITLE
Harden test acceptance safeguards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
@@ -102,6 +103,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:

--- a/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
+++ b/apps/desktop/src/renderer/components/CareerProfileProductExperience.test.tsx
@@ -310,25 +310,26 @@ test('adds a typed career detail and dismisses its success feedback', async () =
   fireEvent.change(within(editor).getByLabelText('Skill name'), { target: { value: 'React' } })
   fireEvent.change(within(editor).getByLabelText('Level'), { target: { value: 'expert' } })
   const timeout = vi.spyOn(window, 'setTimeout')
-  fireEvent.click(within(editor).getByRole('button', { name: 'Save detail' }))
-
-  await waitFor(() => expect(createCareerProfileItem).toHaveBeenCalledWith(expect.objectContaining({
-    evidenceIds: [],
-    expectedProfileRevision: 4,
-    value: { kind: 'skill', name: 'React', level: 'expert' }
-  })))
-  expect(await screen.findByRole('button', { name: /React/i })).not.toBeNull()
-  expect(screen.queryByText(/"kind"|JSON/i)).toBeNull()
-  expect(await screen.findByText('Career detail added.')).not.toBeNull()
-  const dismissCallIndex = timeout.mock.calls.findIndex(([, delay]) => delay === 5_000)
-  const dismiss = timeout.mock.calls[dismissCallIndex]?.[0]
-  expect(dismiss).toBeTypeOf('function')
-  if (typeof dismiss !== 'function') throw new Error('Expected a transient feedback timer')
+  let dismissCallIndex = -1
   try {
+    fireEvent.click(within(editor).getByRole('button', { name: 'Save detail' }))
+
+    await waitFor(() => expect(createCareerProfileItem).toHaveBeenCalledWith(expect.objectContaining({
+      evidenceIds: [],
+      expectedProfileRevision: 4,
+      value: { kind: 'skill', name: 'React', level: 'expert' }
+    })))
+    expect(await screen.findByRole('button', { name: /React/i })).not.toBeNull()
+    expect(screen.queryByText(/"kind"|JSON/i)).toBeNull()
+    expect(await screen.findByText('Career detail added.')).not.toBeNull()
+    dismissCallIndex = timeout.mock.calls.findIndex(([, delay]) => delay === 5_000)
+    const dismiss = timeout.mock.calls[dismissCallIndex]?.[0]
+    expect(dismiss).toBeTypeOf('function')
+    if (typeof dismiss !== 'function') throw new Error('Expected a transient feedback timer')
     act(() => { dismiss() })
     expect(screen.queryByText('Career detail added.')).toBeNull()
   } finally {
-    window.clearTimeout(timeout.mock.results[dismissCallIndex]?.value)
+    if (dismissCallIndex >= 0) window.clearTimeout(timeout.mock.results[dismissCallIndex]?.value)
     timeout.mockRestore()
   }
 })

--- a/docs/acceptance/career-profile-product-experience/README.md
+++ b/docs/acceptance/career-profile-product-experience/README.md
@@ -33,7 +33,7 @@ Run `pnpm test:frontend:packaged` on arm64 macOS to build the current commit and
 | `08-wide-after-restart-1440x1024.png` | Profile and Evidence persistence after packaged-app restart |
 | `09-narrow-restored-baseline-980x640.png` | Restored baseline with excluded Evidence clearly marked unavailable |
 
-Every PNG was visually inspected, stripped of metadata, and checksum-pinned in `tests/public-release/synthetic-fixtures.json`.
+Every checked-in historical PNG was visually inspected, stripped of metadata, and checksum-pinned in `tests/public-release/synthetic-fixtures.json`. Current-commit CI smoke generates disposable screenshots and validates the journey and output manifest, but does not treat those unreviewed pixels as matching the historical checksum set.
 
 ## Archive proof
 
@@ -54,7 +54,7 @@ The report is bound to `HEAD` and a canonical product-source digest of the stage
 - excludes PNGs directly under this acceptance directory, because they are generated evidence;
 - keeps `tests/public-release/synthetic-fixtures.json` in the source manifest but canonicalizes it by removing only asset records whose path is one of those excluded acceptance PNGs. Every other manifest field and asset record remains source identity.
 
-Therefore rerunning acceptance, copying the report/screenshots, or updating only their matching synthetic-fixture checksum records cannot change the canonical product-source digest recorded by the report. Any other staged source change does change it. The harness separately records a sorted generated-output manifest (`path`, `size`, SHA-256) and digest for all nine screenshots, and fails unless every screenshot hash matches its synthetic-fixture record. The report itself is intentionally not self-checksummed.
+Therefore rerunning acceptance, copying the report/screenshots, or updating only their matching synthetic-fixture checksum records cannot change the canonical product-source digest recorded by the report. Any other staged source change does change it. The harness separately records a sorted generated-output manifest (`path`, `size`, SHA-256) and digest for all nine screenshots. Historical acceptance runs require every screenshot hash to match its reviewed synthetic-fixture record; current-commit CI smoke records fresh disposable hashes without claiming historical pixel equivalence. The report itself is intentionally not self-checksummed.
 
 The report also records the exercised `.app` manifest SHA-256 and ZIP-extracted `.app` manifest SHA-256. The run fails unless those bundles are byte-for-byte equivalent by sorted file/symlink/mode manifest. Unstaged generated report/PNG changes are allowed; an unstaged fixture-manifest change is allowed only when its canonicalized non-acceptance content still equals the staged blob. Other unstaged product-source changes fail the run.
 

--- a/docs/acceptance/career-profile-product-experience/capture.mjs
+++ b/docs/acceptance/career-profile-product-experience/capture.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto'
 import { execFileSync, spawn } from 'node:child_process'
-import { chmod, mkdir, readFile, readlink, readdir, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, readFile, readlink, readdir, rename, stat, unlink, writeFile } from 'node:fs/promises'
 import { openSync } from 'node:fs'
 import net from 'node:net'
 import path from 'node:path'
@@ -53,10 +53,21 @@ const acceptanceScreenshotNames = [
 const acceptanceRelativeDirectory = 'docs/acceptance/career-profile-product-experience'
 const fixtureManifestRelativePath = 'tests/public-release/synthetic-fixtures.json'
 let smokeStage = 'initialization'
+let statusWriteSequence = 0
 
 async function markStage(state, stage) {
   smokeStage = stage
-  if (statusPath) await writeFile(statusPath, `${state}:${stage}\n`, { mode: 0o600 })
+  if (!statusPath) return
+
+  const temporaryStatusPath = `${statusPath}.${process.pid}.${statusWriteSequence++}.tmp`
+  try {
+    await writeFile(temporaryStatusPath, `${state}:${stage}\n`, { mode: 0o600 })
+    await rename(temporaryStatusPath, statusPath)
+  } finally {
+    await unlink(temporaryStatusPath).catch(error => {
+      if (error?.code !== 'ENOENT') throw error
+    })
+  }
 }
 
 function assert(condition, message) {

--- a/scripts/generate_docx_pagination_baseline.py
+++ b/scripts/generate_docx_pagination_baseline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -66,7 +67,26 @@ def main() -> None:
                 }
 
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT.write_text(json.dumps(baseline, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    serialized = json.dumps(baseline, indent=2, ensure_ascii=False) + "\n"
+    temporary_output: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=OUTPUT.parent,
+            prefix=f".{OUTPUT.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(serialized)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_output = Path(temporary.name)
+        temporary_output.replace(OUTPUT)
+        temporary_output = None
+    finally:
+        if temporary_output is not None:
+            temporary_output.unlink(missing_ok=True)
     print(f"Wrote {len(baseline)} pagination baselines to {OUTPUT.relative_to(ROOT)}")
 
 

--- a/scripts/run-packaged-frontend-smoke.mjs
+++ b/scripts/run-packaged-frontend-smoke.mjs
@@ -1,11 +1,34 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
-import { chmod, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const taskRoot = path.join(root, '.task')
+
+async function rejectSymlinkedPathComponents(base, target) {
+  const relative = path.relative(base, target)
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('Packaged frontend runtime must remain inside the checkout')
+  }
+
+  let current = base
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment)
+    try {
+      const metadata = await lstat(current)
+      if (metadata.isSymbolicLink()) {
+        throw new Error(`Refusing symlinked runtime path component: ${path.relative(base, current)}`)
+      }
+    } catch (error) {
+      if (error?.code === 'ENOENT') break
+      throw error
+    }
+  }
+}
+
+await rejectSymlinkedPathComponents(root, taskRoot)
 await mkdir(taskRoot, { recursive: true, mode: 0o700 })
 const temporaryRoot = await mkdtemp(path.join(taskRoot, 'packaged-frontend-'))
 const runtime = path.join(temporaryRoot, 'runtime')

--- a/tests/connected_agents/test_evidence_index.py
+++ b/tests/connected_agents/test_evidence_index.py
@@ -58,7 +58,7 @@ def test_connected_agents_evidence_index_is_complete_unique_and_honest():
         assert 0 <= entry["owner_phase"] <= 8
         if entry["status"] == "verified":
             assert entry["source_commit"]
-            assert len(entry["source_commit"]) == 40
+            assert re.fullmatch(r"[0-9a-f]{40}", entry["source_commit"])
             assert entry["proof_refs"]
             assert entry["remaining_proof"] is None
             commit = subprocess.run(
@@ -68,6 +68,15 @@ def test_connected_agents_evidence_index_is_complete_unique_and_honest():
                 check=False,
             )
             assert commit.returncode == 0, f'{entry["id"]} references an unreachable commit'
+            reachable = subprocess.run(
+                ["git", "merge-base", "--is-ancestor", entry["source_commit"], "HEAD"],
+                cwd=ROOT,
+                capture_output=True,
+                check=False,
+            )
+            assert reachable.returncode == 0, (
+                f'{entry["id"]} source commit is not reachable from HEAD'
+            )
             for proof_ref in entry["proof_refs"]:
                 if proof_ref.startswith("https://"):
                     assert GITHUB_PR.fullmatch(proof_ref), (
@@ -75,7 +84,12 @@ def test_connected_agents_evidence_index_is_complete_unique_and_honest():
                     )
                 else:
                     proof_path = proof_ref.split("::", 1)[0]
-                    assert (ROOT / proof_path).is_file(), (
+                    resolved_root = ROOT.resolve()
+                    resolved_proof = (ROOT / proof_path).resolve()
+                    assert resolved_proof.is_relative_to(resolved_root), (
+                        f'{entry["id"]} proof path escapes the repository'
+                    )
+                    assert resolved_proof.is_file(), (
                         f'{entry["id"]} references a missing proof file'
                     )
         else:


### PR DESCRIPTION
## What changed
- harden packaged frontend smoke path and state-file safety
- make DOCX pagination baseline writes atomic
- tighten acceptance evidence commit/proof validation
- prevent macOS CI checkouts from persisting credentials
- guarantee frontend timer cleanup
- clarify historical screenshot evidence

## Verification
- `pnpm test:frontend:packaged`
- `pnpm check`
- `pnpm contracts:check`
- `pnpm contracts:test-drift`
- `git diff --check`

No production deployment or installed-app replacement.