### PR TITLE
Fix Save Job MCP startup and retry recovery regressions

### DIFF
--- a/apps/desktop/src/renderer/components/AgentPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.test.tsx
@@ -273,6 +273,8 @@ test('runtime transport quarantine updates the tab and close gate until ready st
   }))
   expect(screen.getByRole('tab', { name: 'Session 1, Quarantined' })).not.toBeNull()
   expect((screen.getByRole('button', { name: 'Close Session 1' }) as HTMLButtonElement).disabled).toBe(true)
+  expect(screen.queryByRole('button', { name: 'Retry turn' })).toBeNull()
+  expect(screen.getByRole('button', { name: 'Confirm cleanup and retry turn' })).not.toBeNull()
 
   act(() => emit({
     kind: 'event', conversationId: 'conv_1', recoveryState: 'ready',
@@ -280,6 +282,7 @@ test('runtime transport quarantine updates the tab and close gate until ready st
   }))
   expect(screen.getByRole('tab', { name: 'Session 1, Idle' })).not.toBeNull()
   expect((screen.getByRole('button', { name: 'Close Session 1' }) as HTMLButtonElement).disabled).toBe(false)
+  expect(screen.queryByRole('button', { name: 'Confirm cleanup and retry turn' })).toBeNull()
 })
 
 test('drafts survive switching and two sessions may send independently', async () => {

--- a/apps/desktop/src/renderer/components/AgentPanel.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.tsx
@@ -74,6 +74,7 @@ export function AgentPanel({ agentLabel, avatarId, contextLabel, apiState = 'con
   }
   const activeId = sessions.activeId
   const activeSummary = sessions.activeSession?.summary
+  const retryRequiresRecovery = activeSummary?.recoveryState === 'quarantined'
   const panelRefs = useRef(new Map<string, HTMLDivElement>())
   const lastScrollTops = useRef(new Map<string, number>())
   const pinnedToBottom = useRef(true)
@@ -87,6 +88,7 @@ export function AgentPanel({ agentLabel, avatarId, contextLabel, apiState = 'con
     && !conversation.operationPending
     && apiState === 'connected'
     && activeSummary?.availability?.state !== 'locked'
+    && activeSummary?.recoveryState === 'ready'
   )
 
 
@@ -292,8 +294,8 @@ export function AgentPanel({ agentLabel, avatarId, contextLabel, apiState = 'con
                           </div>
                         )}
                         {terminal.retryable && !conversation.activeTurn && activeSummary?.availability?.state !== 'locked' && (
-                          <button aria-label="Retry turn" className="retry-button" onClick={() => { if (activeId) void sessions.retry(activeId, item.turnId) }} type="button">
-                            <RotateCcw aria-hidden="true" size={13} /> Retry
+                          <button aria-label={retryRequiresRecovery ? 'Confirm cleanup and retry turn' : 'Retry turn'} className="retry-button" onClick={() => { if (activeId) void sessions.retry(activeId, item.turnId) }} type="button">
+                            <RotateCcw aria-hidden="true" size={13} /> {retryRequiresRecovery ? 'Confirm cleanup & retry' : 'Retry'}
                           </button>
                         )}
                       </article>
@@ -317,8 +319,8 @@ export function AgentPanel({ agentLabel, avatarId, contextLabel, apiState = 'con
                   <strong><CircleAlert aria-hidden="true" size={14} /> {noticeLabel}</strong>
                   <p>{item.label}</p>
                   {item.retryable && !conversation.activeTurn && activeSummary?.availability?.state !== 'locked' && (
-                    <button aria-label="Retry turn" className="retry-button" onClick={() => { if (activeId) void sessions.retry(activeId, item.turnId ?? '') }} type="button">
-                      <RotateCcw aria-hidden="true" size={13} /> Retry
+                    <button aria-label={retryRequiresRecovery ? 'Confirm cleanup and retry turn' : 'Retry turn'} className="retry-button" onClick={() => { if (activeId) void sessions.retry(activeId, item.turnId ?? '') }} type="button">
+                      <RotateCcw aria-hidden="true" size={13} /> {retryRequiresRecovery ? 'Confirm cleanup & retry' : 'Retry'}
                     </button>
                   )}
                 </article>

--- a/scripts/macos/jobos_mcp_runtime.py
+++ b/scripts/macos/jobos_mcp_runtime.py
@@ -163,8 +163,10 @@ def keychain_credentials(runtime: Mapping[str, Any]) -> dict[str, str]:
 
 def main(arguments: list[str] | None = None) -> None:
     values = list(sys.argv[1:] if arguments is None else arguments)
-    if len(values) != 1:
-        raise RuntimeError("Usage: jobos_mcp_runtime.py <runtime.json>")
+    if len(values) not in {1, 2}:
+        raise RuntimeError(
+            "Usage: jobos_mcp_runtime.py <runtime.json> [legacy-credentials.json]"
+        )
 
     runtime_path = _absolute_existing_path(values[0], "runtime configuration")
     runtime = json.loads(runtime_path.read_text(encoding="utf-8"))

--- a/services/api/jobos_api/agent_gateway.py
+++ b/services/api/jobos_api/agent_gateway.py
@@ -32,6 +32,10 @@ class DefinitiveSessionCreationError(RuntimeError):
     """The provider rejected session creation before accepting it."""
 
 
+class DefinitivePreSubmitError(RuntimeError):
+    """The provider rejected work before the prompt could be submitted."""
+
+
 @dataclass(frozen=True)
 class AgentContext:
     turn_id: str

--- a/services/api/jobos_api/conversations.py
+++ b/services/api/jobos_api/conversations.py
@@ -16,6 +16,7 @@ from .agent_gateway import (
     AgentGateway,
     AmbiguousDeliveryError,
     ConnectedAgentProvider,
+    DefinitivePreSubmitError,
     GatewayEvent,
 )
 from .career_profile_context import CareerProfileContextStore
@@ -611,6 +612,23 @@ class ConversationService:
                         permission_state={"scope": "global"},
                     ),
                 )
+        except DefinitivePreSubmitError as error:
+            logger.warning(
+                "Agent turn was rejected before prompt submission (%s, code=%s)",
+                type(error).__name__,
+                getattr(error, "code", None),
+            )
+            current = self.store.turn_record(turn_id)
+            if current and current["cancel_requested"]:
+                return
+            self.store.settle_active_turn(
+                turn_id,
+                "failed",
+                event_type="error",
+                summary=safe_error_summary(error),
+                detail={"actionable": True, "retry": True},
+            )
+            self._restore_session_after_isolated_turn(turn_id)
         except Exception as error:
             logger.warning(
                 "Agent turn submission failed (%s, code=%s)",

--- a/services/api/jobos_api/hermes_adapter.py
+++ b/services/api/jobos_api/hermes_adapter.py
@@ -16,6 +16,7 @@ from .agent_gateway import (
     AgentContext,
     AmbiguousDeliveryError,
     ConnectionState,
+    DefinitivePreSubmitError,
     DefinitiveSessionCreationError,
     GatewayEvent,
 )
@@ -465,7 +466,9 @@ class HermesWebSocketGateway:
                     timeout=self._request_timeout,
                 )
         if self._session_isolation_state != "verified":
-            raise RuntimeError("Hermes session isolation could not be verified") from None
+            raise DefinitivePreSubmitError(
+                "Hermes session isolation could not be verified"
+            ) from None
 
     async def _create_session(self) -> dict[str, Any]:
         try:
@@ -504,7 +507,7 @@ class HermesWebSocketGateway:
 
     async def submit_turn(self, text: str, context: AgentContext) -> None:
         if not self._live_session_id:
-            raise RuntimeError("Hermes session is not attached")
+            raise DefinitivePreSubmitError("Hermes session is not attached")
         await self._require_session_verification()
         self._clear_pending_async_continuation()
         self._active_turn_id = context.turn_id

--- a/services/api/tests/test_agent_contract.py
+++ b/services/api/tests/test_agent_contract.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from jobos_api.agent_gateway import (
     AgentContext,
     AmbiguousDeliveryError,
+    DefinitivePreSubmitError,
     GatewayEvent,
 )
 from jobos_api.app import create_app
@@ -1126,6 +1127,54 @@ def test_isolated_submission_failure_recovers_with_the_isolated_session_id(tmp_p
 
     assert recoveries == [("stored-session", turn_id)]
     assert recovery_turn_id is None
+
+
+def test_definitive_pre_submit_failure_can_retry_without_remote_cleanup(tmp_path):
+    async def scenario():
+        store = JobOsStateStore(tmp_path / "jobos.db")
+        store.initialize()
+
+        class PreSubmitFailureGateway(FakeGateway):
+            def __init__(self):
+                super().__init__()
+                self.attempts = 0
+
+            async def submit_turn(self, text, context):
+                self.attempts += 1
+                if self.attempts == 1:
+                    raise DefinitivePreSubmitError(
+                        "Hermes session isolation could not be verified"
+                    )
+                await super().submit_turn(text, context)
+
+        gateway = PreSubmitFailureGateway()
+        service = ConversationService(store, gateway)
+        failed = await service.send(
+            SendMessageRequest(
+                text="Explain why the browser tool was unavailable",
+                idempotency_key="definitive-pre-submit-failure",
+            ),
+            actor_id="device-a",
+            context={"selected_job_id": None, "workspace": {}},
+        )
+        failed_record = store.turn_record(failed.turn_id)
+        assert failed_record is not None
+        recovery_after_failure = store.recovery_turn_id()
+        retried = await service.retry(
+            failed.turn_id,
+            RetryTurnRequest(idempotency_key="definitive-pre-submit-retry"),
+            actor_id="device-a",
+        )
+        return failed_record, recovery_after_failure, retried, gateway
+
+    failed_record, recovery_after_failure, retried, gateway = asyncio.run(scenario())
+
+    assert failed_record["status"] == "failed"
+    assert recovery_after_failure is None
+    assert retried is not None
+    assert retried.source_turn_id == failed_record["turn_id"]
+    assert gateway.attempts == 2
+    assert len(gateway.submissions) == 1
 
 
 def test_rotated_durable_id_reconciles_without_transcript_or_raw_metadata(tmp_path):

--- a/services/api/tests/test_hermes_adapter.py
+++ b/services/api/tests/test_hermes_adapter.py
@@ -6,6 +6,7 @@ import pytest
 from jobos_api.agent_gateway import (
     AgentContext,
     AmbiguousDeliveryError,
+    DefinitivePreSubmitError,
     DefinitiveSessionCreationError,
     GatewayEvent,
 )
@@ -1259,7 +1260,7 @@ def test_reconnect_resets_session_isolation_verification(tmp_path):
         await asyncio.sleep(0)
 
         await gateway.create_or_resume_conversation("stored-1")
-        with pytest.raises(RuntimeError) as caught:
+        with pytest.raises(DefinitivePreSubmitError) as caught:
             await gateway.submit_turn(
                 "must not submit", AgentContext("turn-1", None, {}, "conv_test")
             )
@@ -1267,6 +1268,24 @@ def test_reconnect_resets_session_isolation_verification(tmp_path):
 
         assert [request["method"] for request in second.requests] == ["session.resume"]
         assert str(caught.value) == "Hermes session isolation could not be verified"
+
+    asyncio.run(scenario())
+
+
+def test_missing_live_session_is_a_definitive_pre_submit_failure(tmp_path):
+    async def scenario():
+        gateway = HermesWebSocketGateway(
+            url="ws://127.0.0.1:9119/api/ws",
+            token=TOKEN,
+            cwd=tmp_path,
+        )
+
+        with pytest.raises(DefinitivePreSubmitError) as caught:
+            await gateway.submit_turn(
+                "must not submit", AgentContext("turn-1", None, {}, "conv_test")
+            )
+
+        assert str(caught.value) == "Hermes session is not attached"
 
     asyncio.run(scenario())
 

--- a/tests/public-release/test_mcp_runtime_launcher.py
+++ b/tests/public-release/test_mcp_runtime_launcher.py
@@ -168,6 +168,45 @@ def test_mcp_runtime_main_executes_the_release_module(tmp_path, monkeypatch):
     assert environment["PYTHONPATH"] == str(Path(str(runtime["jobos_root"])) / "services/mcp")
 
 
+def test_mcp_runtime_main_accepts_the_legacy_profile_credentials_argument(
+    tmp_path, monkeypatch
+):
+    runtime, credentials = runtime_files(tmp_path)
+    runtime_path = tmp_path / "runtime.json"
+    runtime_path.write_text(json.dumps(runtime), encoding="utf-8")
+    legacy_credentials_path = tmp_path / "demo-credentials.json"
+    legacy_credentials_path.write_text("deliberately unreadable", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        jobos_mcp_runtime,
+        "keychain_credentials",
+        lambda _runtime: credentials,
+    )
+    monkeypatch.setattr(
+        jobos_mcp_runtime.os,
+        "execve",
+        lambda executable, arguments, environment: captured.update(
+            executable=executable,
+            arguments=arguments,
+            environment=environment,
+        ),
+    )
+
+    jobos_mcp_runtime.main([str(runtime_path), str(legacy_credentials_path)])
+
+    assert captured["executable"] == str(runtime["python_path"])
+    assert captured["arguments"] == [
+        str(runtime["python_path"]),
+        "-P",
+        "-m",
+        "jobos_mcp",
+    ]
+    environment = captured["environment"]
+    assert isinstance(environment, dict)
+    assert environment["JOBOS_DEVICE_TOKEN"] == "device-secret-value"
+
+
 def test_mcp_runtime_reads_credentials_from_keychain_without_a_credentials_file(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## What changed
- keeps the active MCP runtime compatible with the installed JobHunter profile launcher while still sourcing secrets from Keychain
- classifies failures before `prompt.submit` as definitive so safe retries do not require fake remote cleanup
- preserves quarantine for genuinely ambiguous delivery and labels that action as cleanup plus retry
- blocks new composer sends while recovery is unresolved

## Regression coverage
- legacy two-argument profile launcher against the current release runtime
- missing/unverified Hermes session before prompt submission
- immediate retry without recovery quarantine
- truthful quarantined Retry UI

## Verification
- focused Python: 138 passed
- focused desktop: 42 passed
- `pnpm check`
- contract generation/drift checks
- `git diff --check`
- independent Codex review: pass, zero security or logic findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery handling for failed agent message submissions, allowing eligible failures to be retried without quarantining the conversation.
  - Updated retry controls to clearly indicate when cleanup confirmation is required.
  - Prevented message sending until session recovery is ready.

- **Compatibility**
  - macOS MCP runtime launching now supports both current configuration-only usage and the optional legacy credentials-file argument.

- **Tests**
  - Added coverage for retryable submission failures, recovery behavior, and legacy runtime launcher compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->