### PR TITLE
fix(agent): keep chat metadata in the header

### DIFF
--- a/apps/desktop/src/renderer/components/AgentPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.test.tsx
@@ -80,6 +80,21 @@ test('renders accessible tabs and routes additive creation through the New Chat 
   expect(screen.queryByRole('alertdialog')).toBeNull()
 })
 
+test('keeps session binding metadata in the header above the flexible chat body', async () => {
+  install()
+  render(<Harness />)
+  await screen.findByRole('tab', { name: 'Session 1, Idle' })
+
+  const panel = screen.getByRole('complementary', { name: 'Agent chat' })
+  const header = panel.querySelector('.agent-session-header')
+  const body = screen.getByRole('tabpanel')
+
+  expect(header).not.toBeNull()
+  expect(header?.querySelector('.agent-session-toolbar')).not.toBeNull()
+  expect(header?.querySelector('.agent-binding')?.textContent).toContain('Hermesdefault · mediumLocked for this chat')
+  expect(header?.nextElementSibling).toBe(body)
+})
+
 test('every session tab controls a persistent panel while only the selected panel is visible', async () => {
   install([summary(1), summary(2)])
   render(<Harness />)

--- a/apps/desktop/src/renderer/components/AgentPanel.tsx
+++ b/apps/desktop/src/renderer/components/AgentPanel.tsx
@@ -198,17 +198,19 @@ export function AgentPanel({ agentLabel, avatarId, contextLabel, apiState = 'con
       <div className="agent-context">
         <span title={contextLabel}><BriefcaseBusiness aria-hidden="true" size={16} strokeWidth={1.5} /> <span>{contextLabel}</span></span>
       </div>
-      <AgentSessionTabs controller={sessions} onNewChat={onNewChat} />
-      {activeSummary?.binding ? (
-        <div className="agent-binding" role="status">
-          <strong>{agentLabel ?? (activeSummary.binding.provider === 'codex' ? 'ChatGPT · Codex' : 'Hermes')}</strong>
-          <span>{activeSummary.binding.modelId} · {activeSummary.binding.reasoningEffort}</span>
-          <small>Locked for this chat</small>
-        </div>
-      ) : null}
-      {activeSummary?.availability?.state === 'locked' ? (
-        <div className="agent-connection offline" role="status"><WifiOff aria-hidden="true" size={14} /> This chat is read-only · {activeSummary.availability.reason ?? 'Reconnect its agent to continue'}</div>
-      ) : null}
+      <div className="agent-session-header">
+        <AgentSessionTabs controller={sessions} onNewChat={onNewChat} />
+        {activeSummary?.binding ? (
+          <div className="agent-binding" role="status">
+            <strong>{agentLabel ?? (activeSummary.binding.provider === 'codex' ? 'ChatGPT · Codex' : 'Hermes')}</strong>
+            <span>{activeSummary.binding.modelId} · {activeSummary.binding.reasoningEffort}</span>
+            <small>Locked for this chat</small>
+          </div>
+        ) : null}
+        {activeSummary?.availability?.state === 'locked' ? (
+          <div className="agent-connection offline" role="status"><WifiOff aria-hidden="true" size={14} /> This chat is read-only · {activeSummary.availability.reason ?? 'Reconnect its agent to continue'}</div>
+        ) : null}
+      </div>
 
       {(sessions.order.length ? sessions.order : ['']).map(panelId => {
         const selected = !panelId || panelId === activeId

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -854,6 +854,7 @@ button:focus-visible {
 
 .agent-context > span { display: flex; align-items: center; gap: 10px; }
 .agent-context > span > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-session-header { min-width: 0; }
 .agent-session-toolbar { display: flex; min-width: 0; align-items: stretch; gap: 6px; padding: 6px 8px; border-bottom: 1px solid var(--border); background: var(--surface); }
 .agent-session-tabs { display: grid; grid-template-columns: repeat(var(--agent-session-count), minmax(36px, 1fr)); flex: 1; min-width: 0; gap: 3px; }
 .agent-session-tab { min-width: 36px; min-height: 40px; overflow: hidden; display: flex; align-items: center; justify-content: center; gap: 6px; padding: 6px; border: 1px solid transparent; border-radius: var(--radius-sm); color: var(--text-soft); background: var(--surface-raised); font-size: 12px; font-weight: 700; white-space: nowrap; cursor: pointer; }


### PR DESCRIPTION
## What changed
- group the session tabs and locked agent/model metadata into one chat header row
- keep the conversation body as the panel grid’s only flexible row
- add a regression test for the header/body DOM boundary

## Why
The binding metadata was introduced as an extra direct child of a five-row grid. It consumed the flexible chat row, leaving a large blank band and pushing the Fresh conversation state against the composer.

## Verification
- 44 focused Agent Panel tests passed
- full `pnpm check` passed
- `pnpm contracts:check` passed
- desktop: 582 tests passed
- Python: 1,037 passed, 4 skipped
- docx engine/editor: 710 passed, 1 skipped
- updater tests: 10 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the agent session header layout to better accommodate session tabs, binding details, and locked-chat notices.
  * Preserved the existing displayed information and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->