### PR TITLE
Fix Codex document publication writes

### DIFF
--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -761,6 +761,7 @@ def create_app(
         CodexGatewayFactory(
             codex_client,
             cwd=settings.resolved_codex_home() / "workspace",
+            publication_root=settings.resolved_local_artifact_root() / "publication-inbox",
         )
         if codex_client is not None
         else None

--- a/services/api/jobos_api/codex_adapter.py
+++ b/services/api/jobos_api/codex_adapter.py
@@ -30,9 +30,20 @@ _TOOL_REVIEW_TIMEOUT_SECONDS = 300.0
 class CodexGatewayFactory:
     """Create isolated JobOS conversation gateways over one private app-server."""
 
-    def __init__(self, client: CodexRpcClient, *, cwd: Path) -> None:
+    def __init__(
+        self,
+        client: CodexRpcClient,
+        *,
+        cwd: Path,
+        publication_root: Path | None = None,
+    ) -> None:
         self._client = client
         self._cwd = cwd.expanduser().absolute()
+        self._publication_root = (
+            publication_root.expanduser().absolute()
+            if publication_root is not None
+            else self._cwd / "publication-inbox"
+        )
         self._gateways: dict[str, CodexAppServerGateway] = {}
         self._rate_limit_snapshot: dict[str, object] = {}
         self._rate_limit_updates: list[dict[str, object]] = []
@@ -47,6 +58,7 @@ class CodexGatewayFactory:
         gateway = CodexAppServerGateway(
             client=self._client,
             cwd=self._cwd,
+            publication_root=self._publication_root,
             conversation_id=conversation_id,
             unregister=self._unregister,
             rate_limit_snapshot=self._rate_limit_snapshot,
@@ -125,6 +137,7 @@ class CodexAppServerGateway:
         *,
         client: CodexRpcClient,
         cwd: Path,
+        publication_root: Path,
         conversation_id: str,
         unregister: Callable[[str, CodexAppServerGateway], None],
         rate_limit_snapshot: dict[str, object],
@@ -132,6 +145,7 @@ class CodexAppServerGateway:
     ) -> None:
         self._client = client
         self._cwd = cwd
+        self._publication_root = publication_root
         self._conversation_id = conversation_id
         self._unregister = unregister
         self._thread_id: str | None = None
@@ -176,6 +190,16 @@ class CodexAppServerGateway:
                 "AGENT_PROVIDER_UNAVAILABLE", "Codex workspace is unsafe"
             )
         os.chmod(self._cwd, 0o700)
+        if self._publication_root.parent.is_symlink() or self._publication_root.is_symlink():
+            raise CodexRuntimeError(
+                "AGENT_PROVIDER_UNAVAILABLE", "Codex publication inbox is unsafe"
+            )
+        self._publication_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if self._publication_root.is_symlink() or not self._publication_root.is_dir():
+            raise CodexRuntimeError(
+                "AGENT_PROVIDER_UNAVAILABLE", "Codex publication inbox is unsafe"
+            )
+        os.chmod(self._publication_root, 0o700)
         if not was_running and self._thread_id is not None:
             result = await self._client.request(
                 "thread/resume",
@@ -184,7 +208,7 @@ class CodexAppServerGateway:
                     "cwd": str(self._cwd),
                     "approvalPolicy": "never",
                     "approvalsReviewer": "user",
-                    "sandbox": "read-only",
+                    "sandbox": "workspace-write",
                 },
             )
             thread = result.get("thread") if isinstance(result, dict) else None
@@ -204,7 +228,7 @@ class CodexAppServerGateway:
             "cwd": str(self._cwd),
             "approvalPolicy": "never",
             "approvalsReviewer": "user",
-            "sandbox": "read-only",
+            "sandbox": "workspace-write",
         }
         if stored_session_id is None:
             method = "thread/start"
@@ -309,7 +333,11 @@ class CodexAppServerGateway:
             "clientUserMessageId": context.turn_id,
             "approvalPolicy": "never",
             "approvalsReviewer": "user",
-            "sandboxPolicy": {"type": "readOnly", "networkAccess": False},
+            "sandboxPolicy": {
+                "type": "workspaceWrite",
+                "writableRoots": [str(self._publication_root)],
+                "networkAccess": False,
+            },
         }
         if context.model_id is not None:
             params["model"] = context.model_id
@@ -431,7 +459,7 @@ class CodexAppServerGateway:
                 "cwd": str(self._cwd),
                 "approvalPolicy": "never",
                 "approvalsReviewer": "user",
-                "sandbox": "read-only",
+                "sandbox": "workspace-write",
             },
         )
         resumed_thread = resumed.get("thread") if isinstance(resumed, dict) else None

--- a/services/api/tests/test_codex_adapter.py
+++ b/services/api/tests/test_codex_adapter.py
@@ -131,7 +131,12 @@ def context(conversation_id: str = "conv_alpha") -> AgentContext:
 @pytest.mark.anyio
 async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: Path) -> None:
     client = FakeCodexClient()
-    gateway = CodexGatewayFactory(client, cwd=tmp_path).create("conv_alpha")
+    publication_root = tmp_path / "artifacts" / "publication-inbox"
+    gateway = CodexGatewayFactory(
+        client,
+        cwd=tmp_path / "codex-workspace",
+        publication_root=publication_root,
+    ).create("conv_alpha")
 
     assert gateway.connection_state == "offline"
     assert await gateway.create_or_resume_conversation(None) == ("thread-a", "thread-a")
@@ -147,8 +152,8 @@ async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: P
     ]
     thread_params = client.requests[0][1]
     assert isinstance(thread_params, dict)
-    assert thread_params["sandbox"] == "read-only"
-    assert thread_params["cwd"] == str(tmp_path)
+    assert thread_params["sandbox"] == "workspace-write"
+    assert thread_params["cwd"] == str(tmp_path / "codex-workspace")
     turn_params = client.requests[-1][1]
     assert isinstance(turn_params, dict)
     assert turn_params["threadId"] == "thread-a"
@@ -157,9 +162,11 @@ async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: P
     assert turn_params["effort"] == "medium"
     assert turn_params["approvalPolicy"] == "never"
     assert turn_params["sandboxPolicy"] == {
-        "type": "readOnly",
+        "type": "workspaceWrite",
+        "writableRoots": [str(publication_root)],
         "networkAccess": False,
     }
+    assert publication_root.is_dir()
     prompt = turn_params["input"][0]["text"]  # type: ignore[index]
     assert "conversation_id=\"conv_alpha\"" in prompt
     assert "turn_id=\"turn_12345678\"" in prompt


### PR DESCRIPTION
## What changed
- run JobOS Codex conversations in workspace-write mode instead of read-only
- grant writes only to the isolated Codex workspace and JobOS publication inbox
- keep network access disabled and preserve JobOS MCP publication validation
- add regression coverage for the exact sandbox policy and configured inbox

## Why
Codex could call `document_publication_prepare`, but JobOS then denied every filesystem write needed to create the promised PDF/DOCX. This made the supported publication workflow impossible.

## Verification
- full API pytest suite
- Codex adapter tests: 20 passed
- MCP publication tests: 46 passed
- Ruff: passed
- `git diff --cached --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved workspace isolation for Codex operations.
  * Restricted writable access to the publication inbox and disabled network access during turn execution.
  * Automatically validates and securely creates the publication directory.

* **Bug Fixes**
  * Improved reliability for conversation start, resume, recovery, and turn execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->