### PR TITLE
Fix Codex publication root mismatch

### DIFF
--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -757,11 +757,16 @@ def create_app(
         )
         configured_gateway = True
     selected_gateway_factory = gateway_factory or OfflineAgentGatewayFactory()
+    publication_root = settings.resolved_local_artifact_root() / "publication-inbox"
     codex_gateway_factory = (
         CodexGatewayFactory(
             codex_client,
-            cwd=settings.resolved_codex_home() / "workspace",
-            publication_root=settings.resolved_local_artifact_root() / "publication-inbox",
+            # Codex's macOS workspace sandbox reliably grants the active cwd,
+            # while additional writableRoots can still be rejected by Seatbelt.
+            # Make the app-owned inbox the workspace boundary so document
+            # generation is both functional and narrowly scoped.
+            cwd=publication_root,
+            publication_root=publication_root,
         )
         if codex_client is not None
         else None

--- a/services/api/jobos_api/app.py
+++ b/services/api/jobos_api/app.py
@@ -757,15 +757,11 @@ def create_app(
         )
         configured_gateway = True
     selected_gateway_factory = gateway_factory or OfflineAgentGatewayFactory()
-    publication_root = settings.resolved_local_artifact_root() / "publication-inbox"
+    publication_root = settings.resolved_codex_publication_root()
     codex_gateway_factory = (
         CodexGatewayFactory(
             codex_client,
-            # Codex's macOS workspace sandbox reliably grants the active cwd,
-            # while additional writableRoots can still be rejected by Seatbelt.
-            # Make the app-owned inbox the workspace boundary so document
-            # generation is both functional and narrowly scoped.
-            cwd=publication_root,
+            cwd=settings.resolved_codex_home() / "workspace",
             publication_root=publication_root,
         )
         if codex_client is not None

--- a/services/api/jobos_api/local_config.py
+++ b/services/api/jobos_api/local_config.py
@@ -166,6 +166,7 @@ def settings_from_config(path: Path) -> Settings:
         jobs_db_path=effective["jobs_db_path"],
         artifact_provider=effective["artifact_provider"],
         local_artifact_root=effective["local_artifact_root"],
+        codex_publication_root=artifact_root / "publication-inbox",
         artifact_roots=effective["artifact_roots"],
         job_provider=effective["job_provider"],
         job_hunter_db_path=effective["job_hunter_db_path"],

--- a/services/api/jobos_api/main.py
+++ b/services/api/jobos_api/main.py
@@ -98,6 +98,12 @@ def settings_from_environment() -> Settings:
             Path(value) if (value := os.environ.get("JOBOS_CODEX_APP_SERVER_PATH")) else None
         ),
         codex_home_path=(Path(value) if (value := os.environ.get("JOBOS_CODEX_HOME")) else None),
+        codex_publication_root=Path(
+            os.environ.get(
+                "JOBOS_CODEX_PUBLICATION_ROOT",
+                application_data / "artifacts/publication-inbox",
+            )
+        ),
         codex_request_timeout=float(os.environ.get("JOBOS_CODEX_REQUEST_TIMEOUT", "15")),
         codex_mcp_command=(
             Path(value) if (value := os.environ.get("JOBOS_CODEX_MCP_COMMAND")) else None

--- a/services/api/jobos_api/settings.py
+++ b/services/api/jobos_api/settings.py
@@ -87,6 +87,7 @@ class Settings(BaseModel):
     hermes_request_timeout: float = Field(default=5.0, gt=0, le=30)
     codex_app_server_path: Path | None = None
     codex_home_path: Path | None = None
+    codex_publication_root: Path | None = None
     codex_request_timeout: float = Field(default=15.0, gt=0, le=60)
     codex_mcp_command: Path | None = None
     codex_mcp_args: tuple[str, ...] = ()
@@ -198,6 +199,12 @@ class Settings(BaseModel):
 
     def resolved_codex_home(self) -> Path:
         return self.codex_home_path or self.state_db_path.parent.parent / "codex-home"
+
+    def resolved_codex_publication_root(self) -> Path:
+        return (
+            self.codex_publication_root
+            or self.resolved_local_artifact_root() / "publication-inbox"
+        )
 
     def resolved_artifact_roots(self) -> tuple[Path, ...]:
         roots = (self.resolved_local_artifact_root(), *self.artifact_roots)

--- a/services/api/tests/test_codex_adapter.py
+++ b/services/api/tests/test_codex_adapter.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import jobos_api.codex_adapter as codex_adapter_module
 import pytest
@@ -137,12 +138,19 @@ async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: P
     publication_root.parent.mkdir()
     gateway = CodexGatewayFactory(
         client,
-        cwd=tmp_path / "codex-workspace",
+        # The macOS sandbox grants the active workspace root reliably. Keep
+        # the Codex cwd and JobOS publication inbox identical in production.
+        cwd=publication_root,
         publication_root=publication_root,
     ).create("conv_alpha")
 
     assert gateway.connection_state == "offline"
     assert await gateway.create_or_resume_conversation(None) == ("thread-a", "thread-a")
+    thread_start = cast(
+        dict[str, object],
+        next(params for method, params in client.requests if method == "thread/start"),
+    )
+    assert thread_start["cwd"] == str(publication_root)
     assert gateway.connection_state == "online"
     await gateway.submit_turn("Tailor this", context())
 
@@ -156,7 +164,7 @@ async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: P
     thread_params = client.requests[0][1]
     assert isinstance(thread_params, dict)
     assert thread_params["sandbox"] == "workspace-write"
-    assert thread_params["cwd"] == str(tmp_path / "codex-workspace")
+    assert thread_params["cwd"] == str(publication_root)
     turn_params = client.requests[-1][1]
     assert isinstance(turn_params, dict)
     assert turn_params["threadId"] == "thread-a"

--- a/services/api/tests/test_codex_adapter.py
+++ b/services/api/tests/test_codex_adapter.py
@@ -138,9 +138,7 @@ async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: P
     publication_root.parent.mkdir()
     gateway = CodexGatewayFactory(
         client,
-        # The macOS sandbox grants the active workspace root reliably. Keep
-        # the Codex cwd and JobOS publication inbox identical in production.
-        cwd=publication_root,
+        cwd=tmp_path / "codex-workspace",
         publication_root=publication_root,
     ).create("conv_alpha")
 
@@ -150,7 +148,7 @@ async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: P
         dict[str, object],
         next(params for method, params in client.requests if method == "thread/start"),
     )
-    assert thread_start["cwd"] == str(publication_root)
+    assert thread_start["cwd"] == str(tmp_path / "codex-workspace")
     assert gateway.connection_state == "online"
     await gateway.submit_turn("Tailor this", context())
 
@@ -164,7 +162,7 @@ async def test_codex_turn_uses_opaque_thread_and_exact_jobos_context(tmp_path: P
     thread_params = client.requests[0][1]
     assert isinstance(thread_params, dict)
     assert thread_params["sandbox"] == "workspace-write"
-    assert thread_params["cwd"] == str(publication_root)
+    assert thread_params["cwd"] == str(tmp_path / "codex-workspace")
     turn_params = client.requests[-1][1]
     assert isinstance(turn_params, dict)
     assert turn_params["threadId"] == "thread-a"

--- a/services/api/tests/test_initialize.py
+++ b/services/api/tests/test_initialize.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from jobos_api.initialize import initialize_jobos
+from jobos_api.installation_profiles import InstallationProfileRegistry
 from jobos_api.local_config import (
     LocalConfigError,
     load_credentials,
@@ -164,6 +165,67 @@ def test_token_configured_source_defaults_use_application_data_not_cwd(tmp_path,
     assert configured.resolved_local_artifact_root() == (
         tmp_path / "Library/Application Support/JobOS/artifacts"
     )
+    assert configured.resolved_codex_publication_root() == (
+        tmp_path / "Library/Application Support/JobOS/artifacts/publication-inbox"
+    )
+
+
+def test_token_configured_codex_publication_root_does_not_follow_runtime_artifacts(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("jobos_api.local_config.sys.platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("JOBOS_DEVICE_TOKEN", "source-default-device-token")
+    monkeypatch.setenv("JOBOS_MCP_TOKEN", "source-default-mcp-token")
+    monkeypatch.setenv("JOBOS_LOCAL_ARTIFACT_ROOT", str(tmp_path / "job-hunter-artifacts"))
+    monkeypatch.delenv("JOBOS_CODEX_PUBLICATION_ROOT", raising=False)
+
+    configured = settings_from_environment()
+
+    assert configured.resolved_local_artifact_root() == tmp_path / "job-hunter-artifacts"
+    assert configured.resolved_codex_publication_root() == (
+        tmp_path / "Library/Application Support/JobOS/artifacts/publication-inbox"
+    )
+
+
+def test_config_backed_codex_publication_root_stays_with_jobos_artifacts(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("jobos_api.local_config.sys.platform", "linux")
+    initialize_jobos(tmp_path)
+    config_path = tmp_path / "config.json"
+    settings_from_config(config_path)
+    registry = InstallationProfileRegistry(tmp_path / "installation-profiles.json")
+    data = registry.load()
+    external_artifacts = (tmp_path / "job-hunter-artifacts").absolute()
+    active = next(
+        profile for profile in data.profiles if profile.profile_id == data.active_profile_id
+    )
+    assert active.anchored_runtime is not None
+    anchored_runtime = active.anchored_runtime.model_copy(
+        update={
+            "local_artifact_root": external_artifacts,
+            "artifact_roots": (external_artifacts,),
+        }
+    )
+    registry.write(
+        data.model_copy(
+            update={
+                "registry_revision": data.registry_revision + 1,
+                "profiles": tuple(
+                    profile.model_copy(update={"anchored_runtime": anchored_runtime})
+                    if profile.profile_id == active.profile_id
+                    else profile
+                    for profile in data.profiles
+                ),
+            }
+        )
+    )
+
+    configured = settings_from_config(config_path)
+
+    assert configured.resolved_local_artifact_root() == external_artifacts
+    assert configured.resolved_codex_publication_root() == tmp_path / "artifacts/publication-inbox"
 
 
 def test_config_backed_settings_honor_explicit_career_profile_activation(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed
- keeps Codex in its private workspace while granting write access only to JobOS's prepared publication inbox
- separates the Codex publication inbox from profile-specific artifact storage
- resolves the publication inbox from the same base JobOS config used by `document_publication_prepare`
- adds regressions for token-configured and profile-anchored split-root setups

## Root cause
Live installed acceptance found a split-brain path bug. The MCP prepared files under the base JobOS artifact root, while the Codex adapter derived its writable root from the active profile's overridden JobHunter artifact root. Codex correctly blocked writes because the prepared path was outside its declared sandbox.

## Verification
- focused initialize + Codex adapter tests passed (37 tests)
- full API suite passed with one existing skip
- Ruff passed on all changed Python files
- `git diff --check` passed
- real installed publication acceptance will be rerun against this exact candidate before merge